### PR TITLE
feat: REPAIR gate for incomplete durable transitions (v1.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.13.0 (2026-07-22)
+
+Minor: first-class ``REPAIR`` resolution gate for incomplete durable transition records. Heal missing context before execute; do not spawn a second side effect.
+
+### REPAIR gate
+
+- Add ``TransitionGate.REPAIR`` — returned when a durable record is missing ``idempotency_key``, has an invalid/missing ``side_effect_boundary``, has an invalid/missing ``terminal_outcome``, or healable status/terminal drift.
+- Add ``transition_needs_repair()`` / ``repair_transition_fields()`` and ``ActionLedger.repair_transition()`` — fill safe defaults, then re-resolve (claim loops continue; peers with a held lease still ``POLL``).
+- Owner-side ``renew_lease()`` remains the renew half of the taxonomy (extend a live lease so peers keep polling); it does not invent missing terminal state.
+- Export ``TransitionGate``, ``transition_needs_repair``, and ``repair_transition_fields`` from the package root.
+
+### Docs
+
+- Document ``REPAIR`` in the resolution-gates table (SDK README + handbook).
+
 ## 1.12.0 (2026-07-21)
 
 Minor: add zero-touch, command-based YAML auto-instrumentation while preserving explicit decorator and module instrumentation APIs.

--- a/docs/index.html
+++ b/docs/index.html
@@ -598,6 +598,7 @@ ALLOW         fresh claim / policy allows retry    tool runs
 RETURN        COMPLETED                          return stored result
 POLL          IN_FLIGHT (valid lease)            wait for other worker
 RECLAIM       read EXPIRED / FAILED_*            take over stale lease
+REPAIR        incomplete durable key/boundary/terminal  heal, re-resolve (v1.13.0)
 SOFT_BLOCK    read UNKNOWN / BLOCKED only        retry by default (v1.9.0)
 HARD_BLOCK    ambiguous mutating transition      stop; reconcile if ref present</pre>
       <p>
@@ -607,6 +608,11 @@ HARD_BLOCK    ambiguous mutating transition      stop; reconcile if ref present<
         reclaim / hard-block by class) before allowing another attempt. Call
         <code>renew_lease()</code> inside long-running ledgered tools so peers keep
         polling instead of reclaiming.
+      </p>
+      <p>
+        <strong>REPAIR (v1.13.0):</strong> when the durable record is incomplete but
+        healable, claim loops call <code>repair_transition()</code> then re-resolve —
+        never a second side effect. A held lease is still <code>POLL</code> for peers.
       </p>
       <p>
         <strong>Read</strong> (<code>side_effect_class: read</code>): poll, reclaim,

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -45,7 +45,7 @@ supported for explicit code-level control.
 |---------|-------------------|
 | **Stale or broken context** | TTL cache, message repair, history limits; agent sees fresh, valid data |
 | **Bad or unauthorized tool calls** | Validate inputs/outputs, allowlists, scoped paths; block before execution |
-| **Duplicate side effects on retry** | Transition envelope (v1.3+): `side_effect_class`, terminal outcomes, resolution **gates** (`POLL` / `SOFT_BLOCK` / `HARD_BLOCK`), `external_operation_ref` + `Reconciler`, ledgers, signed receipts |
+| **Duplicate side effects on retry** | Transition envelope (v1.3+): `side_effect_class`, terminal outcomes, resolution **gates** (`POLL` / `REPAIR` / `SOFT_BLOCK` / `HARD_BLOCK`), `external_operation_ref` + `Reconciler`, ledgers, signed receipts |
 
 Framework-agnostic. Raw message lists and plain Python functions (LangGraph, CrewAI, OpenAI tool loops, etc.).
 
@@ -312,16 +312,17 @@ Each duplicate dispatch is classified to a gate. Read-only and side-effecting to
 | `RETURN` | `COMPLETED` | return stored result — no re-execution |
 | `POLL` | `IN_FLIGHT` with valid lease (`LeaseValidity.HELD`) | wait for the other worker |
 | `RECLAIM` | read-only `EXPIRED` / `FAILED_*` | take over stale lease and run |
