### PR TITLE
docs: resolution gates, SOFT_BLOCK, and EXPIRED reclaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ Python 3.10+. Framework-agnostic.
 
 These aren't reasoning failures. They're runtime failures. Mycelium sits between your agent loop and your tools:
 
-- **Duplicate side effects on retry:** classify tools (`read` vs `keyed_mutate` vs `non_idempotent_mutate`, etc.), hash a durable transition key, resolve duplicates by terminal state — poll reads, hard-block ambiguous writes
+- **Duplicate side effects on retry:** classify tools (`read` vs `keyed_mutate` vs `non_idempotent_mutate`, etc.), hash a durable **transition key**, resolve duplicates by **terminal state** — not blind re-execute
+  - **Read tools:** poll in-flight, reclaim expired leases, **soft-block** ambiguous `UNKNOWN` (safe retry by default)
+  - **Mutating tools:** hard-block ambiguity; **reconcile** via `external_operation_ref` when a provider lookup can prove run-or-not (`COMPLETED` / `NOT_EXECUTED` / still blocked)
+  - **Stale lease (`EXPIRED`):** strict classes reclaim only when reconcile proves `NOT_EXECUTED` (fail-closed without a ref)
 - **Stale or broken context:** fresh tool data, valid message transcripts
 - **Bad tool calls:** block invalid inputs and out-of-scope tools before they run
 
