### PR TITLE
Fix: use PAT for tag push (PyPI doesn't support reusable workflows)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,6 @@
 name: Publish
 
 on:
-  workflow_call:
   push:
     tags:
       - "v*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ jobs:
   release:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.setup_branch_protection != 'true'
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.check.outputs.version }}
-      should_release: ${{ steps.check.outputs.should_release }}
     permissions:
       contents: write
     steps:
@@ -67,16 +64,29 @@ jobs:
           python3 .github/scripts/extract-changelog.py \
             "${{ steps.check.outputs.version }}" > /tmp/release-notes.md
 
-      - name: Create tag and GitHub Release
+      - name: Create tag, push, and create GitHub Release
         if: steps.check.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
         run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "::error::RELEASE_PAT secret is not set."
+            echo "::error::"
+            echo "::error::The tag push needs a PAT so publish.yml's on: push: tags: v* trigger fires."
+            echo "::error::(GITHUB_TOKEN cannot trigger other workflows.)"
+            echo "::error::"
+            echo "::error::1. Create a PAT at https://github.com/settings/tokens/new"
+            echo "::error::   (permissions: contents: write, on this repo only)"
+            echo "::error::2. Add it as a repository secret named RELEASE_PAT at"
+            echo "::error::   Settings → Secrets and variables → Actions"
+            exit 1
+          fi
           VERSION="${{ steps.check.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "v${VERSION}" -m "v${VERSION}" "${{ github.sha }}"
-          git push origin "v${VERSION}"
+          git push "https://x-access-token:${RELEASE_PAT}@github.com/${{ github.repository }}.git" "v${VERSION}"
 
           if [ -s /tmp/release-notes.md ]; then
             gh release create "v${VERSION}" \
@@ -89,15 +99,6 @@ jobs:
               --title "v${VERSION}" \
               --generate-notes
           fi
-
-  publish:
-    needs: release
-    if: needs.release.outputs.should_release == 'true'
-    uses: ./.github/workflows/publish.yml
-    secrets: inherit
-    permissions:
-      contents: read
-      id-token: write
 
   configure-branch-protection:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.setup_branch_protection == 'true'

--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ Multi-worker / cloud ledgers: `pip install 'mycelium-runtime[redis]'` or
 
 ## Release process
 
+### One-time setup
+
+Create a GitHub Personal Access Token with `contents: write` scope on this repo and add it as a repository secret named `RELEASE_PAT` at **Settings → Secrets and variables → Actions**. This is required because the tag push uses the PAT (instead of `GITHUB_TOKEN`) so that `publish.yml`'s `on: push: tags: v*` trigger fires — `GITHUB_TOKEN`-pushed tags cannot trigger other workflows.
+
+### Per-release steps
+
 1. Create a feature branch, make changes, open a PR to `main`.
 2. CI (pytest + ruff on Python 3.10–3.13) must pass.
 3. To release, bump the version in `sdk/pyproject.toml` and add a `## X.Y.Z (date)` section to `CHANGELOG.md` in the **same PR**.
@@ -139,11 +145,11 @@ Multi-worker / cloud ledgers: `pip install 'mycelium-runtime[redis]'` or
    - Reads the version from `sdk/pyproject.toml`.
    - Checks whether tag `v{version}` already exists — if it does, exits quietly (doc-only or non-version merges release nothing).
    - Runs the SDK tests and ruff (Python 3.12) as a safety gate before tagging.
-   - Creates an annotated tag `v{version}` on the merge commit.
+   - Creates an annotated tag `v{version}` and pushes it (via PAT so the tag-push triggers the publish workflow).
    - Creates a GitHub Release with notes extracted from the matching `CHANGELOG.md` section (falls back to auto-generated notes if extraction finds nothing).
-   - Calls the [publish](.github/workflows/publish.yml) workflow to build and upload to PyPI (trusted publishing).
+   - The tag push triggers [publish.yml](.github/workflows/publish.yml) (`on: push: tags: v*`) which builds and uploads to PyPI via trusted publishing.
 
-**Manual escape hatch:** pushing a `v*` tag or triggering `workflow_dispatch` on the publish workflow still works — the existing manual path is unchanged.
+**Manual escape hatch:** pushing a `v*` tag or triggering `workflow_dispatch` on the publish workflow still works — the existing manual path is unchanged. If the automation fails, publish manually by running `git push origin v{version}` locally after merging.
 
 ## License
 


### PR DESCRIPTION
PyPI's Trusted Publishing does not support reusable workflows (`workflow_call`), which caused the v1.16.1 publish to fail. The tag was created and the GitHub Release was generated, but the PyPI upload was rejected.

**Changes:**

- Removed `workflow_call:` from `publish.yml` — no longer needed.
- Removed the `publish:` job from `release.yml` — the tag push now triggers `publish.yml`'s native `on: push: tags: v*` trigger.
- `release.yml` now pushes the tag via `RELEASE_PAT` (a PAT with `contents: write`), because `GITHUB_TOKEN`-pushed tags cannot trigger other workflows.
- If `RELEASE_PAT` is not set, the workflow fails with clear setup instructions.
- Updated README with the PAT setup step.

**Setup needed after merge:**

Create a GitHub PAT (classic, `contents: write` scope, this repo only) and add it as `RELEASE_PAT` at **Settings → Secrets and variables → Actions**. The workflow will guide you if it's missing.