### PR TITLE
docs: sync version banners to v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.13.1 (2026-07-22)
+
+Docs/packaging patch: sync version banners and PyPI long description after the v1.13.0 `REPAIR` release. No code changes.
+
+### Docs
+
+- Bust shields.io badge cache keys to `release=1.13.1` (root README, SDK README, handbook).
+- Root / SDK / handbook version lines: v1.12.0 → v1.13.1; root “What it does” → v1.13.x.
+- SDK current-package line mentions `REPAIR` gate.
+- Republish so PyPI’s project description picks up the new banners.
+
 ## 1.13.0 (2026-07-22)
 
 Minor: first-class ``REPAIR`` resolution gate for incomplete durable transition records. Heal missing context before execute; do not spawn a second side effect.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.12.0)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.13.1)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -8,7 +8,7 @@
 
 Prevents predictable failures *before* they reach the LLM. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.12.0**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.13.1**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 
@@ -16,7 +16,7 @@ Developers running **agents with side-effect tools** in production (payments, em
 
 Python 3.10+. Framework-agnostic.
 
-## What it does (v1.12.x)
+## What it does (v1.13.x)
 
 These aren't reasoning failures. They're runtime failures. Mycelium sits between your agent loop and your tools:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -381,7 +381,7 @@
 
     <h1>Mycelium: runtime guards for AI agents</h1>
     <p class="badges">
-      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.12.0" alt="PyPI version"></a>
+      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.13.1" alt="PyPI version"></a>
       <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/pyversions/mycelium-runtime.svg" alt="Python versions"></a>
       <a href="https://pepy.tech/project/mycelium-runtime"><img src="https://static.pepy.tech/badge/mycelium-runtime" alt="PyPI downloads"></a>
       <a href="https://github.com/mycelium-labs/mycelium"><img src="https://img.shields.io/github/license/mycelium-labs/mycelium.svg" alt="MIT license"></a>
@@ -391,9 +391,9 @@
       LLM: duplicate tool execution on retry, stale context, invalid tool calls.
       YAML callable paths and <code>mycelium run</code> add guards without editing each function.
       Classify tools, hash a durable transition key, resolve duplicates by terminal
-      state and resolution gates (poll / soft-block reads, hard-block or reconcile
+      state and resolution gates (poll / repair / soft-block reads, hard-block or reconcile
       writes via <code>external_operation_ref</code>). Framework-agnostic.
-      Early but API-stable (v1.12.0): breaking changes only at major versions.
+      Early but API-stable (v1.13.1): breaking changes only at major versions.
     </p>
 
     <section id="architecture">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.12.0)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.13.1)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.12.0** (command auto-instrumentation + transition envelope).
+Current package: **mycelium-runtime v1.13.1** (`REPAIR` gate + command auto-instrumentation + transition envelope).
 
 ## One painful bug → a few lines of config
 

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -90,7 +90,7 @@ from mycelium.transition_resolution import (
     transition_needs_repair,
 )
 
-__version__ = "1.13.0"
+__version__ = "1.13.1"
 
 __all__ = [
     "ActionLedger",

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.13.0"
+version = "1.13.1"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -377,7 +377,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.12.0"
+version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Sync root README, SDK README (PyPI long description), and handbook banners from v1.12.0 → **v1.13.1**.
- Bust shields.io `release=` cache keys; bump package to 1.13.1 so a tag republishes PyPI description after the REPAIR release.

## Test plan
- [ ] Merge and tag `v1.13.1`
- [ ] Confirm PyPI project page shows v1.13.1 banners