### PR TITLE
feat: SOFT_BLOCK gate for read-only UNKNOWN (v1.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.9.0 (2026-07-19)
+
+Ship the `SOFT_BLOCK` gate for read-only tools. An ambiguous `UNKNOWN` / `BLOCKED` terminal outcome on a reversible read no longer polls to a `LedgerPollTimeoutError`; it resolves through a dedicated read-only gate.
+
+### Read-only SOFT_BLOCK
+
+- New `SOFT_BLOCK` member on `TransitionGate` and a `resolve_read_only_gate(entry)` resolver describing the full read-only taxonomy: `COMPLETED` → `RETURN`, `IN_FLIGHT` → `POLL`, `EXPIRED` / `FAILED_BEFORE_EFFECT` / `FAILED_AFTER_EFFECT` → `RECLAIM`, `BLOCKED` / `UNKNOWN` → `SOFT_BLOCK`.
+- Because re-running a read-only tool is always safe, a `SOFT_BLOCK` resolves **by default to a retry**: the ambiguous entry is reset to a fresh in-flight claim and the tool runs exactly once more.
+- Opt into deferral with `ActionLedger(defer_read_only_unknown=True)` (or the `@ledger` / `@ledger_sync` `defer_read_only_unknown=` argument). The claim then raises the new `LedgerSoftBlockError` so an expensive read can be deferred and retried later by the caller (cost-dependent) instead of re-executing immediately.
+- `LedgerSoftBlockError` is a *deferral*, not a terminal stop — distinct from the payment/non-idempotent `LedgerHardBlockError`, which still requires manual reconciliation. Side-effecting `UNKNOWN` resolution is unchanged (still hard-blocks / reconciles).
+- Export `LedgerSoftBlockError` from the package root. Works in sync and async claim paths.
+
 ## 1.8.0 (2026-07-19)
 
 Enforce `retry_only_with_same_provider_idempotency_key` instead of trusting it. When a tool opts in, a retry is allowed only if it provably reuses the same provider idempotency key; otherwise it hard-blocks.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Prevents predictable failures *before* they reach the LLM. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.8.0**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.9.0**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -389,7 +389,7 @@
       LLM: duplicate tool execution on retry, stale context, invalid tool calls.
       Classify tools, hash a durable transition key, resolve duplicates by terminal
       state: poll reads, hard-block ambiguous writes. Framework-agnostic.
-      Early but API-stable (v1.8.0): breaking changes only at major versions.
+      Early but API-stable (v1.9.0): breaking changes only at major versions.
     </p>
 
     <section id="architecture">
@@ -437,6 +437,7 @@ bounded, bounded_sync, ToolRegistry, ToolRunner
 ledger, ledger_sync, task_ledger, task_ledger_sync
 ActionLedger, TaskLedger, StateFlush, AuditReceiptEmitter, verify_receipt
 LedgerHardBlockError, LedgerPollTimeoutError
+LedgerSoftBlockError                                 # read-only UNKNOWN defer (v1.9.0)
 side_effect, mark_maybe_crossed, mark_crossed        # boundary markers (v1.5.0)
 record_external_operation                            # provider handle (v1.6.0)
 Reconciler, ReconcileResult, ReconcileStatus         # provider reconcile (v1.7.0)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.8.0** (transition envelope).
+Current package: **mycelium-runtime v1.9.0** (transition envelope).
 
 ## One painful bug → a few lines of config
 
@@ -258,7 +258,7 @@ async def send_payment(amount: float, recipient: str) -> dict:
 
 - Record every tool invocation in a durable `ActionLedger`
 - Deduplicate retries and redispatches via a rich **transition key** (scope + tool + args + `side_effect_class` + policy), not only `tool_call_id`
-- **`read` tools:** poll in-flight, reclaim expired leases, retry failed-before-effect
+- **`read` tools:** poll in-flight, reclaim expired leases, retry failed-before-effect, **soft-block** ambiguous `UNKNOWN`/`BLOCKED` states (safe to re-run; opt into deferral with `defer_read_only_unknown=True` → `LedgerSoftBlockError`)
 - **Mutating tools:** return completed results, poll in-flight, **hard-block** ambiguous states (`LedgerHardBlockError`)
 - Persist failed attempts with **terminal outcomes** (`FAILED_BEFORE_EFFECT`, `FAILED_AFTER_EFFECT`, etc.) for audit and reconciliation
 
@@ -266,7 +266,7 @@ async def send_payment(amount: float, recipient: str) -> dict:
 
 | Class | Typical use | Duplicate handling |
 |-------|-------------|-------------------|
-| `read` | search, fetch | poll / reclaim / retry |
+| `read` | search, fetch | poll / reclaim / retry / soft-block on `UNKNOWN` |
 | `idempotent_mutate` | upsert / set status | retry if boundary not crossed |
 | `keyed_mutate` | Stripe-style create/charge | retry only with same provider key |
 | `non_idempotent_mutate` | send email, spawn subagent | hard-block on ambiguity |

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -9,6 +9,7 @@ from mycelium.action_ledger import (
     LedgerHardBlockError,
     LedgerPendingError,
     LedgerPollTimeoutError,
+    LedgerSoftBlockError,
     LedgerStorage,
     get_ledger,
     ledger,
@@ -81,7 +82,7 @@ from mycelium.transition import (
     execution_scope,
 )
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 __all__ = [
     "ActionLedger",
@@ -92,6 +93,7 @@ __all__ = [
     "LedgerHardBlockError",
     "LedgerPendingError",
     "LedgerPollTimeoutError",
+    "LedgerSoftBlockError",
     "LedgerStorage",
     "get_ledger",
     "ledger",

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -37,7 +37,9 @@ from mycelium.transition import (
 from mycelium.transition_resolution import (
     TransitionGate,
     hard_block_message,
+    resolve_read_only_gate,
     resolve_side_effect_gate,
+    soft_block_message,
 )
 
 if TYPE_CHECKING:
@@ -65,6 +67,16 @@ class LedgerPollTimeoutError(LedgerError):
 
 class LedgerHardBlockError(LedgerError):
     """Raised when a side-effecting transition requires manual reconciliation."""
+
+
+class LedgerSoftBlockError(LedgerError):
+    """Raised when a reversible (read-only) transition is deferred.
+
+    Signals an ambiguous ``UNKNOWN`` / ``BLOCKED`` outcome on a read-only tool.
+    Unlike :class:`LedgerHardBlockError`, re-running the tool is safe, so this
+    is a *deferral* the caller may retry later rather than a terminal stop. Only
+    raised when the ledger is configured with ``defer_read_only_unknown=True``.
+    """
 
 
 def _ledger_owner() -> str:
@@ -381,12 +393,17 @@ class ActionLedger:
         poll_interval: float = DEFAULT_POLL_INTERVAL,
         poll_timeout: float | None = DEFAULT_POLL_TIMEOUT,
         reconciler: Reconciler | None = None,
+        defer_read_only_unknown: bool = False,
     ) -> None:
         self._storage = storage if storage is not None else InMemoryLedgerStorage()
         self._lease_ttl = lease_ttl
         self._poll_interval = poll_interval
         self._poll_timeout = poll_timeout
         self._reconciler = reconciler
+        # Read-only UNKNOWN/BLOCKED gate resolution: when False (default) the
+        # ambiguous state is safely re-run (SOFT_BLOCK -> retry); when True the
+        # claim raises LedgerSoftBlockError so the caller can defer the retry.
+        self._defer_read_only_unknown = defer_read_only_unknown
 
     # --- public API ---
 
@@ -477,6 +494,14 @@ class ActionLedger:
         poll_deadline = time.time() + timeout if timeout is not None else None
 
         while True:
+            existing = self.get(request_id)
+            if existing is not None and (
+                resolve_read_only_gate(existing) == TransitionGate.SOFT_BLOCK
+            ):
+                return self._resolve_read_only_soft_block(
+                    request_id, tool, args, kwargs, existing
+                )
+
             entry = self._new_inflight_entry(request_id, tool, args, kwargs)
             outcome, existing = self._storage.try_claim_inflight(entry, lease_ttl=ttl)
             if outcome == "completed" and existing is not None:
@@ -494,6 +519,30 @@ class ActionLedger:
             raise LedgerError(
                 f"Unexpected claim outcome {outcome!r} for read-only tool {tool!r}"
             )
+
+    def _resolve_read_only_soft_block(
+        self,
+        request_id: str,
+        tool: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        existing: LedgerEntry,
+    ) -> LedgerEntry:
+        """Resolve a read-only ``SOFT_BLOCK`` (``UNKNOWN`` / ``BLOCKED``).
+
+        Re-running a read-only tool is always safe, so by default the ambiguous
+        entry is reset to a fresh in-flight claim and the tool runs exactly once
+        more. When the ledger is configured with ``defer_read_only_unknown``,
+        raise :class:`LedgerSoftBlockError` instead so an expensive read can be
+        deferred and retried by the caller (cost-dependent).
+        """
+        if self._defer_read_only_unknown:
+            raise LedgerSoftBlockError(
+                soft_block_message(existing, tool=tool, request_id=request_id)
+            )
+        fresh = self._new_inflight_entry(request_id, tool, args, kwargs)
+        self._storage.set(fresh)
+        return fresh
 
     def _poll_read_only(
         self,
@@ -544,6 +593,14 @@ class ActionLedger:
         poll_deadline = time.time() + timeout if timeout is not None else None
 
         while True:
+            existing = self.get(request_id)
+            if existing is not None and (
+                resolve_read_only_gate(existing) == TransitionGate.SOFT_BLOCK
+            ):
+                return self._resolve_read_only_soft_block(
+                    request_id, tool, args, kwargs, existing
+                )
+
             entry = self._new_inflight_entry(request_id, tool, args, kwargs)
             outcome, existing = self._storage.try_claim_inflight(entry, lease_ttl=ttl)
             if outcome == "completed" and existing is not None:
@@ -1355,6 +1412,7 @@ def ledger(
     poll_interval: float | None = None,
     poll_timeout: float | None = None,
     reconciler: Reconciler | None = None,
+    defer_read_only_unknown: bool = False,
 ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
     """Decorator that records async tool invocations in an ActionLedger."""
 
@@ -1366,7 +1424,10 @@ def ledger(
     if poll_timeout is not None:
         ledger_kwargs["poll_timeout"] = poll_timeout
     action_ledger = ActionLedger(
-        storage=storage, reconciler=reconciler, **ledger_kwargs
+        storage=storage,
+        reconciler=reconciler,
+        defer_read_only_unknown=defer_read_only_unknown,
+        **ledger_kwargs,
     )
 
     def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
@@ -1399,6 +1460,7 @@ def ledger_sync(
     poll_interval: float | None = None,
     poll_timeout: float | None = None,
     reconciler: Reconciler | None = None,
+    defer_read_only_unknown: bool = False,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator that records sync tool invocations in an ActionLedger."""
 
@@ -1410,7 +1472,10 @@ def ledger_sync(
     if poll_timeout is not None:
         ledger_kwargs["poll_timeout"] = poll_timeout
     action_ledger = ActionLedger(
-        storage=storage, reconciler=reconciler, **ledger_kwargs
+        storage=storage,
+        reconciler=reconciler,
+        defer_read_only_unknown=defer_read_only_unknown,
+        **ledger_kwargs,
     )
 
     def decorator(func: Callable[P, R]) -> Callable[P, R]:

--- a/sdk/mycelium/transition_resolution.py
+++ b/sdk/mycelium/transition_resolution.py
@@ -30,7 +30,32 @@ class TransitionGate(StrEnum):
     RETURN = "RETURN"
     POLL = "POLL"
     RECLAIM = "RECLAIM"
+    SOFT_BLOCK = "SOFT_BLOCK"
     HARD_BLOCK = "HARD_BLOCK"
+
+
+def resolve_read_only_gate(existing: _ExistingTransition) -> TransitionGate:
+    """Decide how to handle an existing transition for a *read-only* tool.
+
+    Read-only tools produce no external effect, so re-running is always safe.
+    The gate is therefore lighter than the side-effecting resolver:
+
+    - ``COMPLETED`` → ``RETURN`` the stored result
+    - ``IN_FLIGHT`` → ``POLL`` while another worker holds a valid lease
+    - ``EXPIRED`` / ``FAILED_BEFORE_EFFECT`` / ``FAILED_AFTER_EFFECT`` →
+      ``RECLAIM`` (safe to re-execute)
+    - ``BLOCKED`` / ``UNKNOWN`` → ``SOFT_BLOCK`` — an ambiguous terminal state
+      must not hard-block a reversible read, so the caller defers or retries
+      (cost-dependent) instead of parking it for a human.
+    """
+    outcome = existing.resolved_terminal_outcome()
+    if outcome == TerminalOutcome.COMPLETED:
+        return TransitionGate.RETURN
+    if outcome == TerminalOutcome.IN_FLIGHT:
+        return TransitionGate.POLL
+    if outcome in (TerminalOutcome.BLOCKED, TerminalOutcome.UNKNOWN):
+        return TransitionGate.SOFT_BLOCK
+    return TransitionGate.RECLAIM
 
 
 def _entry_boundary(existing: _ExistingTransition) -> SideEffectBoundary:
@@ -151,8 +176,23 @@ def hard_block_message(
     )
 
 
+def soft_block_message(
+    existing: _ExistingTransition,
+    *,
+    tool: str,
+    request_id: str,
+) -> str:
+    outcome = existing.resolved_terminal_outcome()
+    return (
+        f"Read-only tool {tool!r} request {request_id!r} is {outcome.value}; "
+        "soft-blocked — safe to defer and retry"
+    )
+
+
 __all__ = [
     "TransitionGate",
     "hard_block_message",
+    "resolve_read_only_gate",
     "resolve_side_effect_gate",
+    "soft_block_message",
 ]

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.8.0"
+version = "1.9.0"
 description = "Runtime guards for AI agents: stale context, bad tool calls, duplicate side effects on retry"
 keywords = [
   "ai-agents",

--- a/sdk/tests/test_read_only_resolution.py
+++ b/sdk/tests/test_read_only_resolution.py
@@ -13,13 +13,16 @@ from mycelium import (
     LedgerEntry,
     LedgerPendingError,
     LedgerPollTimeoutError,
+    LedgerSoftBlockError,
     SideEffectClass,
     TerminalOutcome,
     ToolTransitionBinding,
     TransitionScope,
     execution_scope,
+    get_ledger,
     ledger_sync,
 )
+from mycelium.transition_resolution import TransitionGate, resolve_read_only_gate
 
 
 def _read_only_binding() -> ToolTransitionBinding:
@@ -161,3 +164,129 @@ def test_read_only_poll_timeout() -> None:
 
     with pytest.raises(LedgerPollTimeoutError):
         ledger.claim_read_only("stuck", "search_docs", (), {})
+
+
+def _entry(
+    outcome: TerminalOutcome,
+    *,
+    lease_until: float | None = None,
+) -> LedgerEntry:
+    return LedgerEntry(
+        request_id="ro",
+        tool="search_docs",
+        args=[],
+        kwargs={"query": "billing"},
+        status="in-flight",
+        terminal_outcome=outcome.value,
+        lease_until=lease_until,
+        idempotency_key="ro",
+    )
+
+
+def test_resolve_read_only_gate_matrix() -> None:
+    assert (
+        resolve_read_only_gate(_entry(TerminalOutcome.COMPLETED))
+        == TransitionGate.RETURN
+    )
+    assert (
+        resolve_read_only_gate(
+            _entry(TerminalOutcome.IN_FLIGHT, lease_until=time.time() + 100)
+        )
+        == TransitionGate.POLL
+    )
+    # A stale in-flight lease resolves to EXPIRED -> safe to reclaim.
+    assert (
+        resolve_read_only_gate(
+            _entry(TerminalOutcome.IN_FLIGHT, lease_until=time.time() - 1)
+        )
+        == TransitionGate.RECLAIM
+    )
+    assert (
+        resolve_read_only_gate(_entry(TerminalOutcome.FAILED_BEFORE_EFFECT))
+        == TransitionGate.RECLAIM
+    )
+    assert (
+        resolve_read_only_gate(_entry(TerminalOutcome.UNKNOWN))
+        == TransitionGate.SOFT_BLOCK
+    )
+    assert (
+        resolve_read_only_gate(_entry(TerminalOutcome.BLOCKED))
+        == TransitionGate.SOFT_BLOCK
+    )
+
+
+def test_read_only_unknown_soft_block_retries_by_default() -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(storage=storage, poll_interval=0.01)
+    request_id = "ro-unknown"
+    storage.set(
+        LedgerEntry(
+            request_id=request_id,
+            tool="search_docs",
+            args=[],
+            kwargs={"query": "billing"},
+            status="failed",
+            terminal_outcome=TerminalOutcome.UNKNOWN.value,
+            idempotency_key=request_id,
+        )
+    )
+
+    claimed = ledger.claim_read_only(
+        request_id, "search_docs", (), {"query": "billing"}
+    )
+
+    # Reversible read is reset to a fresh in-flight claim so it runs once more.
+    assert claimed.status == "in-flight"
+    assert claimed.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT
+
+
+def test_read_only_unknown_soft_block_defers_when_configured() -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(storage=storage, defer_read_only_unknown=True)
+    request_id = "ro-unknown-defer"
+    storage.set(
+        LedgerEntry(
+            request_id=request_id,
+            tool="search_docs",
+            args=[],
+            kwargs={"query": "billing"},
+            status="failed",
+            terminal_outcome=TerminalOutcome.UNKNOWN.value,
+            idempotency_key=request_id,
+        )
+    )
+
+    with pytest.raises(LedgerSoftBlockError):
+        ledger.claim_read_only(request_id, "search_docs", (), {"query": "billing"})
+
+
+def test_read_only_unknown_reexecutes_via_decorator() -> None:
+    storage = InMemoryLedgerStorage()
+    binding = _read_only_binding()
+    attempts = {"count": 0}
+
+    @ledger_sync(storage=storage, transition_binding=binding)
+    def search_docs(query: str) -> dict[str, object]:
+        attempts["count"] += 1
+        return {"query": query, "hits": attempts["count"]}
+
+    inner = get_ledger(search_docs)
+    assert inner is not None
+
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+        first = search_docs(query="billing", tool_call_id="call_ro")
+        assert first == {"query": "billing", "hits": 1}
+
+        # Simulate an ambiguous crash-after-claim recorded as UNKNOWN.
+        request_id = inner.derive_request_id(
+            "search_docs",
+            (),
+            {"query": "billing", "tool_call_id": "call_ro"},
+            transition_binding=binding,
+        )
+        inner.mark_unknown(request_id, error="ambiguous crash")
+
+        second = search_docs(query="billing", tool_call_id="call_ro")
+
+    assert attempts["count"] == 2
+    assert second == {"query": "billing", "hits": 2}

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Ships the `SOFT_BLOCK` gate for read-only tools (the pending "UNKNOWN → SOFT_BLOCK or retry" item). An ambiguous `UNKNOWN` / `BLOCKED` terminal outcome on a reversible read no longer polls to a `LedgerPollTimeoutError` — it resolves through a dedicated read-only gate.

- Add `SOFT_BLOCK` to `TransitionGate` and a `resolve_read_only_gate()` resolver documenting the full read-only taxonomy: `COMPLETED → RETURN`, `IN_FLIGHT → POLL`, `EXPIRED`/`FAILED_* → RECLAIM`, `BLOCKED`/`UNKNOWN → SOFT_BLOCK`.
- Re-running a read-only tool is safe, so `SOFT_BLOCK` resolves **to a retry by default** (reset to a fresh in-flight claim; runs once more).
- Opt into deferral with `ActionLedger(defer_read_only_unknown=True)` (and the `@ledger` / `@ledger_sync` argument) → raises the new `LedgerSoftBlockError`, a deferral distinct from the terminal `LedgerHardBlockError`.
- Side-effecting `UNKNOWN` resolution is unchanged (still hard-block / reconcile). Works in sync + async claim paths.
- Exports `LedgerSoftBlockError` from the package root.

## Release (v1.9.0, MINOR)

Version bumped in lockstep per the release checklist: `sdk/pyproject.toml`, `sdk/mycelium/__init__.py`, `sdk/uv.lock`, `CHANGELOG.md`, root + `sdk/README.md`, `docs/index.html`. Tag/PyPI publish happens only after this PR merges to `main`.

## Test plan

- [x] `ruff check mycelium tests` clean
- [x] `pytest tests/` — 190 passed, 2 skipped
- [x] New tests: read-only gate matrix, default retry path, defer path (`LedgerSoftBlockError`), decorator re-execution
- [ ] After merge: tag `v1.9.0`, confirm `publish.yml` + `pages.yml` succeed and PyPI shows 1.9.0