### PR TITLE
Add command-based auto-instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Command auto-instrumentation
+
+- Add `mycelium run --config mycelium.yaml -- python ...` to apply YAML tool/task guards without editing application functions.
+- Add validated, unique `callable: module:function` targets and explicit-name tool/task application helpers.
+- Fail closed on missing/non-callable targets, unsupported Python startup flags, and partially wrapped callables; skip fully configured wrappers to prevent double instrumentation.
+- Preserve child argv, environment, working directory, signals, and exit status by replacing the launcher process with the target Python interpreter.
+- Preserve optional LangGraph `ToolRuntime` identity propagation for command-wrapped tools.
+
 ## 1.11.0 (2026-07-21)
 
 Minor: automatically propagate trusted LangGraph runtime identity into Mycelium transition keys, without coupling the core transition model to LangGraph.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,22 @@ action_ledger:
 
 tools:
   my_side_effect_tool:
+    callable: my_app.tools:my_side_effect_tool
     side_effect_class: non_idempotent_mutate
 ```
+
+Launch your existing Python application without adding decorators:
+
+```bash
+mycelium run --config mycelium.yaml -- python -m my_app
+```
+
+`mycelium run` validates and wraps every configured callable before the
+application starts. It preserves the child process's arguments, working
+directory, signals, and exit code. The command accepts the current Python
+interpreter only.
+
+Explicit instrumentation remains supported when you prefer code-level control:
 
 ```python
 from mycelium import load_config
@@ -72,6 +86,11 @@ config = load_config("mycelium.yaml")
 def my_side_effect_tool(...) -> dict:
     ...
 ```
+
+Do not combine standalone guard decorators with command mode on the same
+function. Fully configured `@config.apply` wrappers are detected and skipped.
+Keep callable modules import-safe: registrations performed inside a target
+module while that module is still importing cannot be retroactively replaced.
 
 With the optional LangGraph integration, `ToolNode` / `create_agent` injects
 `ToolRuntime`; Mycelium automatically maps its `tool_call_id`, thread, run, and

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
         "name": "How do I prevent duplicate tool execution in LangGraph?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Classify each tool (read vs keyed_mutate vs non_idempotent_mutate, etc.), enable transition: in mycelium.yaml, and use @config.apply. Mycelium hashes a durable transition key and resolves duplicates by terminal state and resolution gates: read tools poll or soft-block UNKNOWN; mutating tools hard-block or reconcile against the provider when you record external_operation_ref. pip install mycelium-runtime && mycelium demo"
+          "text": "Classify each tool (read vs keyed_mutate vs non_idempotent_mutate, etc.), enable transition: in mycelium.yaml, and use callable paths with mycelium run or @config.apply. Mycelium hashes a durable transition key and resolves duplicates by terminal state and resolution gates: read tools poll or soft-block UNKNOWN; mutating tools hard-block or reconcile against the provider when you record external_operation_ref. pip install mycelium-runtime && mycelium demo"
         }
       },
       {
@@ -428,10 +428,19 @@ pip install 'mycelium-runtime[postgres]'
 mycelium init              # on-ramp (transition + one ledgered tool)
 mycelium init --full       # reference: all guards (fill TODOs; not default)
 mycelium init --minimal    # smaller multi-guard scaffold
-mycelium demo              # langgraph#7417 bug and fix</pre>
+mycelium demo              # langgraph#7417 bug and fix
+mycelium run --config mycelium.yaml -- python -m my_agent</pre>
+      <p>
+        <strong>Zero-touch command mode:</strong> add a unique
+        <code>callable: module:function</code> to every configured tool/task.
+        <code>mycelium run</code> validates and wraps those functions before
+        the application starts, then preserves native argv, signals, working
+        directory, and exit status. Existing <code>@config.apply</code> and
+        <code>config.instrument</code> flows remain supported.
+      </p>
       <p>
         <strong>LangGraph runtime IDs (v1.11.0):</strong> the default LangGraph on-ramp enables
-        <code>integrations.langgraph</code>. With <code>@config.apply</code>,
+        <code>integrations.langgraph</code>. With command mode or <code>@config.apply</code>,
         Mycelium adds LangGraph’s trusted, hidden <code>ToolRuntime</code>
         parameter and maps its tool-call, thread, run, and node identifiers into
         the generic transition key. Explicit IDs still override captured values;
@@ -704,6 +713,7 @@ audit_receipt:
 
 tools:
   fetch_customer:
+    callable: my_agent.tools:fetch_customer
     side_effect_class: read
     protect: {entity_param: customer_id, ttl: 60}
     bounded:
@@ -714,6 +724,7 @@ tools:
         name: {type: string, required: true}
 
   delete_file:
+    callable: my_agent.tools:delete_file
     side_effect_class: non_idempotent_mutate
     bounded:
       schema:
@@ -722,6 +733,7 @@ tools:
       path_param: path
 
   send_payment:
+    callable: my_agent.tools:send_payment
     side_effect_class: keyed_mutate
     retry_permission: manual_reconciliation_required
     bounded:
@@ -730,6 +742,7 @@ tools:
         recipient: {type: string, required: true}
 
   search_docs:
+    callable: my_agent.tools:search_docs
     side_effect_class: read
     bounded:
       schema:
@@ -737,6 +750,7 @@ tools:
 
 tasks:
   process_invoice:
+    callable: my_agent.tasks:process_invoice
     ledger: true
     id_from: [invoice_id]
 
@@ -753,15 +767,17 @@ history_guard:
 
 message_validator:
   enabled: true</pre>
+      <pre># option A: zero-touch command mode
+mycelium run --config mycelium.yaml -- python -m my_agent</pre>
       <pre>from mycelium import load_config
 import my_tools
 
 config = load_config("mycelium.yaml")
 
-# option A: instrument a module
+# option B: instrument a module
 tools = config.instrument(my_tools)
 
-# option B: decorate one function (name must match tools: key)
+# option C: decorate one function (name must match tools: key)
 @config.apply
 def send_payment(amount: float, recipient: str) -> dict:
     return gateway.charge(amount, recipient)
@@ -773,6 +789,13 @@ def process_invoice(invoice_id: str) -> dict:
 with config.run(thread_id):
     messages = config.prepare_messages(messages)
     runner = config.build_runner(registry=config.registry)</pre>
+      <p>
+        Command mode fails closed for missing targets and partial wrappers, and
+        skips fully configured explicit wrappers. Keep target modules
+        import-safe. Registration performed inside a target module before its
+        import completes cannot be retroactively replaced; move that
+        registration to the entrypoint or use explicit instrumentation.
+      </p>
     </section>
 
     <section id="common-searches">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -17,14 +17,15 @@ mycelium demo                  # see the bug and the fix (no LangGraph required)
 ```
 
 