-Not Langfuse. Use both if you want traces and guards.
+Not Langfuse. Use both if you want traces and guards. Full resolution rules: [sdk/README.md](sdk/README.md#resolution-gates).
 
 ## Use it
 
@@ -66,7 +69,7 @@ def my_side_effect_tool(...) -> dict:
 my_side_effect_tool(..., tool_call_id=call["id"])
 ```
 
-Pass `tool_call_id` from your framework. Redispatch resolves the existing transition — read tools poll and return; mutating tools won't execute twice unsafely.
+Pass `tool_call_id` from your framework. Redispatch resolves the existing transition: read tools poll/soft-block; mutating tools hard-block or reconcile against the provider when you record `external_operation_ref`.
 
 Multi-worker / cloud: `pip install 'mycelium-runtime[redis]'`. See the [handbook](https://mycelium-labs.github.io/mycelium/).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
         "name": "How do I build reliable AI agents in production?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Most agent failures in production are not reasoning failures; they are runtime failures: a tool runs twice on retry, context goes stale, or the model emits an invalid tool call. Make agents reliable by guarding the runtime, not just the prompt. Mycelium sits between your agent loop and your tools: it classifies each tool by side effect, hashes a durable transition key, and resolves duplicate dispatches by terminal state (poll reads, hard-block ambiguous writes), while validating message history and tool inputs before execution. It is framework-agnostic and works with LangGraph, CrewAI, or a plain Python loop. pip install mycelium-runtime"
+          "text": "Most agent failures in production are not reasoning failures; they are runtime failures: a tool runs twice on retry, context goes stale, or the model emits an invalid tool call. Make agents reliable by guarding the runtime, not just the prompt. Mycelium classifies each tool by side effect, hashes a durable transition key, and resolves duplicate dispatches through resolution gates (poll reads, soft-block ambiguous reads, hard-block ambiguous writes, reconcile via external_operation_ref when a provider lookup can prove run-or-not). Framework-agnostic. pip install mycelium-runtime"
         }
       },
       {
@@ -42,7 +42,7 @@
         "name": "How do I prevent duplicate tool execution in LangGraph?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Classify each tool (read vs keyed_mutate vs non_idempotent_mutate, etc.), enable transition: in mycelium.yaml, and use @config.apply. Mycelium hashes a durable transition key and resolves duplicates by terminal state: read-only tools poll in-flight; side-effecting tools hard-block ambiguous retries. pip install mycelium-runtime && mycelium demo"
+          "text": "Classify each tool (read vs keyed_mutate vs non_idempotent_mutate, etc.), enable transition: in mycelium.yaml, and use @config.apply. Mycelium hashes a durable transition key and resolves duplicates by terminal state and resolution gates: read tools poll or soft-block UNKNOWN; mutating tools hard-block or reconcile against the provider when you record external_operation_ref. pip install mycelium-runtime && mycelium demo"
         }
       },
       {
@@ -72,7 +72,7 @@
     "alternateName": "mycelium-runtime",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "OS Independent",
-    "description": "Runtime guards for AI agents. Prevents predictable failures before they reach the LLM: duplicate tool execution on retry, stale context, and invalid tool calls. Framework-agnostic Python library for LangGraph, CrewAI, and plain Python loops.",
+    "description": "Runtime guards for AI agents. Prevents predictable failures before they reach the LLM: duplicate tool execution on retry, stale context, and invalid tool calls. Transition envelope with resolution gates, external_operation_ref reconcile, and framework-agnostic Python for LangGraph, CrewAI, and plain loops.",
     "url": "https://mycelium-labs.github.io/mycelium/",
     "downloadUrl": "https://pypi.org/project/mycelium-runtime/",
     "codeRepository": "https://github.com/mycelium-labs/mycelium",
@@ -370,6 +370,7 @@
       <li><a href="#context">Context</a></li>
       <li><a href="#tools">Tools</a></li>
       <li><a href="#actions">Actions</a></li>
+      <li><a href="#resolution">Resolution</a></li>
       <li><a href="#yaml">YAML</a></li>
       <li><a href="#common-searches">FAQ</a></li>
     </ol>
@@ -388,7 +389,8 @@
       Runtime guards for AI agents. Prevents predictable failures before they reach the
       LLM: duplicate tool execution on retry, stale context, invalid tool calls.
       Classify tools, hash a durable transition key, resolve duplicates by terminal
-      state: poll reads, hard-block ambiguous writes. Framework-agnostic.
+      state and resolution gates (poll / soft-block reads, hard-block or reconcile
+      writes via <code>external_operation_ref</code>). Framework-agnostic.
       Early but API-stable (v1.9.2): breaking changes only at major versions.
     </p>
 
@@ -397,8 +399,8 @@
       <p class="arch-caption">
         Mycelium wraps your agent loop. Guards run on messages and tools before side effects
         and before the next LLM call. The transition envelope classifies each tool, hashes
-        a durable key per dispatch, and resolves duplicates by terminal state, not by
-        re-running blindly. Not a framework. Not observability.
+        a durable key per dispatch, and resolves duplicates through gates and terminal
+        outcomes — not by re-running blindly. Not a framework. Not observability.
       </p>
       <div class="arch-flow">
         <div class="arch-box">Your agent loop<br><span style="font-weight:400;color:var(--ink-muted)">LangGraph · CrewAI · Python</span></div>
@@ -519,10 +521,8 @@ def fetch_customer(customer_id: str) -> dict:
       <p>
         Each ledgered tool gets a <code>side_effect_class</code> and a
         <code>transition_key</code> (scope, tool, args, class, policy version).
-        Duplicate dispatches resolve by terminal state:
-        <code>read</code> tools poll in-flight and reclaim expired leases;
-        <code>payment</code> and write tools return completed results or hard-block
-        ambiguous retries (<code>LedgerHardBlockError</code>).
+        Duplicate dispatches resolve through <a href="#resolution">gates</a> and
+        terminal outcomes — not blind re-execution.
       </p>
       <pre>from mycelium import load_config
 
@@ -536,7 +536,7 @@ def send_payment(amount: float, recipient: str) -> dict:
 def search_docs(query: str) -> dict:
     return {"query": query, "hits": 3}
 
-# read: second call polls and returns cached result
+# read: second call polls or soft-blocks UNKNOWN (safe retry by default)
 search_docs(query="billing", tool_call_id="call_read")
 
 # payment: duplicate resolves existing transition; won't charge twice
@@ -550,6 +550,68 @@ def process_invoice(invoice_id: str, amount: float) -> dict:
 
 process_invoice(invoice_id="inv-42", amount=100.0)
 process_invoice(invoice_id="inv-42", amount=200.0)  # returns first result</pre>
+    </section>
+
+    <section id="resolution">
+      <h2>Resolution</h2>
+      <p>
+        Each duplicate dispatch is classified to a <strong>gate</strong>. Read-only and
+        side-effecting tools use different resolvers.
+      </p>
+      <pre>Gate          Typical trigger                    Effect
+ALLOW         fresh claim / policy allows retry    tool runs
+RETURN        COMPLETED                          return stored result
+POLL          IN_FLIGHT (valid lease)            wait for other worker
+RECLAIM       read EXPIRED / FAILED_*            take over stale lease
+SOFT_BLOCK    read UNKNOWN / BLOCKED only        retry by default (v1.9.0)
+HARD_BLOCK    ambiguous mutating transition      stop; reconcile if ref present</pre>
+      <p>
+        <strong>Read</strong> (<code>side_effect_class: read</code>): poll, reclaim,
+        retry failed-before-effect. Ambiguous <code>UNKNOWN</code> →
+        <code>SOFT_BLOCK</code> (safe retry). Opt into deferral with
+        <code>defer_read_only_unknown=True</code> → <code>LedgerSoftBlockError</code>.
+      </p>
+      <p>
+        <strong>Mutating</strong> (payment, email, subagent, irreversible): return
+        completed, poll in-flight, hard-block ambiguity. Stale lease
+        (<code>EXPIRED + not_crossed</code>): hard-block until reconcile proves
+        <code>NOT_EXECUTED</code> (fail-closed without <code>external_operation_ref</code>).
+      </p>
+      <pre>from mycelium import ledger_sync, side_effect, record_external_operation
+from mycelium import Reconciler, ReconcileResult
+
+@ledger_sync(transition_binding=binding)
+def send_payment(amount, recipient, *, idempotency_key: str):
+    with side_effect():                              # maybe_crossed → UNKNOWN on crash
+        record_external_operation(idempotency_key)   # handle for provider lookup
+        return gateway.charge(amount, recipient, idempotency_key=idempotency_key)
+
+class StripeReconciler:  # read-only: never charges
+    def reconcile(self, entry) -> ReconcileResult:
+        pi = stripe.PaymentIntent.retrieve(entry.external_operation_ref)
+        if pi.status == "succeeded":
+            return ReconcileResult.completed(pi)
+        if pi.status in ("canceled", "requires_payment_method"):
+            return ReconcileResult.not_executed()
+        return ReconcileResult.unknown()
+
+@ledger_sync(transition_binding=binding, reconciler=StripeReconciler())
+def send_payment(...): ...</pre>
+      <p>
+        <code>external_operation_ref</code> is the provider handle (id or idempotency key),
+        not proof by itself. The <code>Reconciler</code> does a read-only lookup:
+        <code>COMPLETED</code> → return result;
+        <code>NOT_EXECUTED</code> → run exactly once more;
+        <code>UNKNOWN</code> / no ref / no reconciler → <code>LedgerHardBlockError</code>.
+      </p>
+      <pre>Boundary at failure     Terminal outcome        Redispatch
+not_crossed             FAILED_BEFORE_EFFECT    retry if policy allows
+maybe_crossed           UNKNOWN                 hard-block → reconcile
+crossed                 FAILED_AFTER_EFFECT     hard-block
+
+EXPIRED + not_crossed + ref + NOT_EXECUTED   → reclaim (v1.9.2)
+EXPIRED + not_crossed, no ref                → hard-block (not provable)
+EXPIRED + maybe_crossed / crossed            → hard-block</pre>
     </section>
 
     <section id="yaml">
@@ -663,8 +725,9 @@ with config.run(thread_id):
           <strong>runtime failures</strong>: a tool runs twice on retry, context goes stale,
           or the model emits an invalid tool call. To make AI agents reliable, guard the
           runtime, not just the prompt. Mycelium classifies each tool by side effect, hashes a
-          durable transition key, and resolves duplicate dispatches by terminal state, while
-          validating message history and tool inputs before anything executes. Framework-agnostic:
+          durable transition key, and resolves duplicate dispatches through resolution
+          gates (poll reads, soft-block ambiguous reads, hard-block or reconcile writes),
+          while validating message history and tool inputs before anything executes. Framework-agnostic:
           LangGraph, CrewAI, or plain Python. <code>pip install mycelium-runtime</code>
         </p>
       </div>
@@ -674,11 +737,11 @@ with config.run(thread_id):
         <p>
           Add <code>transition:</code> and <code>side_effect_class</code> per tool in
           <code>mycelium.yaml</code>. Mycelium hashes a durable transition key (scope, tool,
-          args, class, policy) and resolves duplicates by terminal state, not by re-running
-          blindly. LangGraph Cloud can redispatch long tool calls while the first is still
-          in flight (<a href="https://github.com/langchain-ai/langgraph/issues/7417">langgraph#7417</a>).
-          <code>read</code> tools poll and return the cached result;
-          <code>payment</code> / write tools hard-block ambiguous retries.
+          args, class, policy) and resolves duplicates through gates: return completed,
+          poll in-flight, soft-block ambiguous reads, hard-block or reconcile mutating
+          tools when <code>external_operation_ref</code> is recorded. LangGraph Cloud
+          can redispatch long tool calls while the first is still in flight
+          (<a href="https://github.com/langchain-ai/langgraph/issues/7417">langgraph#7417</a>).
           <code>pip install mycelium-runtime &amp;&amp; mycelium demo</code>
         </p>
       </div>
@@ -698,9 +761,11 @@ with config.run(thread_id):
         <p>
           Classify each tool (<code>read</code>, <code>keyed_mutate</code>, <code>non_idempotent_mutate</code>, etc.), enable
           <code>transition:</code> in YAML, and wrap with <code>@config.apply</code>.
-          On framework retry or worker redispatch, Mycelium resolves the existing transition:
-          return completed, poll in-flight, or raise <code>LedgerHardBlockError</code> when
-          reconciliation is required. Framework-agnostic.
+          On framework retry or worker redispatch, Mycelium resolves the existing
+          transition: return completed, poll in-flight, soft-block ambiguous reads,
+          or raise <code>LedgerHardBlockError</code> / reconcile via
+          <code>Reconciler</code> when <code>external_operation_ref</code> is present.
+          Framework-agnostic.
         </p>
       </div>
     </section>

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -36,7 +36,7 @@ subagent_task(task="analyze_market", tool_call_id=call["id"])
 |---------|-------------------|
 | **Stale or broken context** | TTL cache, message repair, history limits; agent sees fresh, valid data |
 | **Bad or unauthorized tool calls** | Validate inputs/outputs, allowlists, scoped paths; block before execution |
-| **Duplicate side effects on retry** | v1.3 transition envelope (side-effect class, poll / hard-block), ledgers, state flush, signed receipts |
+| **Duplicate side effects on retry** | Transition envelope (v1.3+): `side_effect_class`, terminal outcomes, resolution **gates** (`POLL` / `SOFT_BLOCK` / `HARD_BLOCK`), `external_operation_ref` + `Reconciler`, ledgers, signed receipts |
 
 Framework-agnostic. Raw message lists and plain Python functions (LangGraph, CrewAI, OpenAI tool loops, etc.).
 
@@ -258,15 +258,33 @@ async def send_payment(amount: float, recipient: str) -> dict:
 
 - Record every tool invocation in a durable `ActionLedger`
 - Deduplicate retries and redispatches via a rich **transition key** (scope + tool + args + `side_effect_class` + policy), not only `tool_call_id`
-- **`read` tools:** poll in-flight, reclaim expired leases, retry failed-before-effect, **soft-block** ambiguous `UNKNOWN`/`BLOCKED` states (safe to re-run; opt into deferral with `defer_read_only_unknown=True` → `LedgerSoftBlockError`)
-- **Mutating tools:** return completed results, poll in-flight, **hard-block** ambiguous states (`LedgerHardBlockError`). For `EXPIRED + not_crossed`, reclaim only when an `external_operation_ref` reconcile proves `NOT_EXECUTED` (fail-closed without a ref)
-- Persist failed attempts with **terminal outcomes** (`FAILED_BEFORE_EFFECT`, `FAILED_AFTER_EFFECT`, etc.) for audit and reconciliation
+- Resolve redispatches through **gates** (see [Resolution gates](#resolution-gates)) instead of re-running blindly
+- Persist failed attempts with **terminal outcomes** (`FAILED_BEFORE_EFFECT`, `FAILED_AFTER_EFFECT`, `UNKNOWN`, `EXPIRED`, etc.) for audit and reconciliation
+
+### Resolution gates
+
+Each duplicate dispatch is classified to a gate. Read-only and side-effecting tools use different resolvers.
+
+| Gate | Typical trigger | What happens |
+|------|-----------------|--------------|
+| `ALLOW` | no prior transition, or policy permits retry (e.g. `FAILED_BEFORE_EFFECT` + same provider key) | tool runs |
+| `RETURN` | `COMPLETED` | return stored result — no re-execution |
+| `POLL` | `IN_FLIGHT` with valid lease | wait for the other worker |
+| `RECLAIM` | read-only `EXPIRED` / `FAILED_*` | take over stale lease and run |
+| `SOFT_BLOCK` | read-only `UNKNOWN` / `BLOCKED` only | **retry by default** (safe — reads don't spend); opt into deferral with `defer_read_only_unknown=True` → `LedgerSoftBlockError` |
+| `HARD_BLOCK` | ambiguous mutating transition | stop; run `Reconciler` when `external_operation_ref` is present, else fail-closed |
+
+**Read-only** (`side_effect_class: read`): poll, reclaim, retry failed-before-effect, soft-block on ambiguous `UNKNOWN`/`BLOCKED`.
+
+**Mutating** (payment, email, subagent, irreversible, …): return completed, poll in-flight, hard-block ambiguity. For **`EXPIRED + not_crossed`**, the gate is `HARD_BLOCK` until a reconciler proves the effect never ran — see [Stale lease + reconcile](#stale-lease--reconcile-exired--not_crossed).
+
+`REPAIR` (fix missing durable context before execute) is planned; not shipped yet.
 
 ### Side-effect classes
 
 | Class | Typical use | Duplicate handling |
 |-------|-------------|-------------------|
-| `read` | search, fetch | poll / reclaim / retry / soft-block on `UNKNOWN` |
+| `read` | search, fetch | poll / reclaim / retry; `SOFT_BLOCK` on `UNKNOWN` |
 | `idempotent_mutate` | upsert / set status | retry if boundary not crossed |
 | `keyed_mutate` | Stripe-style create/charge | retry only with same provider key |
 | `non_idempotent_mutate` | send email, spawn subagent | hard-block on ambiguity |
@@ -311,6 +329,20 @@ The boundary drives failure classification and only ever moves forward (`not_cro
 
 Because `maybe_crossed` is written durably *before* the call, a process crash mid-call leaves the entry ambiguous and a redispatch hard-blocks instead of double-spending. For finer control use `mark_maybe_crossed()` / `mark_crossed()` directly. Works the same inside `async` tools.
 
+### Read-only `SOFT_BLOCK` (v1.9.0)
+
+When a read-only tool ends in `UNKNOWN` or `BLOCKED`, the resolver returns `SOFT_BLOCK` — not a terminal stop. Re-running a read is always safe, so the default is **retry** (reset to a fresh in-flight claim and run once more). For expensive reads, opt into deferral:
+
+```python
+from mycelium import ledger_sync, LedgerSoftBlockError
+
+@ledger_sync(transition_binding=read_binding, defer_read_only_unknown=True)
+def search_docs(query: str) -> dict:
+    ...
+```
+
+With `defer_read_only_unknown=True`, ambiguous read-only states raise `LedgerSoftBlockError` so the caller can retry later (cost-dependent). Side-effecting tools never use `SOFT_BLOCK`; they use `HARD_BLOCK` / reconcile.
+
 ### Recording the provider handle (`record_external_operation()`)
 
 When a side-effecting tool talks to a provider, record the provider's operation handle — its returned id (Stripe `pi_...`, a message id, a run id) or the idempotency key you sent — so an ambiguous transition can later be **reconciled** against the provider instead of parked for a human:
@@ -327,6 +359,8 @@ def send_payment(amount, recipient):
 ```
 
 The ref is stored on the entry (`external_operation_ref`) across all backends and shown in the hard-block message. Prefer recording the **idempotency key before the call** for keyed providers — it survives a crash mid-call, unlike a returned id.
+
+`external_operation_ref` is the **handle** for provider lookup; it is not proof by itself. Proof comes from the reconciler's read-only query (below).
 
 ### Reconciling automatically (`Reconciler`)
 
@@ -359,6 +393,22 @@ def send_payment(amount, recipient):
 | `UNKNOWN` | hard-blocks, exactly as if no reconciler were set |
 
 Reconciliation is **fail-closed**: no ref, no reconciler, or a reconciler that raises/times out all resolve to a hard-block — an exception in the reconciler never propagates. Async tools can implement `reconcile_async`; the async claim path prefers it and falls back to `reconcile`. Wire a reconciler via `@ledger` / `@ledger_sync` or `ActionLedger(reconciler=...)`.
+
+### Stale lease + reconcile (`EXPIRED + not_crossed`)
+
+When a worker dies or a lease expires while a side-effecting tool is still `IN_FLIGHT`, the transition becomes `EXPIRED`. Resolution depends on boundary and class:
+
+| Situation | Gate | Reclaim? |
+|-----------|------|----------|
+| `EXPIRED` + `maybe_crossed` / `crossed` | `HARD_BLOCK` | no — effect may have happened |
+| `EXPIRED` + `not_crossed`, strict class, **no** `external_operation_ref` | `HARD_BLOCK` | no — not provable |
+| `EXPIRED` + `not_crossed` + ref + reconciler → `NOT_EXECUTED` | reconcile → fresh claim | yes — provider proves effect never ran |
+| `EXPIRED` + `not_crossed` + ref + reconciler → `COMPLETED` | `RETURN` | no — return stored/reconciled result |
+| `EXPIRED` + `not_crossed`, `multi_use` + `SAFE_RETRY` (e.g. idempotent read/write) | `ALLOW` | yes — reclaim without reconcile |
+
+If a duplicate worker is **polling** an in-flight transition and the lease expires mid-poll, the poll loop returns (v1.9.2) so the claim path can reconcile instead of hard-blocking immediately.
+
+Record `external_operation_ref` early (ideally the idempotency key before the provider call) so stale-lease and `UNKNOWN` cases can be resolved automatically instead of parking for a human.
 
 ### Enforcing the same provider idempotency key (`provider_idempotency_key_param`)
 


### PR DESCRIPTION
## Summary

Document the current transition resolution model shipped in v1.9.0–v1.9.2 across root README, SDK README, and the GitHub Pages handbook.

- Gate taxonomy: `ALLOW` / `RETURN` / `POLL` / `RECLAIM` / `SOFT_BLOCK` / `HARD_BLOCK`
- Read-only `SOFT_BLOCK` (default retry; opt-in `LedgerSoftBlockError`)
- `external_operation_ref` as provider handle; `Reconciler` as proof
- `EXPIRED + not_crossed` reclaim only when reconcile proves `NOT_EXECUTED`

## Test plan

- [ ] Preview handbook locally / after Pages deploy: resolution section + sidebar link
- [ ] Spot-check root README “What it does” and sdk README gate / EXPIRED sections
- [ ] No version bump / no tag (docs-only)