### PR TITLE
docs: map public sufficiency gates to Mycelium TransitionGate (v1.13.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.13.2 (2026-07-22)
+
+Docs patch: map public transition-sufficiency gate language to Mycelium’s internal gates. No code changes.
+
+### Docs
+
+- Handbook + SDK README: public `ALLOW` / `REPAIR` / `SOFT_BLOCK` / `HARD_BLOCK` (`BLOCK`) ↔ Mycelium `TransitionGate` table (incl. `RETURN` / `POLL` / `RECLAIM`).
+- Bust version banners to v1.13.2 so PyPI’s long description picks up the mapping.
+
 ## 1.13.1 (2026-07-22)
 
 Docs/packaging patch: sync version banners and PyPI long description after the v1.13.0 `REPAIR` release. No code changes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.13.1)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.13.2)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -8,7 +8,7 @@
 
 Prevents predictable failures *before* they reach the LLM. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.13.1**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.13.2**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -381,7 +381,7 @@
 
     <h1>Mycelium: runtime guards for AI agents</h1>
     <p class="badges">
-      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.13.1" alt="PyPI version"></a>
+      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.13.2" alt="PyPI version"></a>
       <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/pyversions/mycelium-runtime.svg" alt="Python versions"></a>
       <a href="https://pepy.tech/project/mycelium-runtime"><img src="https://static.pepy.tech/badge/mycelium-runtime" alt="PyPI downloads"></a>
       <a href="https://github.com/mycelium-labs/mycelium"><img src="https://img.shields.io/github/license/mycelium-labs/mycelium.svg" alt="MIT license"></a>
@@ -393,7 +393,7 @@
       Classify tools, hash a durable transition key, resolve duplicates by terminal
       state and resolution gates (poll / repair / soft-block reads, hard-block or reconcile
       writes via <code>external_operation_ref</code>). Framework-agnostic.
-      Early but API-stable (v1.13.1): breaking changes only at major versions.
+      Early but API-stable (v1.13.2): breaking changes only at major versions.
     </p>
 
     <section id="architecture">
@@ -601,6 +601,28 @@ RECLAIM       read EXPIRED / FAILED_*            take over stale lease
 REPAIR        incomplete durable key/boundary/terminal  heal, re-resolve (v1.13.0)
 SOFT_BLOCK    read UNKNOWN / BLOCKED only        retry by default (v1.9.0)
 HARD_BLOCK    ambiguous mutating transition      stop; reconcile if ref present</pre>
+      <p id="sufficiency-gates">
+        <strong>Public transition-sufficiency language:</strong> discussions of
+        redispatch (e.g. langgraph#7417) often use a four-gate vocabulary —
+        <code>ALLOW</code> / <code>REPAIR</code> / <code>SOFT_BLOCK</code> /
+        <code>HARD_BLOCK</code> (sometimes just <code>BLOCK</code>). Mycelium
+        implements that public set and adds finer internal gates for the same
+        decisions:
+      </p>
+      <pre>Public          Mycelium internal                         Notes
+ALLOW           ALLOW                                     run / safe retry
+REPAIR          REPAIR                                    heal durable context; owner renew_lease for live lease
+SOFT_BLOCK      SOFT_BLOCK                                read-only defer / safe retry
+HARD_BLOCK      HARD_BLOCK                                stop; reconcile if ref present
+(must not run)  RETURN / POLL                             already done, or wait on held lease
+(read reclaim)  RECLAIM                                   take over expired read lease and run</pre>
+      <p>
+        So: public <code>BLOCK</code> ≈ Mycelium <code>HARD_BLOCK</code>, while
+        <code>RETURN</code> and <code>POLL</code> are also “do not execute again”
+        outcomes under a richer internal taxonomy. Use the public four words when
+        talking to platforms; use the full Mycelium table when implementing or
+        debugging a ledgered tool.
+      </p>
       <p>
         <strong>Lease validity (v1.10.0):</strong> <code>lease_until</code> is resolution
         metadata — not part of <code>transition_key</code>. Resolution checks

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.13.1)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.13.2)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.13.1** (`REPAIR` gate + command auto-instrumentation + transition envelope).
+Current package: **mycelium-runtime v1.13.2** (`REPAIR` gate + command auto-instrumentation + transition envelope).
 
 ## One painful bug → a few lines of config
 
@@ -315,6 +315,19 @@ Each duplicate dispatch is classified to a gate. Read-only and side-effecting to
 | `REPAIR` | incomplete durable key / boundary / terminal (healable) | fix record, re-resolve — **no** second side effect |
 | `SOFT_BLOCK` | read-only `UNKNOWN` / `BLOCKED` only | **retry by default** (safe — reads don't spend); opt into deferral with `defer_read_only_unknown=True` → `LedgerSoftBlockError` |
 | `HARD_BLOCK` | ambiguous mutating transition | stop; run `Reconciler` when `external_operation_ref` is present, else fail-closed |
+
+**Public transition-sufficiency language:** #7417-style discussions often use four words — `ALLOW` / `REPAIR` / `SOFT_BLOCK` / `HARD_BLOCK` (sometimes `BLOCK`). Mycelium implements that set and adds finer internals:
+
+| Public | Mycelium | Notes |
+|--------|----------|-------|
+| `ALLOW` | `ALLOW` | run / safe retry |
+| `REPAIR` | `REPAIR` | heal durable context; owner `renew_lease()` for a live lease |
+| `SOFT_BLOCK` | `SOFT_BLOCK` | read-only defer / safe retry |
+| `HARD_BLOCK` / `BLOCK` | `HARD_BLOCK` | stop; reconcile if ref present |
+| *(must not run again)* | `RETURN` / `POLL` | already done, or wait on a held lease |
+| *(read reclaim)* | `RECLAIM` | take over an expired read lease and run |
+
+Public `BLOCK` ≈ Mycelium `HARD_BLOCK`. `RETURN` and `POLL` are also “do not execute again” under the richer internal taxonomy — use the four public words with platforms; use the full table when implementing or debugging.
 
 **Lease validity (v1.10.0):** `lease_until` is resolution metadata — **not** part of `transition_key` (so renewals do not fork identity). Before reclaim/retry, resolution classifies the window via `LeaseValidity` (`HELD` → poll, `EXPIRED` → reclaim or hard-block by class, `UNBOUNDED` → no TTL). During long work call `renew_lease()` inside the ledgered tool to keep peers on `POLL`.
 

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -90,7 +90,7 @@ from mycelium.transition_resolution import (
     transition_needs_repair,
 )
 
-__version__ = "1.13.1"
+__version__ = "1.13.2"
 
 __all__ = [
     "ActionLedger",

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.13.1"
+version = "1.13.2"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -377,7 +377,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.13.1"
+version = "1.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Handbook `#sufficiency-gates` + SDK README map public ALLOW/REPAIR/SOFT_BLOCK/HARD_BLOCK to Mycelium TransitionGate.
- Docs patch v1.13.2 for PyPI banner sync.

## Test plan
- [ ] Merge + tag v1.13.2