-```python
-from mycelium import load_config
+```yaml
+tools:
+  subagent_task:
+    callable: my_agent.tools:subagent_task
+    side_effect_class: non_idempotent_mutate
+```
 
-config = load_config("mycelium.yaml")  # includes transition: + side_effect_class
-
-@config.apply
-def subagent_task(task: str) -> dict:
-    return run_slow_subagent(task)
+```bash
+mycelium run --config mycelium.yaml -- python -m my_agent
 ```
 
 In v1.11.0, the default `mycelium init` YAML enables `integrations.langgraph`. LangGraph's
@@ -32,6 +33,11 @@ In v1.11.0, the default `mycelium init` YAML enables `integrations.langgraph`. L
 its `tool_call_id`, thread, run, and node into the transition key. No
 `tool_call_id` parameter is needed on your function. Explicit IDs still win;
 custom tool executors may continue passing them manually.
+
+`mycelium run` wraps all configured tool/task callable paths before application
+startup and then replaces itself with the child Python process. Existing
+`@config.apply`, `@config.apply_task`, and `config.instrument` flows remain
+supported for explicit code-level control.
 
 ## What else it does
 
@@ -244,20 +250,38 @@ action_ledger:
 
 tools:
   send_payment:
+    callable: my_agent.tools:send_payment
     side_effect_class: keyed_mutate
     # spendability defaults to single_use for keyed_mutate
     retry_permission: manual_reconciliation_required
   search_docs:
+    callable: my_agent.tools:search_docs
     side_effect_class: read
     # spendability defaults to multi_use for read
 ```
 
-When enabled, `@config.apply` adds a hidden keyword-only
+When enabled, command mode or `@config.apply` adds a hidden keyword-only
 `runtime: ToolRuntime` parameter. LangGraph treats it as a trusted injected
 argument (not an LLM-visible tool input), while the original function remains
 unchanged. Calls outside LangGraph still work. This requires
 `mycelium-runtime[langgraph]` and LangGraph's `ToolNode` or `create_agent`;
 custom executors must pass IDs themselves.
+
+For zero-touch instrumentation, launch with:
+
+```bash
+mycelium run --config mycelium.yaml -- python -m my_agent
+```
+
+Every non-noop tool/task must declare a unique `callable: module:function`.
+Targets are imported and validated before the application entrypoint runs;
+missing/non-callable targets and partial Mycelium wrappers stop startup. A
+fully configured `@config.apply` or `@config.apply_task` target is skipped.
+Only the current Python interpreter is accepted, and `-E`, `-I`, and `-S` are
+rejected because they disable the startup hook. Keep target modules import-safe.
+Code that registers a function inside its own module before that import
+completes cannot be retroactively updated; move registration to the entrypoint
+or use explicit instrumentation for that target.
 
 Async tools:
 
@@ -565,6 +589,7 @@ audit_receipt:
 # Per-tool: side_effect_class + schemas
 tools:
   fetch_customer:
+    callable: my_agent.tools:fetch_customer
     side_effect_class: read
     protect: {entity_param: customer_id, ttl: 60}
     bounded:
@@ -572,6 +597,7 @@ tools:
         customer_id: {type: string, required: true, pattern: "^c\\d+$"}
 
   send_payment:
+    callable: my_agent.tools:send_payment
     side_effect_class: keyed_mutate
     bounded:
       schema:
@@ -579,10 +605,12 @@ tools:
         recipient: {type: string, required: true}
 
   search_docs:
+    callable: my_agent.tools:search_docs
     side_effect_class: read
 
 tasks:
   process_invoice:
+    callable: my_agent.tasks:process_invoice
     ledger: true
     id_from: [invoice_id]
 
@@ -595,6 +623,13 @@ history_guard:
 message_validator:
   enabled: true
 ```
+
+```bash
+# Zero-touch mode: callable paths above select the functions.
+mycelium run --config mycelium.yaml -- python -m my_agent
+```
+
+Or instrument explicitly in Python:
 
 ```python
 from mycelium import load_config

--- a/sdk/mycelium/__main__.py
+++ b/sdk/mycelium/__main__.py
@@ -1,8 +1,10 @@
-"""CLI entrypoint: ``mycelium init`` and ``mycelium demo``."""
+"""CLI entrypoint: init, demo, and command auto-instrumentation."""
 
 from __future__ import annotations
 
 import argparse
+import os
+import shutil
 import sys
 from importlib import resources
 from pathlib import Path
@@ -35,8 +37,8 @@ def cmd_init(output: Path, *, full: bool, minimal: bool, force: bool) -> int:
     print(f"Wrote {output} ({label} template)")
     if label == "quickstart":
         print(
-            "Next: install mycelium-runtime[langgraph], rename agent_id/subagent_task, "
-            "then use @config.apply in code."
+            "Next: install mycelium-runtime[langgraph], fill the IDs/callable path, "
+            "then use 'mycelium run -- python -m your_package.app'."
         )
         print("Try: mycelium demo")
     else:
@@ -48,6 +50,67 @@ def cmd_demo() -> int:
     from mycelium.quickstart import run_demo
 
     return run_demo()
+
+
+def _validated_python_command(command: list[str]) -> list[str]:
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        raise ValueError("missing command after '--'")
+
+    executable = shutil.which(command[0])
+    if executable is None:
+        raise ValueError(f"Python executable not found: {command[0]!r}")
+    if Path(executable).resolve() != Path(sys.executable).resolve():
+        raise ValueError(
+            "'mycelium run' requires the current Python interpreter; use "
+            f"{sys.executable!r}"
+        )
+    forbidden = {"-E", "-I", "-S"}
+    present = forbidden.intersection(command[1:])
+    if present:
+        flags = ", ".join(sorted(present))
+        raise ValueError(
+            f"Python flag(s) {flags} disable safe Mycelium startup instrumentation"
+        )
+    return [executable, *command[1:]]
+
+
+def cmd_run(config_path: Path, command: list[str]) -> int:
+    """Replace this process with an auto-instrumented Python command."""
+    from mycelium.auto_instrumentation import AUTO_CONFIG_ENV, AUTO_ENABLED_ENV
+    from mycelium.config import ConfigError, load_config
+
+    resolved_config = config_path.resolve()
+    try:
+        config = load_config(resolved_config)
+        config.auto_instrumentation_targets()
+        child_command = _validated_python_command(command)
+    except (ConfigError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    bootstrap_dir = (
+        Path(__file__).resolve().parent
+        / "auto_instrumentation"
+        / "site_bootstrap"
+    )
+    env = dict(os.environ)
+    current_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(bootstrap_dir)
+        if not current_pythonpath
+        else os.pathsep.join((str(bootstrap_dir), current_pythonpath))
+    )
+    env[AUTO_ENABLED_ENV] = "1"
+    env[AUTO_CONFIG_ENV] = str(resolved_config)
+
+    try:
+        os.execvpe(child_command[0], child_command, env)
+    except OSError as exc:
+        print(f"error: cannot start {child_command[0]!r}: {exc}", file=sys.stderr)
+        return 127
+    return 127
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -85,12 +148,30 @@ def main(argv: list[str] | None = None) -> int:
         "demo",
         help="Show LangGraph duplicate-tool bug and the v1.3 transition fix",
     )
