### PR TITLE
docs: envelope field stack + PyPI description republish (v1.9.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.9.3 (2026-07-20)
+
+Docs patch: republish so PyPI’s project description matches the current `sdk/README.md`, and document the transition-envelope field stack in the handbook.
+
+### Docs
+
+- Document the six transition-envelope fields in priority order (`side_effect_class` → `spendability` → `side_effect_boundary` → `terminal_outcome` → `external_operation_ref` → `retry_permission`) and the invariant: required fields for a tool class must be supported/recorded before a redispatch is treated as a safe retry.
+- Handbook `#envelope` section + root / SDK README pointers (Mycelium branding; no third-party product names).
+- Bump version banners to v1.9.3 so the PyPI long description ships with Resolution gates, SOFT_BLOCK, EXPIRED reclaim, and the envelope field stack.
+
 ## 1.9.2 (2026-07-20)
 
 Patch: close the remaining gap on **EXPIRED + not_crossed → reclaim only if provable** via `external_operation_ref` reconcile. No new schema or policy concepts.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Prevents predictable failures *before* they reach the LLM. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.9.2**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.9.3**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 
@@ -24,10 +24,11 @@ These aren't reasoning failures. They're runtime failures. Mycelium sits between
   - **Read tools:** poll in-flight, reclaim expired leases, **soft-block** ambiguous `UNKNOWN` (safe retry by default)
   - **Mutating tools:** hard-block ambiguity; **reconcile** via `external_operation_ref` when a provider lookup can prove run-or-not (`COMPLETED` / `NOT_EXECUTED` / still blocked)
   - **Stale lease (`EXPIRED`):** strict classes reclaim only when reconcile proves `NOT_EXECUTED` (fail-closed without a ref)
+- **Transition envelope fields** (priority order): `side_effect_class` → `spendability` → `side_effect_boundary` → `terminal_outcome` → `external_operation_ref` → `retry_permission` — payment/write needs the heavier set; without it, redispatch is an unsupported second transition, not a retry
 - **Stale or broken context:** fresh tool data, valid message transcripts
 - **Bad tool calls:** block invalid inputs and out-of-scope tools before they run
 
-Not Langfuse. Use both if you want traces and guards. Full resolution rules: [sdk/README.md](sdk/README.md#resolution-gates).
+Not Langfuse. Use both if you want traces and guards. Full resolution rules: [sdk/README.md](sdk/README.md#resolution-gates). Envelope field stack: [sdk/README.md](sdk/README.md#transition-envelope-fields).
 
 ## Use it
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -371,6 +371,7 @@
       <li><a href="#tools">Tools</a></li>
       <li><a href="#actions">Actions</a></li>
       <li><a href="#resolution">Resolution</a></li>
+      <li><a href="#envelope">Envelope</a></li>
       <li><a href="#yaml">YAML</a></li>
       <li><a href="#common-searches">FAQ</a></li>
     </ol>
@@ -391,7 +392,7 @@
       Classify tools, hash a durable transition key, resolve duplicates by terminal
       state and resolution gates (poll / soft-block reads, hard-block or reconcile
       writes via <code>external_operation_ref</code>). Framework-agnostic.
-      Early but API-stable (v1.9.2): breaking changes only at major versions.
+      Early but API-stable (v1.9.3): breaking changes only at major versions.
     </p>
 
     <section id="architecture">
@@ -612,6 +613,37 @@ crossed                 FAILED_AFTER_EFFECT     hard-block
 EXPIRED + not_crossed + ref + NOT_EXECUTED   → reclaim (v1.9.2)
 EXPIRED + not_crossed, no ref                → hard-block (not provable)
 EXPIRED + maybe_crossed / crossed            → hard-block</pre>
+    </section>
+
+    <section id="envelope">
+      <h2>Envelope fields</h2>
+      <p>
+        Six fields decide whether an unresolved prior execution is merely
+        <strong>wasteful</strong> (safe to retry or poll) or <strong>unsafe</strong>
+        (must not re-run). Listed in priority order:
+      </p>
+      <pre>#  Field                    Role
+1  side_effect_class        kind of effect (read, keyed_mutate, …)
+2  spendability             how many times this intent may spend
+3  side_effect_boundary     not_crossed / maybe_crossed / crossed
+4  terminal_outcome         IN_FLIGHT, COMPLETED, UNKNOWN, EXPIRED, …
+5  external_operation_ref   provider handle for read-only reconcile
+6  retry_permission         whether auto-retry is allowed (same-key opt-in)</pre>
+      <p>
+        <strong>Invariant:</strong> for a given tool class, the fields that class
+        <em>requires</em> must already be <em>supported and recorded</em> on the
+        transition before a redispatch is treated as a safe retry. Reads need a
+        lighter set (class + terminal + lease). Payment, write, email, and subagent
+        tools need spendability, boundary, terminal outcome, and usually an external
+        receipt or ref. Without them, a second dispatch is an
+        <strong>unsupported second transition</strong>, not a retry.
+      </p>
+      <p>
+        Also on the durable record: <code>transition_key</code>,
+        <code>idempotency_key</code>, <code>owner</code>, <code>lease_until</code>,
+        <code>receipt_ref</code>. Resolution gates above decide what to do once
+        those fields are present.
+      </p>
     </section>
 
     <section id="yaml">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.9.2** (transition envelope).
+Current package: **mycelium-runtime v1.9.3** (transition envelope).
 
 ## One painful bug → a few lines of config
 
@@ -279,6 +279,23 @@ Each duplicate dispatch is classified to a gate. Read-only and side-effecting to
 **Mutating** (payment, email, subagent, irreversible, …): return completed, poll in-flight, hard-block ambiguity. For **`EXPIRED + not_crossed`**, the gate is `HARD_BLOCK` until a reconciler proves the effect never ran — see [Stale lease + reconcile](#stale-lease--reconcile-exired--not_crossed).
 
 `REPAIR` (fix missing durable context before execute) is planned; not shipped yet.
+
+### Transition envelope fields
+
+Six fields decide whether an unresolved prior execution is merely **wasteful** (safe to retry/poll) or **unsafe** (must not re-run). Priority order:
+
+| # | Field | Role |
+|---|-------|------|
+| 1 | `side_effect_class` | What kind of effect (`read`, `keyed_mutate`, `non_idempotent_mutate`, …) |
+| 2 | `spendability` | How many times the same intent may spend (`multi_use` / `single_use` / `non_replayable`) |
+| 3 | `side_effect_boundary` | Whether the external call was crossed (`not_crossed` / `maybe_crossed` / `crossed`) |
+| 4 | `terminal_outcome` | Where the prior attempt ended (`IN_FLIGHT`, `COMPLETED`, `UNKNOWN`, `EXPIRED`, …) |
+| 5 | `external_operation_ref` | Provider handle for read-only reconcile (id or idempotency key) |
+| 6 | `retry_permission` | Whether automatic retry is allowed (and same-key enforcement when opted in) |
+
+**Invariant:** for a given tool class, the fields that class **requires** must already be **supported and recorded** on the transition before a redispatch is treated as a safe retry. Reads need a lighter set (class + terminal + lease). Payment / write / email / subagent need spendability, boundary, terminal outcome, and usually an external receipt/ref — without them, a second dispatch is an **unsupported second transition**, not a retry.
+
+Also on the durable record: `transition_key`, `idempotency_key`, `owner`, `lease_until`, `receipt_ref`.
 
 ### Side-effect classes
 

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -82,7 +82,7 @@ from mycelium.transition import (
     execution_scope,
 )
 
-__version__ = "1.9.2"
+__version__ = "1.9.3"
 
 __all__ = [
     "ActionLedger",

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.9.2"
+version = "1.9.3"
 description = "Runtime guards for AI agents: stale context, bad tool calls, duplicate side effects on retry"
 keywords = [
   "ai-agents",

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.9.2"
+version = "1.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Docs patch that (1) documents the six transition-envelope fields in Mycelium language and (2) bumps to **v1.9.3** so a tag publish rebuilds PyPI’s long description from the current `sdk/README.md` (gates / SOFT_BLOCK / EXPIRED / envelope stack).

- Handbook `#envelope` section + sidebar link
- SDK README table + invariant (required fields must be supported/recorded before safe retry)
- Root README one-liner + links
- No PHI / third-party product branding

## Release

**v1.9.3** PATCH (docs / packaging only). Tag `v1.9.3` after merge to refresh PyPI.

## Test plan

- [ ] Handbook Envelope section renders; sidebar link works
- [ ] After merge + tag: PyPI description includes “Resolution gates” and “Transition envelope fields”
- [ ] `pip show mycelium-runtime` / PyPI JSON version = 1.9.3