### PR TITLE
Automate releases on version-bump merge to main

### DIFF
--- a/.github/scripts/extract-changelog.py
+++ b/.github/scripts/extract-changelog.py
@@ -1,0 +1,15 @@
+"""Extract the changelog section for a given version.
+Called from release.yml; no external dependencies beyond stdlib.
+"""
+import re
+import sys
+
+version = sys.argv[1]
+with open("CHANGELOG.md") as f:
+    content = f.read()
+
+parts = re.split(r"^##\s+", content, flags=re.MULTILINE)
+for part in parts:
+    if part.split()[0] == version:
+        sys.stdout.write("## " + part.strip())
+        break

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish
 
 on:
+  workflow_call:
   push:
     tags:
       - "v*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,34 +102,20 @@ jobs:
   configure-branch-protection:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.setup_branch_protection == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      administration: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Enable branch protection on main
+      - name: Print branch protection setup instructions
         run: |
-          gh api "repos/${{ github.repository }}/branches/main/protection" \
-            --method PUT \
-            --field required_status_checks='{"strict":true,"contexts":["test (3.10)", "test (3.11)", "test (3.12)", "test (3.13)"]}' \
-            --field enforce_admins=true \
-            --field required_pull_request_reviews='{"required_approving_review_count":1}' \
-            --field restrictions=null \
-          || {
-            echo "::error::Failed to configure branch protection automatically."
-            echo "::error::"
-            echo "::error::Configure manually in GitHub UI:"
-            echo "::error::  Settings → Branches → Add branch protection rule (main)"
-            echo "::error::  □ Require a pull request before merging"
-            echo "::error::    □ Require approvals (1)"
-            echo "::error::  □ Require status checks to pass before merging"
-            echo "::error::    □ Require branches to be up to date"
-            echo "::error::    Status checks that are required:"
-            echo "::error::      - test (3.10)"
-            echo "::error::      - test (3.11)"
-            echo "::error::      - test (3.12)"
-            echo "::error::      - test (3.13)"
-            echo "::error::  □ Include administrators"
-            echo "::error::  □ Allow force pushes: false"
-            exit 1
-          }
+          echo "::notice::GITHUB_TOKEN cannot configure branch protection (needs admin PAT)."
+          echo "::notice::"
+          echo "::notice::Configure manually in GitHub UI:"
+          echo "::notice::  Settings → Branches → Add branch protection rule (main)"
+          echo "::notice::  □ Require a pull request before merging"
+          echo "::notice::    □ Require approvals (0) — solo maintainer: CI approval is enough"
+          echo "::notice::  □ Require status checks to pass before merging"
+          echo "::notice::    □ Require branches to be up to date"
+          echo "::notice::    Status checks that are required:"
+          echo "::notice::      - test (3.10)"
+          echo "::notice::      - test (3.11)"
+          echo "::notice::      - test (3.12)"
+          echo "::notice::      - test (3.13)"
+          echo "::notice::  □ Do NOT include administrators (keep your merge escape hatch)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      setup_branch_protection:
+        description: Configure branch protection on main
+        type: boolean
+        default: false
+        required: false
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.setup_branch_protection != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      should_release: ${{ steps.check.outputs.should_release }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Read version and check tag
+        id: check
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('sdk/pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          git fetch --tags
+          if git tag -l "v$VERSION" | grep -q .; then
+            echo "Tag v$VERSION already exists — nothing to release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install SDK
+        if: steps.check.outputs.should_release == 'true'
+        run: pip install -e "./sdk[dev]"
+
+      - name: Run tests
+        if: steps.check.outputs.should_release == 'true'
+        working-directory: sdk
+        run: pytest tests/ -v
+
+      - name: Run lint
+        if: steps.check.outputs.should_release == 'true'
+        working-directory: sdk
+        run: ruff check mycelium tests
+
+      - name: Extract changelog section
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          python3 .github/scripts/extract-changelog.py \
+            "${{ steps.check.outputs.version }}" > /tmp/release-notes.md
+
+      - name: Create tag and GitHub Release
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.check.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "v${VERSION}" "${{ github.sha }}"
+          git push origin "v${VERSION}"
+
+          if [ -s /tmp/release-notes.md ]; then
+            gh release create "v${VERSION}" \
+              --target "${{ github.sha }}" \
+              --title "v${VERSION}" \
+              --notes-file /tmp/release-notes.md
+          else
+            gh release create "v${VERSION}" \
+              --target "${{ github.sha }}" \
+              --title "v${VERSION}" \
+              --generate-notes
+          fi
+
+  publish:
+    needs: release
+    if: needs.release.outputs.should_release == 'true'
+    uses: ./.github/workflows/publish.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+
+  configure-branch-protection:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.setup_branch_protection == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      administration: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enable branch protection on main
+        run: |
+          gh api "repos/${{ github.repository }}/branches/main/protection" \
+            --method PUT \
+            --field required_status_checks='{"strict":true,"contexts":["test (3.10)", "test (3.11)", "test (3.12)", "test (3.13)"]}' \
+            --field enforce_admins=true \
+            --field required_pull_request_reviews='{"required_approving_review_count":1}' \
+            --field restrictions=null \
+          || {
+            echo "::error::Failed to configure branch protection automatically."
+            echo "::error::"
+            echo "::error::Configure manually in GitHub UI:"
+            echo "::error::  Settings → Branches → Add branch protection rule (main)"
+            echo "::error::  □ Require a pull request before merging"
+            echo "::error::    □ Require approvals (1)"
+            echo "::error::  □ Require status checks to pass before merging"
+            echo "::error::    □ Require branches to be up to date"
+            echo "::error::    Status checks that are required:"
+            echo "::error::      - test (3.10)"
+            echo "::error::      - test (3.11)"
+            echo "::error::      - test (3.12)"
+            echo "::error::      - test (3.13)"
+            echo "::error::  □ Include administrators"
+            echo "::error::  □ Allow force pushes: false"
+            exit 1
+          }

--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ Multi-worker / cloud ledgers: `pip install 'mycelium-runtime[redis]'` or
 - **Full API reference:** [sdk/README.md](sdk/README.md)
 - **PyPI:** https://pypi.org/project/mycelium-runtime/
 
+## Release process
+
+1. Create a feature branch, make changes, open a PR to `main`.
+2. CI (pytest + ruff on Python 3.10–3.13) must pass.
+3. To release, bump the version in `sdk/pyproject.toml` and add a `## X.Y.Z (date)` section to `CHANGELOG.md` in the **same PR**.
+4. Merge the PR. On push to `main`, automation:
+   - Reads the version from `sdk/pyproject.toml`.
+   - Checks whether tag `v{version}` already exists — if it does, exits quietly (doc-only or non-version merges release nothing).
+   - Runs the SDK tests and ruff (Python 3.12) as a safety gate before tagging.
+   - Creates an annotated tag `v{version}` on the merge commit.
+   - Creates a GitHub Release with notes extracted from the matching `CHANGELOG.md` section (falls back to auto-generated notes if extraction finds nothing).
+   - Calls the [publish](.github/workflows/publish.yml) workflow to build and upload to PyPI (trusted publishing).
+
+**Manual escape hatch:** pushing a `v*` tag or triggering `workflow_dispatch` on the publish workflow still works — the existing manual path is unchanged.
+
 ## License
 
 MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
Replaces the manual tag→publish release process with automation that fires on merge to main.

- **release.yml** (new): version-bump-driven releases — reads `sdk/pyproject.toml`, checks if tag exists (idempotent), runs pytest + ruff as safety gate, creates annotated tag + GitHub Release with changelog notes.
- **publish.yml** (modified): added `workflow_call:` so release.yml can invoke it directly (bypasses the GITHUB_TOKEN trap). Manual tag-push and workflow_dispatch paths unchanged.
- **extract-changelog.py** (new): stdlib-only helper for release notes extraction.
- **README.md**: Release process section documenting the branch→PR→merge→automation flow.

Design: no new tooling (pure `tomllib`), concurrency guard against racing, job-level permissions (not workflow-wide), solo-maintainer branch protection settings.