+| `REPAIR` | incomplete durable key / boundary / terminal (healable) | fix record, re-resolve — **no** second side effect |
 | `SOFT_BLOCK` | read-only `UNKNOWN` / `BLOCKED` only | **retry by default** (safe — reads don't spend); opt into deferral with `defer_read_only_unknown=True` → `LedgerSoftBlockError` |
 | `HARD_BLOCK` | ambiguous mutating transition | stop; run `Reconciler` when `external_operation_ref` is present, else fail-closed |
 
 **Lease validity (v1.10.0):** `lease_until` is resolution metadata — **not** part of `transition_key` (so renewals do not fork identity). Before reclaim/retry, resolution classifies the window via `LeaseValidity` (`HELD` → poll, `EXPIRED` → reclaim or hard-block by class, `UNBOUNDED` → no TTL). During long work call `renew_lease()` inside the ledgered tool to keep peers on `POLL`.
 
+**`REPAIR` (v1.13.0):** when the durable record is incomplete but healable (missing `idempotency_key`, invalid/missing `side_effect_boundary` or `terminal_outcome`, or status/terminal drift), claim loops call `repair_transition()` then re-resolve. A held in-flight lease is still `POLL` for peers; the owner extends via `renew_lease()` (not a second execute).
+
 **Read-only** (`side_effect_class: read`): poll, reclaim, retry failed-before-effect, soft-block on ambiguous `UNKNOWN`/`BLOCKED`.
 
 **Mutating** (payment, email, subagent, irreversible, …): return completed, poll in-flight, hard-block ambiguity. For **`EXPIRED + not_crossed`**, the gate is `HARD_BLOCK` until a reconciler proves the effect never ran — see [Stale lease + reconcile](#stale-lease--reconcile-exired--not_crossed).
-
-`REPAIR` (fix missing durable context before execute) is planned; not shipped yet.
 
 ### Transition envelope fields
 

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -84,8 +84,13 @@ from mycelium.transition import (
     execution_scope,
     resolve_lease_validity,
 )
+from mycelium.transition_resolution import (
+    TransitionGate,
+    repair_transition_fields,
+    transition_needs_repair,
+)
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"
 
 __all__ = [
     "ActionLedger",
@@ -138,12 +143,15 @@ __all__ = [
     "RetryPermission",
     "TerminalOutcome",
     "LeaseValidity",
+    "TransitionGate",
     "ToolTransitionBinding",
     "TransitionScope",
     "derive_transition_key",
     "derive_transition_key_for_call",
     "execution_scope",
     "resolve_lease_validity",
+    "repair_transition_fields",
+    "transition_needs_repair",
     "load_config",
     "load_config_from_string",
     "protect",

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -40,9 +40,11 @@ from mycelium.transition import (
 from mycelium.transition_resolution import (
     TransitionGate,
     hard_block_message,
+    repair_transition_fields,
     resolve_read_only_gate,
     resolve_side_effect_gate,
     soft_block_message,
+    transition_needs_repair,
 )
 
 if TYPE_CHECKING:
@@ -167,9 +169,11 @@ def renew_lease(*, lease_ttl: float | None = None) -> None:
     """Extend the active transition's execution lease.
 
     Call during long-running side-effecting work so a still-alive worker does
-    not look ``EXPIRED`` to a redispatched peer. Lease is resolution metadata
-    (not part of ``transition_key``); renewing keeps the same transition
-    ``IN_FLIGHT`` / ``POLL`` instead of opening a reclaim path.
+    not look ``EXPIRED`` to a redispatched peer. This is the owner-side renew
+    half of ``REPAIR`` taxonomy (peers still ``POLL`` on a held lease; incomplete
+    durable fields are healed via ``ActionLedger.repair_transition``). Lease is
+    resolution metadata (not part of ``transition_key``); renewing keeps the
+    same transition ``IN_FLIGHT`` / ``POLL`` instead of opening a reclaim path.
 
     Outside a ledgered tool this is a no-op with a warning.
     """
@@ -223,6 +227,11 @@ class LedgerEntry:
     side_effect_boundary: str = SideEffectBoundary.NOT_CROSSED.value
     external_operation_ref: str | None = None
     provider_idempotency_key: str | None = None
+
+    def __post_init__(self) -> None:
+        # Match from_dict / claim: durable key defaults to request_id.
+        if self.idempotency_key is None:
+            object.__setattr__(self, "idempotency_key", self.request_id)
 
     def resolved_terminal_outcome(self, *, now: float | None = None) -> TerminalOutcome:
         return resolve_terminal_outcome(
@@ -522,12 +531,15 @@ class ActionLedger:
 
         while True:
             existing = self.get(request_id)
-            if existing is not None and (
-                resolve_read_only_gate(existing) == TransitionGate.SOFT_BLOCK
-            ):
-                return self._resolve_read_only_soft_block(
-                    request_id, tool, args, kwargs, existing
-                )
+            if existing is not None:
+                gate = resolve_read_only_gate(existing)
+                if gate == TransitionGate.REPAIR:
+                    self.repair_transition(request_id)
+                    continue
+                if gate == TransitionGate.SOFT_BLOCK:
+                    return self._resolve_read_only_soft_block(
+                        request_id, tool, args, kwargs, existing
+                    )
 
             entry = self._new_inflight_entry(request_id, tool, args, kwargs)
             outcome, existing = self._storage.try_claim_inflight(entry, lease_ttl=ttl)
@@ -621,12 +633,15 @@ class ActionLedger:
 
         while True:
             existing = self.get(request_id)
-            if existing is not None and (
-                resolve_read_only_gate(existing) == TransitionGate.SOFT_BLOCK
-            ):
-                return self._resolve_read_only_soft_block(
-                    request_id, tool, args, kwargs, existing
-                )
+            if existing is not None:
+                gate = resolve_read_only_gate(existing)
+                if gate == TransitionGate.REPAIR:
+                    self.repair_transition(request_id)
+                    continue
+                if gate == TransitionGate.SOFT_BLOCK:
+                    return self._resolve_read_only_soft_block(
+                        request_id, tool, args, kwargs, existing
+                    )
 
             entry = self._new_inflight_entry(request_id, tool, args, kwargs)
             outcome, existing = self._storage.try_claim_inflight(entry, lease_ttl=ttl)
@@ -839,6 +854,9 @@ class ActionLedger:
                     binding,
                     incoming_provider_idempotency_key=incoming_key,
                 )
+                if gate == TransitionGate.REPAIR:
+                    self.repair_transition(request_id)
+                    continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
@@ -866,6 +884,9 @@ class ActionLedger:
                     binding,
                     incoming_provider_idempotency_key=incoming_key,
                 )
+                if gate == TransitionGate.REPAIR:
+                    self.repair_transition(request_id)
+                    continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
@@ -964,6 +985,9 @@ class ActionLedger:
                     binding,
                     incoming_provider_idempotency_key=incoming_key,
                 )
+                if gate == TransitionGate.REPAIR:
+                    self.repair_transition(request_id)
+                    continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
@@ -991,6 +1015,9 @@ class ActionLedger:
                     binding,
                     incoming_provider_idempotency_key=incoming_key,
                 )
+                if gate == TransitionGate.REPAIR:
+                    self.repair_transition(request_id)
+                    continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
@@ -1139,10 +1166,13 @@ class ActionLedger:
     ) -> LedgerEntry:
         """Extend ``lease_until`` for an in-flight transition.
 
-        Only applies while the stored terminal outcome is still ``IN_FLIGHT``
-        (before lease expiry is applied). Renewing after the lease has already
-        expired raises :class:`LedgerError` — reclaim/reconcile must run instead
-        of silently re-asserting ownership.
+        Owner-side heartbeat for long work: keeps peers on ``POLL`` instead of
+        opening reclaim. This is the renew half of the ``REPAIR`` taxonomy
+        (heal incomplete durable fields via :meth:`repair_transition`; extend a
+        still-held lease here). Only applies while the stored terminal outcome
+        is still ``IN_FLIGHT`` (before lease expiry is applied). Renewing after
+        the lease has already expired raises :class:`LedgerError` — reclaim /
+        reconcile must run instead of silently re-asserting ownership.
 
         Backs :func:`renew_lease`.
         """
@@ -1170,6 +1200,33 @@ class ActionLedger:
         if ttl <= 0:
             raise LedgerError("lease_ttl must be positive to renew")
         entry = replace(existing, lease_until=now + ttl)
+        self._storage.set(entry)
+        return entry
+
+    def repair_transition(self, request_id: str) -> LedgerEntry:
+        """Heal incomplete durable transition fields before re-resolving.
+
+        Fills missing ``idempotency_key`` / ``side_effect_boundary`` / terminal
+        alignment. Does not renew a peer lease and does not execute the tool.
+        Claim loops call this when the gate is ``REPAIR``, then re-resolve.
+        """
+        existing = self._storage.get(request_id)
+        if existing is None:
+            raise LedgerError(f"Cannot repair unknown request {request_id!r}")
+        updates = repair_transition_fields(existing)
+        if not updates:
+            if transition_needs_repair(existing):
+                raise LedgerError(
+                    f"Cannot repair request {request_id!r}: incomplete context "
+                    "with no safe field updates"
+                )
+            return existing
+        entry = replace(existing, **updates)
+        if transition_needs_repair(entry):
+            raise LedgerError(
+                f"Cannot repair request {request_id!r}: still incomplete after "
+                "safe field updates"
+            )
         self._storage.set(entry)
         return entry
 

--- a/sdk/mycelium/transition_resolution.py
+++ b/sdk/mycelium/transition_resolution.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Any, Protocol
 
 from mycelium._compat import StrEnum
 from mycelium.transition import (
@@ -13,6 +13,9 @@ from mycelium.transition import (
     TerminalOutcome,
     ToolTransitionBinding,
     blocks_on_ambiguous_replay,
+    legacy_status_from_terminal,
+    parse_terminal_outcome,
+    terminal_from_legacy_status,
 )
 
 
@@ -30,8 +33,105 @@ class TransitionGate(StrEnum):
     RETURN = "RETURN"
     POLL = "POLL"
     RECLAIM = "RECLAIM"
+    REPAIR = "REPAIR"
     SOFT_BLOCK = "SOFT_BLOCK"
     HARD_BLOCK = "HARD_BLOCK"
+
+
+def _raw_terminal_outcome(existing: _ExistingTransition) -> Any:
+    return getattr(existing, "terminal_outcome", None)
+
+
+def _raw_status(existing: _ExistingTransition) -> str | None:
+    status = getattr(existing, "status", None)
+    return str(status) if status is not None else None
+
+
+def _parse_stored_terminal(existing: _ExistingTransition) -> TerminalOutcome | None:
+    raw = _raw_terminal_outcome(existing)
+    if raw is None or raw == "":
+        return None
+    try:
+        return parse_terminal_outcome(raw)
+    except ValueError:
+        return None
+
+
+def _boundary_is_valid(existing: _ExistingTransition) -> bool:
+    raw = getattr(existing, "side_effect_boundary", None)
+    if raw is None or raw == "":
+        return False
+    try:
+        SideEffectBoundary(str(raw))
+    except ValueError:
+        return False
+    return True
+
+
+def transition_needs_repair(existing: _ExistingTransition) -> bool:
+    """True when the durable record is incomplete but safely healable.
+
+    Detects missing ``idempotency_key``, missing/invalid ``side_effect_boundary``,
+    missing/invalid ``terminal_outcome``, or healable status/terminal drift.
+    Does **not** treat a held in-flight lease as repair — peers ``POLL``; the
+    owner extends via ``renew_lease()``.
+    """
+    key = getattr(existing, "idempotency_key", None)
+    if key is None or key == "":
+        return True
+    if not _boundary_is_valid(existing):
+        return True
+
+    stored = _parse_stored_terminal(existing)
+    if stored is None:
+        return True
+
+    status = _raw_status(existing)
+    if status == "completed" and stored != TerminalOutcome.COMPLETED:
+        return True
+    if status == "failed" and stored == TerminalOutcome.IN_FLIGHT:
+        return True
+    return False
+
+
+def repair_transition_fields(
+    existing: _ExistingTransition,
+    *,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Return field updates that heal an incomplete durable transition record.
+
+    Safe defaults only — never invents a completed result, never renews a peer
+    lease, and never weakens a stronger recorded side-effect boundary.
+    """
+    updates: dict[str, Any] = {}
+
+    key = getattr(existing, "idempotency_key", None)
+    request_id = getattr(existing, "request_id", None)
+    if (key is None or key == "") and request_id is not None:
+        updates["idempotency_key"] = str(request_id)
+
+    if not _boundary_is_valid(existing):
+        updates["side_effect_boundary"] = SideEffectBoundary.NOT_CROSSED.value
+
+    stored = _parse_stored_terminal(existing)
+    status = _raw_status(existing) or "in-flight"
+    lease_until = getattr(existing, "lease_until", None)
+
+    if stored is None:
+        healed = terminal_from_legacy_status(status, lease_until=lease_until, now=now)
+        updates["terminal_outcome"] = healed.value
+        updates["status"] = legacy_status_from_terminal(healed)
+    elif status == "completed" and stored != TerminalOutcome.COMPLETED:
+        updates["terminal_outcome"] = TerminalOutcome.COMPLETED.value
+        updates["status"] = legacy_status_from_terminal(TerminalOutcome.COMPLETED)
+    elif status == "failed" and stored == TerminalOutcome.IN_FLIGHT:
+        updates["terminal_outcome"] = TerminalOutcome.FAILED_BEFORE_EFFECT.value
+        updates["status"] = legacy_status_from_terminal(
+            TerminalOutcome.FAILED_BEFORE_EFFECT
+        )
+
+    return updates
 
 
 def resolve_read_only_gate(existing: _ExistingTransition) -> TransitionGate:
@@ -40,6 +140,7 @@ def resolve_read_only_gate(existing: _ExistingTransition) -> TransitionGate:
     Read-only tools produce no external effect, so re-running is always safe.
     The gate is therefore lighter than the side-effecting resolver:
 
+    - Incomplete durable record → ``REPAIR`` (heal, then re-resolve)
     - ``COMPLETED`` → ``RETURN`` the stored result
     - ``IN_FLIGHT`` → ``POLL`` while another worker holds a valid lease
     - ``EXPIRED`` / ``FAILED_BEFORE_EFFECT`` / ``FAILED_AFTER_EFFECT`` →
@@ -48,6 +149,8 @@ def resolve_read_only_gate(existing: _ExistingTransition) -> TransitionGate:
       must not hard-block a reversible read, so the caller defers or retries
       (cost-dependent) instead of parking it for a human.
     """
+    if transition_needs_repair(existing):
+        return TransitionGate.REPAIR
     outcome = existing.resolved_terminal_outcome()
     if outcome == TerminalOutcome.COMPLETED:
         return TransitionGate.RETURN
@@ -60,14 +163,10 @@ def resolve_read_only_gate(existing: _ExistingTransition) -> TransitionGate:
 
 def _entry_boundary(existing: _ExistingTransition) -> SideEffectBoundary:
     raw = getattr(existing, "side_effect_boundary", SideEffectBoundary.NOT_CROSSED.value)
-    return SideEffectBoundary(str(raw))
-
-
-def _retry_allows_failed_before(retry: RetryPermission) -> bool:
-    return retry in (
-        RetryPermission.SAFE_RETRY,
-        RetryPermission.RETRY_ONLY_WITH_SAME_PROVIDER_IDEMPOTENCY_KEY,
-    )
+    try:
+        return SideEffectBoundary(str(raw))
+    except ValueError:
+        return SideEffectBoundary.NOT_CROSSED
 
 
 def _same_provider_idempotency_key(
@@ -89,7 +188,11 @@ def resolve_side_effect_gate(
 ) -> TransitionGate:
     """Decide how to handle an existing transition for a side-effecting tool.
 
-    Lease validity is consulted first via ``resolved_terminal_outcome()``:
+    Incomplete durable context returns ``REPAIR`` first — heal missing key /
+    boundary / terminal fields, then re-resolve. Do not execute a second side
+    effect while the record is incomplete.
+
+    Lease validity is consulted via ``resolved_terminal_outcome()``:
     a still-``HELD`` lease stays ``IN_FLIGHT`` → ``POLL``; an ``EXPIRED`` lease
     becomes ``EXPIRED`` and then reclaim / hard-block by class and boundary.
     ``lease_until`` is not part of the transition key — renew it while work
@@ -101,6 +204,9 @@ def resolve_side_effect_gate(
     ``retry_only_with_same_provider_idempotency_key`` permission stays
     cooperative (backward compatible).
     """
+    if transition_needs_repair(existing):
+        return TransitionGate.REPAIR
+
     outcome = existing.resolved_terminal_outcome()
     boundary = _entry_boundary(existing)
     retry = binding.retry_permission
@@ -204,10 +310,25 @@ def soft_block_message(
     )
 
 
+def repair_message(
+    existing: _ExistingTransition,
+    *,
+    tool: str,
+    request_id: str,
+) -> str:
+    return (
+        f"Tool {tool!r} request {request_id!r} has incomplete durable transition "
+        "context; repair before execute"
+    )
+
+
 __all__ = [
     "TransitionGate",
     "hard_block_message",
+    "repair_message",
+    "repair_transition_fields",
     "resolve_read_only_gate",
     "resolve_side_effect_gate",
     "soft_block_message",
+    "transition_needs_repair",
 ]

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.12.0"
+version = "1.13.0"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",

--- a/sdk/tests/test_repair_gate.py
+++ b/sdk/tests/test_repair_gate.py
@@ -1,0 +1,204 @@
+"""REPAIR gate: heal incomplete durable transition context before execute."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import replace
+
+from mycelium import (
+    ActionLedger,
+    InMemoryLedgerStorage,
+    LedgerEntry,
+    SideEffectBoundary,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    TransitionGate,
+    TransitionScope,
+    execution_scope,
+    ledger_sync,
+    repair_transition_fields,
+    transition_needs_repair,
+)
+from mycelium.transition_resolution import (
+    resolve_read_only_gate,
+    resolve_side_effect_gate,
+)
+
+
+def _payment_binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="a",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def _incomplete_inflight(*, request_id: str = "pay-1") -> LedgerEntry:
+    return LedgerEntry(
+        request_id=request_id,
+        tool="send_payment",
+        args=[],
+        kwargs={"amount": 10},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        lease_until=time.time() + 3600,
+        idempotency_key="",
+        side_effect_boundary="",
+    )
+
+
+def test_transition_needs_repair_detects_missing_key_and_boundary() -> None:
+    entry = _incomplete_inflight()
+    assert transition_needs_repair(entry) is True
+    updates = repair_transition_fields(entry)
+    assert updates["idempotency_key"] == "pay-1"
+    assert updates["side_effect_boundary"] == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_complete_entry_does_not_need_repair() -> None:
+    entry = LedgerEntry(
+        request_id="pay-2",
+        tool="send_payment",
+        args=[],
+        kwargs={},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        lease_until=time.time() + 60,
+        idempotency_key="pay-2",
+        side_effect_boundary=SideEffectBoundary.NOT_CROSSED.value,
+    )
+    assert transition_needs_repair(entry) is False
+    assert resolve_side_effect_gate(entry, _payment_binding()) == TransitionGate.POLL
+
+
+def test_resolve_side_effect_gate_returns_repair_before_poll() -> None:
+    entry = _incomplete_inflight()
+    assert resolve_side_effect_gate(entry, _payment_binding()) == TransitionGate.REPAIR
+
+
+def test_resolve_read_only_gate_returns_repair() -> None:
+    entry = LedgerEntry(
+        request_id="read-1",
+        tool="fetch",
+        args=[],
+        kwargs={},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        lease_until=time.time() + 60,
+        idempotency_key="",
+    )
+    assert resolve_read_only_gate(entry) == TransitionGate.REPAIR
+
+
+def test_status_terminal_drift_needs_repair() -> None:
+    entry = LedgerEntry(
+        request_id="pay-3",
+        tool="send_payment",
+        args=[],
+        kwargs={},
+        status="completed",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        result={"ok": True},
+        idempotency_key="pay-3",
+        side_effect_boundary=SideEffectBoundary.CROSSED.value,
+        finished_at=time.time(),
+    )
+    assert transition_needs_repair(entry) is True
+    updates = repair_transition_fields(entry)
+    assert updates["terminal_outcome"] == TerminalOutcome.COMPLETED.value
+    healed = replace(entry, **updates)
+    assert transition_needs_repair(healed) is False
+    assert resolve_side_effect_gate(healed, _payment_binding()) == TransitionGate.RETURN
+
+
+def test_invalid_terminal_inferred_from_status() -> None:
+    entry = LedgerEntry(
+        request_id="pay-4",
+        tool="send_payment",
+        args=[],
+        kwargs={},
+        status="failed",
+        terminal_outcome="not-a-real-outcome",
+        idempotency_key="pay-4",
+        side_effect_boundary=SideEffectBoundary.NOT_CROSSED.value,
+        error="boom",
+        finished_at=time.time(),
+    )
+    assert transition_needs_repair(entry) is True
+    updates = repair_transition_fields(entry)
+    assert updates["terminal_outcome"] == TerminalOutcome.FAILED_BEFORE_EFFECT.value
+
+
+def test_ledger_repair_then_poll_on_claim() -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(storage=storage, lease_ttl=3600.0)
+    incomplete = _incomplete_inflight(request_id="pay-5")
+    storage.set(incomplete)
+
+    repaired = ledger.repair_transition("pay-5")
+    assert repaired.idempotency_key == "pay-5"
+    assert repaired.side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+    assert transition_needs_repair(repaired) is False
+    assert resolve_side_effect_gate(repaired, _payment_binding()) == TransitionGate.POLL
+
+
+def test_claim_side_effecting_repairs_then_returns_completed() -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(storage=storage)
+    storage.set(
+        LedgerEntry(
+            request_id="pay-6",
+            tool="send_payment",
+            args=[],
+            kwargs={"amount": 5},
+            status="completed",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+            result={"charged": 5},
+            idempotency_key="",
+            side_effect_boundary=SideEffectBoundary.CROSSED.value,
+            finished_at=time.time(),
+            lease_until=None,
+        )
+    )
+    entry = ledger.claim_side_effecting(
+        "pay-6",
+        "send_payment",
+        (),
+        {"amount": 5},
+        _payment_binding(),
+    )
+    assert entry.result == {"charged": 5}
+    assert entry.terminal_outcome == TerminalOutcome.COMPLETED.value
+    assert entry.idempotency_key == "pay-6"
+
+
+def test_decorator_redispatch_repairs_incomplete_completed() -> None:
+    storage = InMemoryLedgerStorage()
+    binding = _payment_binding()
+    calls: list[float] = []
+
+    @ledger_sync(storage=storage, transition_binding=binding)
+    def send_payment(amount: float) -> dict:
+        calls.append(amount)
+        return {"charged": amount}
+
+    with execution_scope(TransitionScope(thread_id="t", run_id="r", node="n")):
+        first = send_payment(10.0)
+        entries = storage.list_all()
+        assert len(entries) == 1
+        # Corrupt the durable record as if a partial write dropped fields.
+        storage.set(
+            replace(
+                entries[0],
+                idempotency_key="",
+            )
+        )
+        second = send_payment(10.0)
+
+    assert first == {"charged": 10.0}
+    assert second == {"charged": 10.0}
+    assert calls == [10.0]
+    healed = storage.list_all()[0]
+    assert healed.idempotency_key is not None
+    assert healed.side_effect_boundary == SideEffectBoundary.CROSSED.value


### PR DESCRIPTION
## Summary
- Add first-class `TransitionGate.REPAIR` for incomplete durable transition records (missing/empty `idempotency_key`, invalid/missing boundary or terminal, healable status/terminal drift).
- Claim loops call `ActionLedger.repair_transition()` then re-resolve — no second side effect. Held in-flight leases stay `POLL` for peers; `renew_lease()` remains the owner renew path.
- Export `TransitionGate`, `transition_needs_repair`, and `repair_transition_fields`; bump to **v1.13.0** (minor — new resolution behavior).

## Test plan
- [x] `pytest` full suite (241 passed, 2 skipped)
- [x] `ruff check mycelium tests`
- [ ] Merge, then tag `v1.13.0` to publish (minor release)