+    run_parser = sub.add_parser(
+        "run",
+        help="Run a Python command with YAML callables auto-instrumented",
+    )
+    run_parser.add_argument(
+        "-c",
+        "--config",
+        type=Path,
+        default=Path("mycelium.yaml"),
+        help="Config path (default: ./mycelium.yaml)",
+    )
+    run_parser.add_argument(
+        "child_command",
+        nargs=argparse.REMAINDER,
+        help="Python command after '--'",
+    )
 
     args = parser.parse_args(argv)
     if args.command == "init":
         return cmd_init(args.output, full=args.full, minimal=args.minimal, force=args.force)
     if args.command == "demo":
         return cmd_demo()
+    if args.command == "run":
+        return cmd_run(args.config, args.child_command)
     return 1
 
 

--- a/sdk/mycelium/auto_instrumentation/__init__.py
+++ b/sdk/mycelium/auto_instrumentation/__init__.py
@@ -1,0 +1,15 @@
+"""Command-based Mycelium auto-instrumentation."""
+
+from mycelium.auto_instrumentation.bootstrap import (
+    AUTO_CONFIG_ENV,
+    AUTO_ENABLED_ENV,
+    initialize_from_environment,
+    instrument_configured_callables,
+)
+
+__all__ = [
+    "AUTO_CONFIG_ENV",
+    "AUTO_ENABLED_ENV",
+    "initialize_from_environment",
+    "instrument_configured_callables",
+]

--- a/sdk/mycelium/auto_instrumentation/bootstrap.py
+++ b/sdk/mycelium/auto_instrumentation/bootstrap.py
@@ -1,0 +1,67 @@
+"""Bootstrap configured callables before the target application starts."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from types import ModuleType
+from typing import Any
+
+from mycelium.config import (
+    AutoInstrumentationTarget,
+    ConfigError,
+    MyceliumConfig,
+    load_config,
+)
+
+AUTO_ENABLED_ENV = "MYCELIUM_AUTO_INSTRUMENT"
+AUTO_CONFIG_ENV = "MYCELIUM_AUTO_CONFIG"
+
+
+def _resolve_module_attribute(
+    target: AutoInstrumentationTarget,
+) -> tuple[ModuleType, Any]:
+    module_name, attribute = target.callable_path.split(":", 1)
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:
+        raise ConfigError(
+            f"cannot import {target.kind} {target.name!r} module "
+            f"{module_name!r}: {exc}"
+        ) from exc
+    if not hasattr(module, attribute):
+        raise ConfigError(
+            f"{target.kind} {target.name!r} callable "
+            f"{target.callable_path!r} does not exist"
+        )
+    value = getattr(module, attribute)
+    if not callable(value) or not hasattr(value, "__name__"):
+        raise ConfigError(
+            f"{target.kind} {target.name!r} target "
+            f"{target.callable_path!r} is not a function"
+        )
+    return module, value
+
+
+def instrument_configured_callables(config: MyceliumConfig) -> None:
+    """Eagerly import, validate, and replace every configured tool/task."""
+    for target in config.auto_instrumentation_targets():
+        module, func = _resolve_module_attribute(target)
+        if target.kind == "tool":
+            wrapped = config.apply_tool(target.name, func)
+        else:
+            wrapped = config.apply_named_task(target.name, func)
+        _, attribute = target.callable_path.split(":", 1)
+        setattr(module, attribute, wrapped)
+
+
+def initialize_from_environment() -> None:
+    """Initialize once when loaded by the launcher's ``sitecustomize``."""
+    enabled = os.environ.pop(AUTO_ENABLED_ENV, None)
+    config_path = os.environ.pop(AUTO_CONFIG_ENV, None)
+    if enabled != "1":
+        return
+    if not config_path:
+        raise ConfigError(f"{AUTO_CONFIG_ENV} is required for auto-instrumentation")
+    config = load_config(config_path)
+    instrument_configured_callables(config)

--- a/sdk/mycelium/auto_instrumentation/site_bootstrap/__init__.py
+++ b/sdk/mycelium/auto_instrumentation/site_bootstrap/__init__.py
@@ -1,0 +1,1 @@
+"""Private startup-path package for command auto-instrumentation."""

