### PR TITLE
fix: EXPIRED + not_crossed reclaim only if provable (v1.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.9.2 (2026-07-20)
+
+Patch: close the remaining gap on **EXPIRED + not_crossed → reclaim only if provable** via `external_operation_ref` reconcile. No new schema or policy concepts.
+
+### EXPIRED reclaim (prove via reconcile)
+
+- Side-effecting poll loops (`_poll_side_effecting` / async) no longer hard-block immediately when a lease expires mid-poll. They return so the outer claim loop can resolve `HARD_BLOCK` through the existing `Reconciler` path.
+- Strict classes (`single_use` / payment / etc.) still gate `EXPIRED + not_crossed` as `HARD_BLOCK`; reclaim happens only when an `external_operation_ref` is present and the reconciler returns `NOT_EXECUTED` (unchanged fail-closed rule when ref/reconciler is missing).
+- Clearer hard-block error text for stale leases: distinguishes `not_crossed` (reclaim only if reconcile proves `NOT_EXECUTED`) from `maybe_crossed` / `crossed` (effect may have happened).
+- Tests: reclaim on `EXPIRED + not_crossed + ref + NOT_EXECUTED`; hard-block without ref; poll-return then reconcile.
+
 ## 1.9.1 (2026-07-19)
 
 Patch: docs sync, a flaky-test fix, and the TSC-007 transition-sufficiency conformance suite. No new schema or policy concepts.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Prevents predictable failures *before* they reach the LLM. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.9.1**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.9.2**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -389,7 +389,7 @@
       LLM: duplicate tool execution on retry, stale context, invalid tool calls.
       Classify tools, hash a durable transition key, resolve duplicates by terminal
       state: poll reads, hard-block ambiguous writes. Framework-agnostic.
-      Early but API-stable (v1.9.1): breaking changes only at major versions.
+      Early but API-stable (v1.9.2): breaking changes only at major versions.
     </p>
 
     <section id="architecture">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.9.1** (transition envelope).
+Current package: **mycelium-runtime v1.9.2** (transition envelope).
 
 ## One painful bug → a few lines of config
 
@@ -259,7 +259,7 @@ async def send_payment(amount: float, recipient: str) -> dict:
 - Record every tool invocation in a durable `ActionLedger`
 - Deduplicate retries and redispatches via a rich **transition key** (scope + tool + args + `side_effect_class` + policy), not only `tool_call_id`
 - **`read` tools:** poll in-flight, reclaim expired leases, retry failed-before-effect, **soft-block** ambiguous `UNKNOWN`/`BLOCKED` states (safe to re-run; opt into deferral with `defer_read_only_unknown=True` → `LedgerSoftBlockError`)
-- **Mutating tools:** return completed results, poll in-flight, **hard-block** ambiguous states (`LedgerHardBlockError`)
+- **Mutating tools:** return completed results, poll in-flight, **hard-block** ambiguous states (`LedgerHardBlockError`). For `EXPIRED + not_crossed`, reclaim only when an `external_operation_ref` reconcile proves `NOT_EXECUTED` (fail-closed without a ref)
 - Persist failed attempts with **terminal outcomes** (`FAILED_BEFORE_EFFECT`, `FAILED_AFTER_EFFECT`, etc.) for audit and reconciliation
 
 ### Side-effect classes

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -82,7 +82,7 @@ from mycelium.transition import (
     execution_scope,
 )
 
-__version__ = "1.9.1"
+__version__ = "1.9.2"
 
 __all__ = [
     "ActionLedger",

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -657,10 +657,19 @@ class ActionLedger:
     ) -> None:
         outcome = existing.resolved_terminal_outcome()
         if outcome == TerminalOutcome.EXPIRED:
-            existing = self.mark_blocked(
-                request_id,
-                error="stale in-flight lease; side-effect boundary unknown",
-            )
+            boundary = SideEffectBoundary(existing.side_effect_boundary)
+            if boundary == SideEffectBoundary.NOT_CROSSED:
+                error = (
+                    "stale in-flight lease with not_crossed boundary; "
+                    "reclaim only if an external_operation_ref reconcile "
+                    "proves NOT_EXECUTED"
+                )
+            else:
+                error = (
+                    "stale in-flight lease; side-effect boundary "
+                    f"{boundary.value} — effect may have happened"
+                )
+            existing = self.mark_blocked(request_id, error=error)
         message = hard_block_message(existing, tool=tool, request_id=request_id)
         raise LedgerHardBlockError(message)
 
@@ -862,7 +871,11 @@ class ActionLedger:
         interval: float,
         poll_deadline: float | None,
     ) -> None:
-        """Wait for an in-flight side-effecting transition; never auto-reclaim."""
+        """Wait for an in-flight side-effecting transition; never auto-reclaim.
+
+        When the lease expires mid-poll, return so the outer claim loop can
+        re-resolve the gate and attempt provider reconcile before hard-blocking.
+        """
         while True:
             if poll_deadline is not None and time.time() >= poll_deadline:
                 current = self.get(request_id)
@@ -882,8 +895,11 @@ class ActionLedger:
             outcome = current.resolved_terminal_outcome()
             if outcome == TerminalOutcome.COMPLETED:
                 return
+            # Leave EXPIRED to the outer claim loop so HARD_BLOCK can attempt
+            # reconcile (EXPIRED + not_crossed + external_operation_ref →
+            # reclaim only when the provider proves NOT_EXECUTED).
             if outcome == TerminalOutcome.EXPIRED:
-                self._raise_hard_block(request_id, tool, current)
+                return
             if outcome == TerminalOutcome.IN_FLIGHT:
                 continue
             if outcome in (
@@ -999,8 +1015,11 @@ class ActionLedger:
             outcome = current.resolved_terminal_outcome()
             if outcome == TerminalOutcome.COMPLETED:
                 return
+            # Leave EXPIRED to the outer claim loop so HARD_BLOCK can attempt
+            # reconcile (EXPIRED + not_crossed + external_operation_ref →
+            # reclaim only when the provider proves NOT_EXECUTED).
             if outcome == TerminalOutcome.EXPIRED:
-                self._raise_hard_block(request_id, tool, current)
+                return
             if outcome == TerminalOutcome.IN_FLIGHT:
                 continue
             if outcome in (

--- a/sdk/mycelium/transition_resolution.py
+++ b/sdk/mycelium/transition_resolution.py
@@ -111,6 +111,11 @@ def resolve_side_effect_gate(
         return TransitionGate.HARD_BLOCK
 
     if outcome == TerminalOutcome.EXPIRED:
+        # maybe_crossed / crossed: effect may have happened → HARD_BLOCK.
+        # Strict spendability (single_use / non_replayable) also HARD_BLOCKs
+        # even on not_crossed: reclaim is only safe when a Reconciler proves
+        # NOT_EXECUTED via external_operation_ref (see ActionLedger claim path).
+        # multi_use + SAFE_RETRY + not_crossed may ALLOW (idempotent reclaim).
         if boundary in (SideEffectBoundary.MAYBE_CROSSED, SideEffectBoundary.CROSSED):
             return TransitionGate.HARD_BLOCK
         if blocks_on_ambiguous_replay(spendability):

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.9.1"
+version = "1.9.2"
 description = "Runtime guards for AI agents: stale context, bad tool calls, duplicate side effects on retry"
 keywords = [
   "ai-agents",

--- a/sdk/tests/test_reconcile.py
+++ b/sdk/tests/test_reconcile.py
@@ -238,3 +238,183 @@ def test_async_reconcile_completed_returns_result() -> None:
     assert result == {"charged": True}
     assert len(calls) == 1
     assert len(reconciler.calls) == 1
+
+
+def test_expired_not_crossed_reclaims_when_reconcile_proves_not_executed() -> None:
+    """EXPIRED + not_crossed + external_operation_ref + NOT_EXECUTED → reclaim.
+
+    Strict (payment) classes hard-block EXPIRED at the gate; reclaim is only
+    allowed when a Reconciler proves the provider never executed the effect.
+    """
+    import time
+
+    from mycelium import LedgerEntry, SideEffectBoundary, get_ledger
+
+    storage = InMemoryLedgerStorage()
+    reconciler = StubReconciler(ReconcileResult.not_executed())
+    calls: list[float] = []
+
+    @ledger_sync(
+        storage=storage,
+        transition_binding=_binding(),
+        reconciler=reconciler,
+        lease_ttl=3600.0,
+    )
+    def charge(amount: float) -> dict[str, bool]:
+        calls.append(amount)
+        return {"charged": True}
+
+    ledger_inst = get_ledger(charge)
+    assert ledger_inst is not None
+
+    with execution_scope(_scope()):
+        # Seed a stale in-flight claim that never crossed the side-effect
+        # boundary but recorded a provider handle before the worker died.
+        request_id = ledger_inst.derive_request_id(
+            "charge",
+            (),
+            {"amount": 10.0, "tool_call_id": "c_expired"},
+            transition_binding=_binding(),
+        )
+        storage.set(
+            LedgerEntry(
+                request_id=request_id,
+                tool="charge",
+                args=[],
+                kwargs={"amount": 10.0},
+                status="in-flight",
+                terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+                lease_until=time.time() - 1,
+                side_effect_boundary=SideEffectBoundary.NOT_CROSSED.value,
+                external_operation_ref="pi_expired_1",
+                idempotency_key=request_id,
+            )
+        )
+
+        result = charge(amount=10.0, tool_call_id="c_expired")
+
+    assert result == {"charged": True}
+    assert calls == [10.0]
+    assert reconciler.calls == [request_id]
+    entry = storage.get(request_id)
+    assert entry is not None
+    assert entry.resolved_terminal_outcome() == TerminalOutcome.COMPLETED
+
+
+def test_expired_not_crossed_hard_blocks_without_external_ref() -> None:
+    """EXPIRED + not_crossed without external_operation_ref is not provable."""
+    import time
+
+    from mycelium import LedgerEntry, SideEffectBoundary, get_ledger
+
+    storage = InMemoryLedgerStorage()
+    reconciler = StubReconciler(ReconcileResult.not_executed())
+
+    @ledger_sync(
+        storage=storage,
+        transition_binding=_binding(),
+        reconciler=reconciler,
+    )
+    def charge(amount: float) -> dict[str, bool]:
+        return {"charged": True}
+
+    ledger_inst = get_ledger(charge)
+    assert ledger_inst is not None
+
+    with execution_scope(_scope()):
+        request_id = ledger_inst.derive_request_id(
+            "charge",
+            (),
+            {"amount": 10.0, "tool_call_id": "c_expired_noref"},
+            transition_binding=_binding(),
+        )
+        storage.set(
+            LedgerEntry(
+                request_id=request_id,
+                tool="charge",
+                args=[],
+                kwargs={"amount": 10.0},
+                status="in-flight",
+                terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+                lease_until=time.time() - 1,
+                side_effect_boundary=SideEffectBoundary.NOT_CROSSED.value,
+                external_operation_ref=None,
+                idempotency_key=request_id,
+            )
+        )
+
+        with pytest.raises(LedgerHardBlockError, match="not_crossed"):
+            charge(amount=10.0, tool_call_id="c_expired_noref")
+
+    assert reconciler.calls == []  # no ref → no provider lookup
+
+
+def test_expired_after_poll_reconciles_instead_of_blind_hard_block() -> None:
+    """Poll returns on EXPIRED so the claim loop can reconcile before blocking.
+
+    Previously ``_poll_side_effecting`` raised ``LedgerHardBlockError`` on
+    EXPIRED without consulting the Reconciler.
+    """
+    import time
+    from dataclasses import replace
+
+    from mycelium import ActionLedger, LedgerEntry, SideEffectBoundary
+    from mycelium.transition_resolution import TransitionGate, resolve_side_effect_gate
+
+    storage = InMemoryLedgerStorage()
+    reconciler = StubReconciler(ReconcileResult.not_executed())
+    ledger = ActionLedger(
+        storage=storage,
+        reconciler=reconciler,
+        poll_interval=0.01,
+        poll_timeout=1.0,
+        lease_ttl=3600.0,
+    )
+    binding = _binding()
+    request_id = "expired-after-poll"
+
+    storage.set(
+        LedgerEntry(
+            request_id=request_id,
+            tool="charge",
+            args=[],
+            kwargs={"amount": 10.0},
+            status="in-flight",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+            lease_until=time.time() + 3600,  # valid → POLL
+            side_effect_boundary=SideEffectBoundary.NOT_CROSSED.value,
+            external_operation_ref="pi_poll_expired",
+            idempotency_key=request_id,
+        )
+    )
+    assert (
+        resolve_side_effect_gate(storage.get(request_id), binding)
+        == TransitionGate.POLL
+    )
+
+    # Expire the lease mid-poll observation window.
+    current = storage.get(request_id)
+    assert current is not None
+    storage.set(replace(current, lease_until=time.time() - 1))
+
+    # Poll must return (not raise) so the outer claim can reconcile.
+    ledger._poll_side_effecting(
+        request_id,
+        tool="charge",
+        interval=0.01,
+        poll_deadline=time.time() + 1.0,
+    )
+
+    claimed = ledger.claim_side_effecting(
+        request_id,
+        "charge",
+        (),
+        {"amount": 10.0},
+        binding,
+    )
+
+    assert reconciler.calls == [request_id]
+    # Reconcile NOT_EXECUTED resets to a fresh in-flight claim (tool may run once).
+    assert claimed.status == "in-flight"
+    assert claimed.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT
+    assert claimed.external_operation_ref is None  # fresh claim

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.9.1"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Patch closing the remaining **EXPIRED + not_crossed → reclaim only if provable** gap. Proof is via existing `external_operation_ref` + `Reconciler` (not bare `not_crossed`).

- Side-effecting poll loops no longer hard-block immediately when a lease expires mid-poll — they return so the claim loop can reconcile.
- Strict classes still gate `EXPIRED + not_crossed` as `HARD_BLOCK`; reclaim only when a ref is present and reconcile returns `NOT_EXECUTED` (fail-closed without ref).
- Clearer hard-block messages for stale leases (`not_crossed` vs `maybe_crossed`/`crossed`).
- Tests for reclaim-with-proof, hard-block-without-ref, and poll-return-then-reconcile.

## Release

**v1.9.2** (PATCH — improvement to shipped reconcile path; no new schema/policy). Version bumped in lockstep. Tag/PyPI only after this PR merges to `main`.

## Test plan

- [x] `ruff check mycelium tests`
- [x] `pytest tests/` — 193 passed, 2 skipped
- [ ] After merge: tag `v1.9.2`, confirm `publish.yml` + `pages.yml`, PyPI shows 1.9.2