--- a/sdk/mycelium/auto_instrumentation/site_bootstrap/sitecustomize.py
+++ b/sdk/mycelium/auto_instrumentation/site_bootstrap/sitecustomize.py
@@ -1,0 +1,18 @@
+"""Python startup hook installed temporarily by ``mycelium run``."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+try:
+    from mycelium.auto_instrumentation import initialize_from_environment
+
+    initialize_from_environment()
+except BaseException as exc:
+    print(
+        f"mycelium: auto-instrumentation failed: {exc}",
+        file=sys.stderr,
+        flush=True,
+    )
+    os._exit(78)

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import functools
 import inspect
+import re
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -70,6 +72,88 @@ class ConfigError(Exception):
     """Raised when a Mycelium config file is invalid or inconsistent."""
 
 
+_CALLABLE_PATH_RE = re.compile(
+    r"^(?:[A-Za-z_][A-Za-z0-9_]*\.)*[A-Za-z_][A-Za-z0-9_]*:"
+    r"[A-Za-z_][A-Za-z0-9_]*$"
+)
+_CONFIG_APPLIED_MARKER = "_mycelium_config_applied"
+_GUARD_MARKERS = (
+    "_mycelium_ledger",
+    "_mycelium_task_ledger",
+    "_mycelium_bounded",
+    "_mycelium_protected",
+    "_mycelium_langgraph_integration",
+)
+
+
+def _parse_callable_path(raw: Any, *, kind: str, name: str) -> str | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not _CALLABLE_PATH_RE.fullmatch(raw):
+        raise ConfigError(
+            f"{kind} {name!r}.callable must be 'package.module:function'"
+        )
+    return raw
+
+
+def _check_existing_config_wrapper(
+    func: Callable[..., Any],
+    *,
+    kind: str,
+    name: str,
+) -> bool:
+    applied = getattr(func, _CONFIG_APPLIED_MARKER, None)
+    if applied is not None:
+        if applied == (kind, name):
+            return True
+        raise ConfigError(
+            f"{kind} {name!r} is already configured as "
+            f"{applied[0]} {applied[1]!r}"
+        )
+    if any(getattr(func, marker, False) for marker in _GUARD_MARKERS):
+        raise ConfigError(
+            f"{kind} {name!r} is already partially Mycelium-wrapped; "
+            "use either @config.apply / @config.apply_task or 'mycelium run', "
+            "not standalone guard decorators plus auto-instrumentation"
+        )
+    return False
+
+
+def _mark_config_applied(
+    func: Callable[..., Any],
+    *,
+    kind: str,
+    name: str,
+) -> None:
+    setattr(func, _CONFIG_APPLIED_MARKER, (kind, name))
+
+
+def _callable_with_name(
+    func: Callable[..., Any],
+    name: str,
+) -> Callable[..., Any]:
+    """Return a metadata-preserving alias whose guard identity is ``name``."""
+    if func.__name__ == name:
+        return func
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_alias(*args: Any, **kwargs: Any) -> Any:
+            return await func(*args, **kwargs)
+
+        alias: Callable[..., Any] = async_alias
+    else:
+
+        @functools.wraps(func)
+        def sync_alias(*args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+
+        alias = sync_alias
+    alias.__name__ = name
+    alias.__qualname__ = name
+    return alias
+
+
 @dataclass(frozen=True)
 class ToolConfig:
     """Parsed configuration for a single tool."""
@@ -84,6 +168,7 @@ class ToolConfig:
     side_effect_boundary: SideEffectBoundary | None = None
     spendability: Spendability | None = None
     provider_idempotency_key_param: str | None = None
+    callable_path: str | None = None
 
     def is_noop(self) -> bool:
         return (
@@ -101,9 +186,19 @@ class TaskConfig:
     name: str
     ledger: dict[str, Any] | None = None
     audit_receipt: bool = False
+    callable_path: str | None = None
 
     def is_noop(self) -> bool:
         return self.ledger is None and not self.audit_receipt
+
+
+@dataclass(frozen=True)
+class AutoInstrumentationTarget:
+    """A YAML entry resolved by command-based auto-instrumentation."""
+
+    kind: str
+    name: str
+    callable_path: str
 
 
 @dataclass
@@ -136,11 +231,21 @@ class MyceliumConfig:
         Guard order (outermost first):
         ``@ledger`` -> ``@bounded`` -> ``@protect`` -> ``func``
         """
-        name = func.__name__
+        return self.apply_tool(func.__name__, func)
+
+    def apply_tool(
+        self,
+        name: str,
+        func: Callable[..., Any],
+    ) -> Callable[..., Any]:
+        """Apply the tool config selected by explicit logical ``name``."""
         tool_config = self.tools.get(name)
         if tool_config is None or tool_config.is_noop():
             return func
+        if _check_existing_config_wrapper(func, kind="tool", name=name):
+            return func
 
+        func = _callable_with_name(func, name)
         is_async = inspect.iscoroutinefunction(func)
 
         # Apply protect first so it sits inside bounded.
@@ -183,6 +288,7 @@ class MyceliumConfig:
                 except LangGraphIntegrationError as exc:
                     raise ConfigError(str(exc)) from exc
 
+        _mark_config_applied(func, kind="tool", name=name)
         return func
 
     @property
@@ -192,15 +298,58 @@ class MyceliumConfig:
             return False
         return bool(self.integrations.get("langgraph", {}).get("enabled", False))
 
+    def auto_instrumentation_targets(self) -> list[AutoInstrumentationTarget]:
+        """Return callable targets, requiring paths for every configured entry."""
+        targets: list[AutoInstrumentationTarget] = []
+        missing: list[str] = []
+        for name, tool in self.tools.items():
+            if tool.is_noop():
+                continue
+            if tool.callable_path is None:
+                missing.append(f"tool {name!r}")
+            else:
+                targets.append(
+                    AutoInstrumentationTarget("tool", name, tool.callable_path)
+                )
+        for name, task in (self.tasks or {}).items():
+            if task.is_noop():
+                continue
+            if task.callable_path is None:
+                missing.append(f"task {name!r}")
+            else:
+                targets.append(
+                    AutoInstrumentationTarget("task", name, task.callable_path)
+                )
+        if missing:
+            joined = ", ".join(missing)
+            raise ConfigError(
+                f"'mycelium run' requires callable paths for: {joined}"
+            )
+        if not targets:
+            raise ConfigError(
+                "'mycelium run' found no configured tool/task callable paths"
+            )
+        return targets
+
     def apply_task(self, func: Callable[..., Any]) -> Callable[..., Any]:
         """Decorator that applies configured task-level guards to a function."""
-        name = func.__name__
+        return self.apply_named_task(func.__name__, func)
+
+    def apply_named_task(
+        self,
+        name: str,
+        func: Callable[..., Any],
+    ) -> Callable[..., Any]:
+        """Apply the task config selected by explicit logical ``name``."""
         if self.tasks is None:
             return func
         task_config = self.tasks.get(name)
         if task_config is None or task_config.is_noop():
             return func
+        if _check_existing_config_wrapper(func, kind="task", name=name):
+            return func
 
+        func = _callable_with_name(func, name)
         is_async = inspect.iscoroutinefunction(func)
         storage = self._build_task_ledger_storage(task_config.ledger)
         id_from = list(task_config.ledger.get("id_from", [])) if task_config.ledger else []
@@ -215,8 +364,19 @@ class MyceliumConfig:
             return func
 
         if is_async:
-            return task_ledger(storage=storage, id_from=id_from, audit_emitter=audit_emitter)(func)
-        return task_ledger_sync(storage=storage, id_from=id_from, audit_emitter=audit_emitter)(func)
+            func = task_ledger(
+                storage=storage,
+                id_from=id_from,
+                audit_emitter=audit_emitter,
+            )(func)
+        else:
+            func = task_ledger_sync(
+                storage=storage,
+                id_from=id_from,
+                audit_emitter=audit_emitter,
+            )(func)
+        _mark_config_applied(func, kind="task", name=name)
+        return func
 
     @property
     def registry(self) -> ToolRegistry:
@@ -658,6 +818,12 @@ def _parse_tool_config(
             )
         provider_idempotency_key_param = value
 
+    callable_path = _parse_callable_path(
+        raw.get("callable"),
+        kind="tool",
+        name=name,
+    )
+
     return ToolConfig(
         name=name,
         protect=protect,
@@ -669,6 +835,7 @@ def _parse_tool_config(
         side_effect_boundary=side_effect_boundary,
         spendability=spendability,
         provider_idempotency_key_param=provider_idempotency_key_param,
+        callable_path=callable_path,
     )
 
 
@@ -698,7 +865,17 @@ def _parse_task_config(
     if audit_auto and ledger is not None and raw.get("audit_receipt") is not False:
         audit_receipt = True
 
-    return TaskConfig(name=name, ledger=ledger, audit_receipt=audit_receipt)
+    callable_path = _parse_callable_path(
+        raw.get("callable"),
+        kind="task",
+        name=name,
+    )
+    return TaskConfig(
+        name=name,
+        ledger=ledger,
+        audit_receipt=audit_receipt,
+        callable_path=callable_path,
+    )
 
 
 def _normalize_ledger_config(
@@ -756,6 +933,7 @@ def _apply_action_ledger_tools(
             side_effect_boundary=existing.side_effect_boundary,
             spendability=existing.spendability,
             provider_idempotency_key_param=existing.provider_idempotency_key_param,
+            callable_path=existing.callable_path,
         )
 
 
@@ -792,6 +970,7 @@ def _apply_task_ledger_tasks(
             name=existing.name,
             ledger=ledger,
             audit_receipt=audit_receipt,
+            callable_path=existing.callable_path,
         )
 
 
@@ -868,6 +1047,27 @@ def _validate_transition_tools(
                 f"tool '{name}' has ledger but no side_effect_class; "
                 "required when 'transition' is configured"
             )
+
+
+def _validate_callable_targets(
+    tools: dict[str, ToolConfig],
+    tasks: dict[str, TaskConfig],
+) -> None:
+    seen: dict[str, tuple[str, str]] = {}
+    entries = [
+        *((tool.callable_path, "tool", name) for name, tool in tools.items()),
+        *((task.callable_path, "task", name) for name, task in tasks.items()),
+    ]
+    for callable_path, kind, name in entries:
+        if callable_path is None:
+            continue
+        previous = seen.get(callable_path)
+        if previous is not None:
+            raise ConfigError(
+                f"callable {callable_path!r} is configured more than once: "
+                f"{previous[0]} {previous[1]!r} and {kind} {name!r}"
+            )
+        seen[callable_path] = (kind, name)
 
 
 def _parse_integrations(data: dict[str, Any]) -> dict[str, dict[str, Any]] | None:
@@ -960,6 +1160,8 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
 
     if task_ledger_raw:
         _apply_task_ledger_tasks(tasks, task_ledger_raw, audit_auto=audit_auto)
+
+    _validate_callable_targets(tools, tasks)
 
     registry_raw = data.get("registry", {})
     if not isinstance(registry_raw, dict):

--- a/sdk/mycelium/templates/mycelium.minimal.yaml
+++ b/sdk/mycelium/templates/mycelium.minimal.yaml
@@ -34,6 +34,7 @@ audit_receipt:
 
 tools:
   fetch_customer:
+    callable: your_package.tools:fetch_customer
     protect:
       entity_param: customer_id
       ttl: 60
@@ -52,6 +53,7 @@ tools:
           required: true
 
   search_docs:
+    callable: your_package.tools:search_docs
     bounded:
       schema:
         query:
@@ -59,6 +61,7 @@ tools:
           required: true
 
   delete_file:
+    callable: your_package.tools:delete_file
     side_effect_class: non_idempotent_mutate
     bounded:
       schema:
@@ -71,6 +74,7 @@ tools:
 
 tasks:
   process_invoice:
+    callable: your_package.tasks:process_invoice
     ledger: true
     id_from:
       - invoice_id

--- a/sdk/mycelium/templates/mycelium.quickstart.yaml
+++ b/sdk/mycelium/templates/mycelium.quickstart.yaml
@@ -8,16 +8,9 @@
 # Next:
 #   1. Fill every <TODO: …> below; rename subagent_task to match your tool.
 #   2. Install `mycelium-runtime[langgraph]`; ToolRuntime IDs are propagated.
-#   3. In code:
-#        from mycelium import load_config
-#        config = load_config("mycelium.yaml")
-#
-#        @config.apply
-#        def subagent_task(task: str, duration_seconds: int) -> dict:
-#            with side_effect():                 # marks the point of no return
-#                run = run_slow_subagent(task)
-#                record_external_operation(run.id)  # provider handle for reconcile
-#            return run
+#   3. Put subagent_task at the callable path below, then launch:
+#        mycelium run --config mycelium.yaml -- python -m your_package.app
+#      Or keep explicit code-level control with @config.apply.
 
 integrations:
   langgraph:
@@ -35,4 +28,5 @@ action_ledger:
 
 tools:
   subagent_task:
+    callable: your_package.tools:subagent_task
     side_effect_class: non_idempotent_mutate

--- a/sdk/mycelium/templates/mycelium.template.yaml
+++ b/sdk/mycelium/templates/mycelium.template.yaml
@@ -13,7 +13,9 @@
 #      Defining a tool under tools: alone does NOT ledger it —
 #      empty allowlist = no duplicate-side-effect protection.
 #   2. Fill transition.agent_id / policy_version
-#   3. load_config + @config.apply / @config.apply_task (or config.instrument)
+#   3. Add callable: module:function to each configured entry, then use:
+#        mycelium run --config mycelium.yaml -- python -m your_package.app
+#      Or keep explicit @config.apply / @config.apply_task / config.instrument.
 #
 # storage (ledgers): memory | file | redis | postgres
 #   memory — process-local  |  file — needs path:
@@ -40,7 +42,7 @@
 #   `record_external_operation(provider_id_or_idempotency_key)` so an ambiguous
 #   transition can later be reconciled against the provider.
 # LangGraph: install `mycelium-runtime[langgraph]`, then enable the optional
-#   integration below. `@config.apply` adds an injected ToolRuntime parameter
+#   integration below. command mode or `@config.apply` adds ToolRuntime metadata
 #   and maps tool_call_id / thread_id / run_id / node into transition identity.
 # To reconcile automatically instead of hard-blocking, pass a read-only
 #   Reconciler in code: `@ledger_sync(reconciler=...)` or
@@ -116,11 +118,11 @@ audit_receipt:
 # ---------------------------------------------------------------------------
 tools: {}
 # One stub per side_effect_class (uncomment + rename):
-#   your_read_tool:                 {side_effect_class: read}
-#   your_idempotent_mutate_tool:    {side_effect_class: idempotent_mutate}
-#   your_keyed_mutate_tool:         {side_effect_class: keyed_mutate}
-#   your_non_idempotent_mutate_tool:{side_effect_class: non_idempotent_mutate}
-#   your_irreversible_tool:         {side_effect_class: irreversible}
+#   your_read_tool:                 {callable: package.tools:read, side_effect_class: read}
+#   your_idempotent_mutate_tool:    {callable: package.tools:update, side_effect_class: idempotent_mutate}
+#   your_keyed_mutate_tool:         {callable: package.tools:charge, side_effect_class: keyed_mutate}
+#   your_non_idempotent_mutate_tool:{callable: package.tools:send, side_effect_class: non_idempotent_mutate}
+#   your_irreversible_tool:         {callable: package.tools:delete, side_effect_class: irreversible}
 # Optional per tool: spendability: multi_use|single_use|non_replayable
 #   (omit to use class default), protect: {entity_param, ttl}, bounded: {schema: {}}
 

--- a/sdk/tests/test_auto_instrumentation.py
+++ b/sdk/tests/test_auto_instrumentation.py
@@ -1,0 +1,175 @@
+"""Unit tests for command-based callable instrumentation."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from types import ModuleType
+
+import pytest
+
+from mycelium import ConfigError, ledger_sync, load_config_from_string
+from mycelium.auto_instrumentation import instrument_configured_callables
+
+
+def _module(monkeypatch, name: str, **attributes):
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        value.__module__ = name
+        setattr(module, attribute, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def test_instruments_sync_tool_and_replaces_module_attribute(monkeypatch) -> None:
+    calls: list[float] = []
+
+    def charge(amount: float) -> dict[str, float]:
+        calls.append(amount)
+        return {"amount": amount}
+
+    module = _module(monkeypatch, "auto_sync_tools", charge=charge)
+    config = load_config_from_string(
+        """
+action_ledger: {storage: memory, tools: [send_payment]}
+tools:
+  send_payment:
+    callable: auto_sync_tools:charge
+"""
+    )
+
+    instrument_configured_callables(config)
+
+    assert module.charge.__name__ == "send_payment"
+    first = module.charge(amount=3.0, request_id="same")
+    second = module.charge(amount=3.0, request_id="same")
+    assert first == second == {"amount": 3.0}
+    assert calls == [3.0]
+
+
+def test_instruments_async_tool(monkeypatch) -> None:
+    calls: list[str] = []
+
+    async def send(to: str) -> str:
+        calls.append(to)
+        return to
+
+    module = _module(monkeypatch, "auto_async_tools", send=send)
+    config = load_config_from_string(
+        """
+action_ledger: {storage: memory, tools: [send_email]}
+tools:
+  send_email:
+    callable: auto_async_tools:send
+"""
+    )
+
+    instrument_configured_callables(config)
+
+    assert inspect.iscoroutinefunction(module.send)
+
+    async def run() -> None:
+        assert await module.send(to="a@example.com", request_id="same") == "a@example.com"
+        assert await module.send(to="a@example.com", request_id="same") == "a@example.com"
+
+    asyncio.run(run())
+    assert calls == ["a@example.com"]
+
+
+def test_instruments_task(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def run_invoice(invoice_id: str) -> dict[str, str]:
+        calls.append(invoice_id)
+        return {"invoice_id": invoice_id}
+
+    module = _module(monkeypatch, "auto_tasks", run_invoice=run_invoice)
+    config = load_config_from_string(
+        """
+task_ledger: {storage: memory, tasks: [process_invoice]}
+tasks:
+  process_invoice:
+    callable: auto_tasks:run_invoice
+    id_from: [invoice_id]
+"""
+    )
+
+    instrument_configured_callables(config)
+
+    assert module.run_invoice(invoice_id="inv-1") == {"invoice_id": "inv-1"}
+    assert module.run_invoice(invoice_id="inv-1") == {"invoice_id": "inv-1"}
+    assert calls == ["inv-1"]
+
+
+def test_explicit_config_apply_is_not_wrapped_twice(monkeypatch) -> None:
+    calls: list[float] = []
+
+    def charge(amount: float) -> float:
+        calls.append(amount)
+        return amount
+
+    config = load_config_from_string(
+        """
+action_ledger: {storage: memory, tools: [send_payment]}
+tools:
+  send_payment:
+    callable: already_wrapped_tools:charge
+"""
+    )
+    wrapped = config.apply_tool("send_payment", charge)
+    module = _module(monkeypatch, "already_wrapped_tools", charge=wrapped)
+
+    instrument_configured_callables(config)
+
+    assert module.charge is wrapped
+    module.charge(amount=1.0, request_id="same")
+    module.charge(amount=1.0, request_id="same")
+    assert calls == [1.0]
+
+
+def test_partial_manual_wrapper_fails_closed(monkeypatch) -> None:
+    @ledger_sync()
+    def charge(amount: float) -> float:
+        return amount
+
+    _module(monkeypatch, "partial_tools", charge=charge)
+    config = load_config_from_string(
+        """
+action_ledger: {storage: memory, tools: [send_payment]}
+tools:
+  send_payment:
+    callable: partial_tools:charge
+"""
+    )
+
+    with pytest.raises(ConfigError, match="partially Mycelium-wrapped"):
+        instrument_configured_callables(config)
+
+
+def test_missing_and_non_callable_targets_fail_closed(monkeypatch) -> None:
+    module = ModuleType("invalid_tools")
+    module.not_callable = 42
+    monkeypatch.setitem(sys.modules, "invalid_tools", module)
+
+    missing = load_config_from_string(
+        """
+action_ledger: {storage: memory, tools: [missing]}
+tools:
+  missing:
+    callable: invalid_tools:missing
+"""
+    )
+    with pytest.raises(ConfigError, match="does not exist"):
+        instrument_configured_callables(missing)
+
+    invalid = load_config_from_string(
+        """
+action_ledger: {storage: memory, tools: [invalid]}
+tools:
+  invalid:
+    callable: invalid_tools:not_callable
+"""
+    )
+    with pytest.raises(ConfigError, match="is not a function"):
+        instrument_configured_callables(invalid)

--- a/sdk/tests/test_cli.py
+++ b/sdk/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from mycelium import load_config
@@ -29,6 +30,7 @@ def test_init_writes_quickstart_template_by_default(tmp_path: Path) -> None:
     assert "agent id" in config.transition.agent_id
 
     assert config.tools["subagent_task"].side_effect_class == SideEffectClass.NON_IDEMPOTENT_MUTATE
+    assert config.tools["subagent_task"].callable_path == "your_package.tools:subagent_task"
 
 
 def test_init_writes_full_template(tmp_path: Path) -> None:
@@ -94,3 +96,39 @@ def test_init_force_overwrite(tmp_path: Path) -> None:
     out.write_text("existing", encoding="utf-8")
     assert main(["init", "-o", str(out), "--force"]) == 0
     assert "action_ledger:" in out.read_text(encoding="utf-8")
+
+
+def test_run_rejects_missing_command_and_unsafe_python_flags(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    config = tmp_path / "mycelium.yaml"
+    config.write_text(
+        """
+action_ledger: {storage: memory, tools: [print_once]}
+tools:
+  print_once:
+    callable: builtins:print
+""",
+        encoding="utf-8",
+    )
+
+    assert main(["run", "--config", str(config), "--"]) == 2
+    assert "missing command" in capsys.readouterr().err
+
+    assert (
+        main(
+            [
+                "run",
+                "--config",
+                str(config),
+                "--",
+                sys.executable,
+                "-S",
+                "-c",
+                "pass",
+            ]
+        )
+        == 2
+    )
+    assert "disable safe Mycelium startup instrumentation" in capsys.readouterr().err

--- a/sdk/tests/test_cli_run.py
+++ b/sdk/tests/test_cli_run.py
@@ -1,0 +1,295 @@
+"""Black-box tests for ``mycelium run``."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def _run(
+    tmp_path: Path,
+    config: Path,
+    module: str,
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(tmp_path)
+        if not existing_pythonpath
+        else os.pathsep.join((str(tmp_path), existing_pythonpath))
+    )
+    env.update(extra_env or {})
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mycelium",
+            "run",
+            "--config",
+            str(config),
+            "--",
+            sys.executable,
+            "-m",
+            module,
+            *args,
+        ],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_run_instruments_sync_tool_and_task_across_processes(
+    tmp_path: Path,
+) -> None:
+    effect_file = tmp_path / "effects.txt"
+    tool_ledger = tmp_path / "tool-ledger.json"
+    task_ledger = tmp_path / "task-ledger.json"
+    config = tmp_path / "mycelium.yaml"
+
+    _write(
+        tmp_path / "runtime_targets.py",
+        """
+import os
+from pathlib import Path
+
+effect_file = Path(os.environ["EFFECT_FILE"])
+
+def charge(amount: float) -> dict:
+    with effect_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"charge:{amount}\\n")
+    return {"amount": amount}
+
+def invoice(invoice_id: str) -> dict:
+    with effect_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"invoice:{invoice_id}\\n")
+    return {"invoice_id": invoice_id}
+""",
+    )
+    _write(
+        tmp_path / "runtime_app.py",
+        """
+import os
+import sys
+from pathlib import Path
+from runtime_targets import charge, invoice
+
+print(f"argv={sys.argv[1:]}")
+print(f"cwd={Path.cwd()}")
+print(f"marker={os.environ.get('MYCELIUM_AUTO_INSTRUMENT')}")
+print(charge(amount=5.0, request_id="payment-1"))
+print(charge(amount=5.0, request_id="payment-1"))
+print(invoice(invoice_id="inv-1"))
+print(invoice(invoice_id="inv-1"))
+""",
+    )
+    _write(
+        config,
+        f"""
+action_ledger:
+  storage: file
+  path: {tool_ledger}
+  tools: [send_payment]
+task_ledger:
+  storage: file
+  path: {task_ledger}
+  tasks: [process_invoice]
+tools:
+  send_payment:
+    callable: runtime_targets:charge
+tasks:
+  process_invoice:
+    callable: runtime_targets:invoice
+    id_from: [invoice_id]
+""",
+    )
+
+    env = {"EFFECT_FILE": str(effect_file)}
+    first = _run(tmp_path, config, "runtime_app", "hello world", extra_env=env)
+    second = _run(tmp_path, config, "runtime_app", "hello world", extra_env=env)
+
+    assert first.returncode == second.returncode == 0, first.stderr + second.stderr
+    assert "argv=['hello world']" in first.stdout
+    assert f"cwd={tmp_path}" in first.stdout
+    assert "marker=None" in first.stdout
+    assert effect_file.read_text(encoding="utf-8").splitlines() == [
+        "charge:5.0",
+        "invoice:inv-1",
+    ]
+
+
+def test_run_instruments_async_tool(tmp_path: Path) -> None:
+    effect_file = tmp_path / "async-effects.txt"
+    config = tmp_path / "mycelium.yaml"
+    _write(
+        tmp_path / "async_targets.py",
+        """
+import os
+from pathlib import Path
+
+async def send(to: str) -> str:
+    with Path(os.environ["EFFECT_FILE"]).open("a", encoding="utf-8") as handle:
+        handle.write(to + "\\n")
+    return to
+""",
+    )
+    _write(
+        tmp_path / "async_app.py",
+        """
+import asyncio
+from async_targets import send
+
+async def main():
+    print(await send(to="a@example.com", request_id="email-1"))
+    print(await send(to="a@example.com", request_id="email-1"))
+
+asyncio.run(main())
+""",
+    )
+    _write(
+        config,
+        f"""
+action_ledger:
+  storage: file
+  path: {tmp_path / "async-ledger.json"}
+  tools: [send_email]
+tools:
+  send_email:
+    callable: async_targets:send
+""",
+    )
+
+    result = _run(
+        tmp_path,
+        config,
+        "async_app",
+        extra_env={"EFFECT_FILE": str(effect_file)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert effect_file.read_text(encoding="utf-8").splitlines() == [
+        "a@example.com"
+    ]
+
+
+def test_run_preserves_child_exit_code(tmp_path: Path) -> None:
+    config = tmp_path / "mycelium.yaml"
+    _write(tmp_path / "exit_targets.py", "def tool(): return 'ok'\n")
+    _write(tmp_path / "exit_app.py", "raise SystemExit(7)\n")
+    _write(
+        config,
+        """
+action_ledger: {storage: memory, tools: [tool]}
+tools:
+  tool:
+    callable: exit_targets:tool
+""",
+    )
+
+    result = _run(tmp_path, config, "exit_app")
+    assert result.returncode == 7
+
+
+def test_run_fails_closed_for_missing_target(tmp_path: Path) -> None:
+    config = tmp_path / "mycelium.yaml"
+    _write(tmp_path / "missing_targets.py", "value = 1\n")
+    _write(tmp_path / "should_not_run.py", "print('APP_RAN')\n")
+    _write(
+        config,
+        """
+action_ledger: {storage: memory, tools: [missing]}
+tools:
+  missing:
+    callable: missing_targets:not_here
+""",
+    )
+
+    result = _run(tmp_path, config, "should_not_run")
+
+    assert result.returncode == 78
+    assert "auto-instrumentation failed" in result.stderr
+    assert "does not exist" in result.stderr
+    assert "APP_RAN" not in result.stdout
+
+
+def test_run_propagates_langgraph_tool_runtime_ids(tmp_path: Path) -> None:
+    effect_file = tmp_path / "langgraph-effects.txt"
+    config = tmp_path / "mycelium.yaml"
+    _write(
+        tmp_path / "langgraph_targets.py",
+        """
+import os
+from pathlib import Path
+
+def charge(amount: float) -> dict:
+    \"\"\"Charge a payment once.\"\"\"
+    with Path(os.environ["EFFECT_FILE"]).open("a", encoding="utf-8") as handle:
+        handle.write(str(amount) + "\\n")
+    return {"amount": amount}
+""",
+    )
+    _write(
+        tmp_path / "langgraph_app.py",
+        """
+from langchain_core.messages import AIMessage
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.prebuilt import ToolNode
+from langgraph_targets import charge
+
+builder = StateGraph(MessagesState)
+builder.add_node("tools", ToolNode([charge]))
+builder.add_edge(START, "tools")
+builder.add_edge("tools", END)
+graph = builder.compile()
+
+for _ in range(2):
+    message = AIMessage(
+        content="",
+        tool_calls=[{
+            "name": "send_payment",
+            "args": {"amount": 9.0},
+            "id": "call-1",
+            "type": "tool_call",
+        }],
+    )
+    graph.invoke(
+        {"messages": [message]},
+        {"configurable": {"thread_id": "thread-1"}, "run_id": "run-1"},
+    )
+""",
+    )
+    _write(
+        config,
+        f"""
+integrations: {{langgraph: {{enabled: true}}}}
+transition: {{agent_id: test, policy_version: "1"}}
+action_ledger:
+  storage: file
+  path: {tmp_path / "langgraph-ledger.json"}
+  tools: [send_payment]
+tools:
+  send_payment:
+    callable: langgraph_targets:charge
+    side_effect_class: non_idempotent_mutate
+""",
+    )
+
+    result = _run(
+        tmp_path,
+        config,
+        "langgraph_app",
+        extra_env={"EFFECT_FILE": str(effect_file)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert effect_file.read_text(encoding="utf-8").splitlines() == ["9.0"]

--- a/sdk/tests/test_config.py
+++ b/sdk/tests/test_config.py
@@ -10,6 +10,7 @@ import pytest
 from mycelium import (
     ConfigError,
     ToolBoundaryError,
+    ledger_sync,
     load_config,
     load_config_from_string,
 )
@@ -245,6 +246,113 @@ def test_empty_config_is_valid() -> None:
     assert config.runner_settings == {}
     assert config.build_history_guard() is None
     assert config.build_message_validator() is None
+
+
+def test_callable_paths_parse_for_tools_and_tasks() -> None:
+    config = load_config_from_string(
+        """
+action_ledger: {storage: memory, tools: [send_payment]}
+task_ledger: {storage: memory, tasks: [process_invoice]}
+tools:
+  send_payment:
+    callable: app.tools.payments:charge
+tasks:
+  process_invoice:
+    callable: app.tasks.invoices:run
+"""
+    )
+
+    assert (
+        config.tools["send_payment"].callable_path
+        == "app.tools.payments:charge"
+    )
+    assert (
+        config.tasks["process_invoice"].callable_path
+        == "app.tasks.invoices:run"
+    )
+    targets = config.auto_instrumentation_targets()
+    assert [(target.kind, target.name) for target in targets] == [
+        ("tool", "send_payment"),
+        ("task", "process_invoice"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "callable_path",
+    ["send_payment", "app.tools", "app-tools:send", "app.tools:send.call"],
+)
+def test_invalid_callable_path_is_rejected(callable_path: str) -> None:
+    with pytest.raises(ConfigError, match="package.module:function"):
+        load_config_from_string(
+            f"""
+tools:
+  send_payment:
+    callable: {callable_path}
+"""
+        )
+
+
+def test_duplicate_callable_target_is_rejected() -> None:
+    with pytest.raises(ConfigError, match="configured more than once"):
+        load_config_from_string(
+            """
+tools:
+  send_payment:
+    callable: app.tools:send
+    ledger: true
+tasks:
+  send_task:
+    callable: app.tools:send
+    ledger: true
+"""
+        )
+
+
+def test_auto_instrumentation_requires_paths_for_all_configured_entries() -> None:
+    config = load_config_from_string(
+        """
+tools:
+  send_payment:
+    ledger: true
+"""
+    )
+    with pytest.raises(ConfigError, match="requires callable paths"):
+        config.auto_instrumentation_targets()
+
+
+def test_apply_tool_uses_explicit_logical_name_and_is_idempotent() -> None:
+    config = load_config_from_string(
+        """
+action_ledger: {storage: memory, tools: [send_payment]}
+tools:
+  send_payment: {}
+"""
+    )
+
+    def charge(amount: float) -> float:
+        return amount
+
+    wrapped = config.apply_tool("send_payment", charge)
+    assert wrapped.__name__ == "send_payment"
+    assert config.apply_tool("send_payment", wrapped) is wrapped
+    assert wrapped(amount=2.0, request_id="call_1") == 2.0
+
+
+def test_apply_tool_rejects_partial_manual_wrapping() -> None:
+    config = load_config_from_string(
+        """
+action_ledger: {storage: memory, tools: [send_payment]}
+tools:
+  send_payment: {}
+"""
+    )
+
+    @ledger_sync()
+    def charge(amount: float) -> float:
+        return amount
+
+    with pytest.raises(ConfigError, match="partially Mycelium-wrapped"):
+        config.apply_tool("send_payment", charge)
 
 
 def test_load_config_from_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add validated `callable: module:function` targets and fail-closed wrapper markers
- add `mycelium run --config ... -- python ...` with native process replacement and startup instrumentation
- document both command and explicit modes, with subprocess and real LangGraph coverage

## Test plan
- [x] `uv run --extra dev ruff check mycelium tests`
- [x] `uv run --extra dev pytest -q` (232 passed, 2 skipped)
- [x] build wheel and verify bootstrap files are packaged