### PR TITLE
fix: reconcile CAS-loss — poll instead of hard-block on concurrent EXPIRED reset (v1.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,72 @@ Minor: worker-death / stream-loss signal — reclaim requires affirmative death 
 
 ## Unreleased
 
+### NOT\_EXECUTED CAS-loss path polls instead of hard-blocking
+
+- `_apply_reconcile_result` CAS loss on NOT\_EXECUTED: re-reads the entry
+  and returns the winner's fresh claim to the claim loop, which polls until
+  the winner completes. Both reconcilers now see the same completed result
+  and the tool runs exactly once (instead of one reconciler hard-blocking).
+- `_raise_hard_block`: re-reads the entry before raising. If the entry is
+  now `IN_FLIGHT` with a live lease (another thread reclaimed it), returns
+  to the claim loop instead of raising. Never `mark_blocked`s an entry
+  whose lease is currently held.
+- `_reconcile_or_hard_block` / `_reconcile_or_hard_block_async`: simplified
+  — no longer asserts unreachable after `_raise_hard_block` since it may
+  return an entry for polling.
+- Claim loop: all six `_reconcile_or_hard_block` call sites (three sync +
+  three async) check for `IN_FLIGHT` return and poll instead of returning
+  the in-flight entry as a resolved result.
+- Operator-resolution path: `_consume_operator_resolution` passes
+  `_cas_race_returns_none=True` so CAS loss on operator release falls
+  through to the reconciler path instead of stamping the winner's entry.
+
+### Tests
+
+- `test_concurrent_reconcile_not_executed_race` rewritten: asserts both
+  threads get the same completed result and the tool ran exactly once
+  (instead of one thread hard-blocking).
+- New `test_concurrent_reconcile_not_executed_race_expired_seed`: same
+  race but seeded from an EXPIRED lease-expired `IN_FLIGHT` entry with
+  not_crossed boundary and external_operation_ref.
+
+## 1.18.1 (2026-07-29)
+
+Patch: unguarded-write races in reconcile NOT\_EXECUTED reset and reclaim
+paths. Both could produce a lost-update where two concurrent writers each
+believe they own the fresh claim — the external design-partner audit
+confirmed neither race has been observed in production, but the contract
+is now enforced at the storage layer.
+
+### Reconciler NOT\_EXECUTED reset via CAS
+
+- `_apply_reconcile_result` for `ReconcileStatus.NOT_EXECUTED` now uses
+  `_try_transition` (CAS) instead of plain `_set_entry`. The expected-from
+  set (`_RECONCILE_NOT_EXECUTED_OUTCOMES`) excludes `IN_FLIGHT` so two
+  reconcilers cannot both write a fresh in-flight claim; EXPIRED entries
+  are advanced to `BLOCKED` first via `mark_blocked` so the CAS pre-condition
+  is unambiguous.
+
+### Reclaim path CAS per backend
+
+- `RedisEntryStorage.try_claim_inflight`: the reclaim path (expired lease /
+  failed entry rewrite) now uses WATCH-based CAS via
+  `_try_reclaim()`.  The stored entry is re-classified under WATCH and only
+  overwritten when it is still reclaimable.  A `WatchError` loop retries
+  from the top.
+- `InMemoryLedgerStorage`: all storage methods (`get`, `set`,
+  `try_claim_inflight`, `try_transition`) are now guarded by a
+  `threading.RLock`, making concurrent in-process claims safe.
+- `FileLedgerStorage`: methods that cross the ``fcntl`` lock are now also
+  guarded by a `threading.Lock` (``flock`` has process-level semantics, so
+  two threads in the same process cannot rely on it alone).
+
+### Tests
+
+- 5 new tests in `tests/test_atomicity_contract.py` covering both race
+  conditions: per-backend reconcile NOT\_EXECUTED race (memory / file /
+  redis) and per-backend reclaim race (InMemory, Redis direct).
+
 ## 1.18.0 (2026-07-29)
 
 Minor: atomicity contract for one-shot terminal outcomes — stale workers must not silently overwrite already-resolved transitions, enforced via CAS on all storage backends.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -839,6 +839,17 @@ The `@ledger` / `@ledger_sync` wrapper captures the current worker's identity (`
 | Redis | `pipe.watch()` on the key; `WatchError` retry loop on conflict |
 | Postgres | `UPDATE ... WHERE payload->>'terminal_outcome' = ANY(...) RETURNING` |
 
+### NOT_EXECUTED reset CAS (v1.18+)
+
+The `NOT_EXECUTED` reset path (reconcile → fresh `IN_FLIGHT` claim) uses a CAS on
+`_RECONCILE_NOT_EXECUTED_OUTCOMES`. When two reconcilers both return
+`NOT_EXECUTED`, the CAS loser reads the winner's entry and returns it to the
+claim loop, which polls until the winner completes rather than hard-blocking.
+The same stale-snapshot guard applies in `_raise_hard_block`: a re-read that
+finds `IN_FLIGHT` with a live lease returns to the claim loop instead of
+raising, and `mark_blocked` is never called on an entry whose lease is
+currently held.
+
 ## For contributors (repo layout)
 
 Clone the GitHub repo to run proofs and tests. PyPI installs only the `mycelium` package.

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -156,6 +156,19 @@ _RESOLUTION_ACCEPTED_STORED_OUTCOMES: frozenset[str] = frozenset({
     TerminalOutcome.FAILED_BEFORE_EFFECT.value,
 })
 
+# Stored terminal-outcome values that **the NOT_EXECUTED reset** accepts.
+# Excludes ``IN_FLIGHT`` so two reconcilers racing ``NOT_EXECUTED``
+# cannot both transition ``IN_FLIGHT → IN_FLIGHT`` — only the first
+# writer wins; the second sees ``IN_FLIGHT`` and fails the CAS.
+# EXPIRED entries (stored ``IN_FLIGHT`` with expired lease) are advanced
+# to ``BLOCKED`` before the CAS (see ``_apply_reconcile_result``).
+_RECONCILE_NOT_EXECUTED_OUTCOMES: frozenset[str] = frozenset({
+    TerminalOutcome.BLOCKED.value,
+    TerminalOutcome.UNKNOWN.value,
+    TerminalOutcome.FAILED_AFTER_EFFECT.value,
+    TerminalOutcome.FAILED_BEFORE_EFFECT.value,
+})
+
 # Policies for tools ledgered without a transition_binding (unclassified).
 # "warn": legacy behavior + a one-time warning when a failed entry is
 # reclaimed. "strict": route the claim through claim_side_effecting with a
@@ -276,6 +289,12 @@ _active_transition_var: ContextVar[_ActiveTransition | None] = ContextVar(
     "mycelium_active_transition",
     default=None,
 )
+
+# Set when _apply_reconcile_result or _raise_hard_block re-reads the entry and
+# finds it already claimed by another thread (CAS-loss or stale snapshot).
+# The claim loop checks this flag: if set, an IN_FLIGHT return means "poll",
+# not "this thread won the fresh claim".
+_reconcile_cas_lost: threading.local = threading.local()
 
 
 def get_active_transition() -> _ActiveTransition | None:
@@ -650,19 +669,33 @@ class LedgerStorage:
 
 
 class InMemoryLedgerStorage(LedgerStorage):
-    """Default in-memory storage. Survives within the process only."""
+    """Default in-memory storage. Survives within the process only.
+
+    Thread-safe via ``_lock`` (``threading.RLock``) so concurrent in-process
+    claims and transitions do not lose writes.  Multi-process users must
+    choose a durable backend.
+    """
 
     def __init__(self) -> None:
         self._entries: dict[str, LedgerEntry] = {}
+        self._lock = threading.RLock()
 
     def get(self, request_id: str) -> LedgerEntry | None:
-        return self._entries.get(request_id)
+        with self._lock:
+            return self._entries.get(request_id)
 
     def set(self, entry: LedgerEntry) -> None:
-        self._entries[entry.request_id] = entry
+        with self._lock:
+            self._entries[entry.request_id] = entry
 
-    def list_all(self) -> list[LedgerEntry]:
-        return list(self._entries.values())
+    def try_claim_inflight(
+        self,
+        entry: LedgerEntry,
+        *,
+        lease_ttl: float = DEFAULT_LEASE_TTL,
+    ) -> tuple[str, LedgerEntry | None]:
+        with self._lock:
+            return default_try_claim_inflight(self, entry, lease_ttl=lease_ttl)
 
     def try_transition(
         self,
@@ -671,22 +704,33 @@ class InMemoryLedgerStorage(LedgerStorage):
         expected_terminal_outcomes: frozenset[str],
         expected_owner: str | None = None,
     ) -> bool:
-        existing = self._entries.get(entry.request_id)
-        if existing is None:
-            return False
-        if existing.terminal_outcome not in expected_terminal_outcomes:
-            return False
-        if expected_owner is not None and existing.owner != expected_owner:
-            return False
-        self.set(entry)
-        return True
+        with self._lock:
+            existing = self._entries.get(entry.request_id)
+            if existing is None:
+                return False
+            if existing.terminal_outcome not in expected_terminal_outcomes:
+                return False
+            if expected_owner is not None and existing.owner != expected_owner:
+                return False
+            self.set(entry)
+            return True
+
+    def list_all(self) -> list[LedgerEntry]:
+        with self._lock:
+            return list(self._entries.values())
 
 
 class FileLedgerStorage(LedgerStorage):
-    """JSON-file-backed storage with ``fcntl`` locking for multi-process safety."""
+    """JSON-file-backed storage with ``fcntl`` + threading locking.
+
+    The ``fcntl`` lock guards across processes; the ``threading.Lock`` guards
+    across threads within the same process (``flock`` has process-level
+    semantics on macOS/Linux, so multiple threads cannot rely on it alone).
+    """
 
     def __init__(self, path: str | Path) -> None:
         self._file = LockedJsonDictFile(path)
+        self._lock = threading.Lock()
 
     def get(self, request_id: str) -> LedgerEntry | None:
         def read(data: dict[str, dict[str, Any]]) -> LedgerEntry | None:
@@ -695,13 +739,15 @@ class FileLedgerStorage(LedgerStorage):
                 return None
             return LedgerEntry.from_dict(raw)
 
-        return self._file.read_modify_write_no_save(read)
+        with self._lock:
+            return self._file.read_modify_write_no_save(read)
 
     def set(self, entry: LedgerEntry) -> None:
         def mutate(data: dict[str, dict[str, Any]]) -> None:
             data[entry.request_id] = entry.to_dict()
 
-        self._file.read_modify_write(mutate)
+        with self._lock:
+            self._file.read_modify_write(mutate)
 
     def try_claim_inflight(
         self,
@@ -726,7 +772,8 @@ class FileLedgerStorage(LedgerStorage):
             data[entry.request_id] = leased.to_dict()
             outcome.append(("claimed", None))
 
-        self._file.read_modify_write(mutate)
+        with self._lock:
+            self._file.read_modify_write(mutate)
         return outcome[0]
 
     def try_transition(
@@ -753,7 +800,8 @@ class FileLedgerStorage(LedgerStorage):
             data[entry.request_id] = entry.to_dict()
             result.append(True)
 
-        self._file.read_modify_write(mutate)
+        with self._lock:
+            self._file.read_modify_write(mutate)
         return result[0]
 
     def list_all(self) -> list[LedgerEntry]:
@@ -1384,26 +1432,41 @@ class ActionLedger:
         *,
         binding: ToolTransitionBinding | None = None,
         now: float | None = None,
-    ) -> None:
-        outcome = existing.resolved_terminal_outcome()
-        if outcome == TerminalOutcome.EXPIRED:
-            boundary = SideEffectBoundary(existing.side_effect_boundary)
-            if boundary == SideEffectBoundary.NOT_CROSSED:
-                error = (
-                    "stale in-flight lease with not_crossed boundary; "
-                    "reclaim only if an external_operation_ref reconcile "
-                    "proves NOT_EXECUTED"
-                )
-            else:
-                error = (
-                    "stale in-flight lease; side-effect boundary "
-                    f"{boundary.value} — effect may have happened"
-                )
-            existing = self.mark_blocked(
-                request_id,
-                error=error,
-                _expected_from=_IN_FLIGHT_OUTCOMES,
-            )
+    ) -> LedgerEntry:
+        current = self.get(request_id)
+        if current is not None:
+            curr_outcome = current.resolved_terminal_outcome(now=now)
+            if curr_outcome == TerminalOutcome.IN_FLIGHT:
+                _reconcile_cas_lost.val = True
+                return current
+            if curr_outcome == TerminalOutcome.COMPLETED:
+                return current
+            if curr_outcome == TerminalOutcome.EXPIRED:
+                boundary = SideEffectBoundary(current.side_effect_boundary)
+                if boundary == SideEffectBoundary.NOT_CROSSED:
+                    error = (
+                        "stale in-flight lease with not_crossed boundary; "
+                        "reclaim only if an external_operation_ref reconcile "
+                        "proves NOT_EXECUTED"
+                    )
+                else:
+                    error = (
+                        "stale in-flight lease; side-effect boundary "
+                        f"{boundary.value} — effect may have happened"
+                    )
+                try:
+                    existing = self.mark_blocked(
+                        request_id,
+                        error=error,
+                        _expected_from=_IN_FLIGHT_OUTCOMES,
+                        _expected_owner=current.owner,
+                    )
+                except LedgerOutcomeAlreadySetError:
+                    again = self.get(request_id)
+                    if again is not None:
+                        _reconcile_cas_lost.val = True
+                        return again
+                    existing = current
         message = hard_block_message(
             existing, tool=tool, request_id=request_id, binding=binding, now=now
         )
@@ -1418,6 +1481,7 @@ class ActionLedger:
         binding: ToolTransitionBinding,
         result: Any,
         _preserved_pkey_first_attempt: float | None = None,
+        _cas_race_returns_none: bool = False,
     ) -> LedgerEntry | None:
         """Map a reconcile result onto the ledger.
 
@@ -1425,6 +1489,11 @@ class ActionLedger:
         result, no re-execution). ``NOT_EXECUTED`` resets the entry to a fresh
         in-flight claim so the tool runs exactly once. ``UNKNOWN`` returns None
         so the caller hard-blocks.
+
+        When ``_cas_race_returns_none`` is True (operator-resolution path),
+        a lost CAS returns None so the caller can fall through. Otherwise
+        (reconciler path) the winner's entry is returned so the claim loop
+        polls instead of hard-blocking.
         """
         if result.status == ReconcileStatus.COMPLETED:
             return self.complete(
@@ -1447,7 +1516,41 @@ class ActionLedger:
                 binding=binding,
                 _provider_key_first_attempt_at=_preserved_pkey_first_attempt,
             )
-            self._set_entry(fresh)
+            # EXPIRED entries have stored terminal ``IN_FLIGHT`` (lease is
+            # resolved at read time).  Advance past ``IN_FLIGHT`` first so the
+            # CAS below cannot race on ``IN_FLIGHT → IN_FLIGHT``.
+            now = time.time()
+            stale = self.get(request_id)
+            _stale_owner: str | None = stale.owner if stale is not None else None
+            if stale is not None and stale.resolved_terminal_outcome(now=now) in (
+                TerminalOutcome.EXPIRED,
+            ):
+                try:
+                    self.mark_blocked(
+                        request_id,
+                        error="reconciling expired entry as NOT_EXECUTED",
+                        _expected_from=_IN_FLIGHT_OUTCOMES,
+                        _expected_owner=_stale_owner,
+                    )
+                except LedgerOutcomeAlreadySetError:
+                    pass
+                after_block = self.get(request_id)
+                if (
+                    after_block is not None
+                    and after_block.terminal_outcome != TerminalOutcome.BLOCKED.value
+                ):
+                    if _cas_race_returns_none:
+                        return None
+                    _reconcile_cas_lost.val = True
+                    return after_block
+            if not self._try_transition(
+                fresh,
+                expected_from=_RECONCILE_NOT_EXECUTED_OUTCOMES,
+            ):
+                if _cas_race_returns_none:
+                    return None
+                _reconcile_cas_lost.val = True
+                return self.get(request_id)
             return fresh
         return None
 
@@ -1537,6 +1640,7 @@ class ActionLedger:
             binding,
             ReconcileResult.not_executed(),
             _preserved_pkey_first_attempt=_preserved,
+            _cas_race_returns_none=True,
         )
         if fresh is None:
             return None
@@ -1569,8 +1673,7 @@ class ActionLedger:
         )
         if resolved is not None:
             return resolved
-        self._raise_hard_block(request_id, tool, existing, binding=binding)
-        raise AssertionError("unreachable")  # _raise_hard_block always raises
+        return self._raise_hard_block(request_id, tool, existing, binding=binding)
 
     async def _reconcile_or_hard_block_async(
         self,
@@ -1591,8 +1694,7 @@ class ActionLedger:
         )
         if resolved is not None:
             return resolved
-        self._raise_hard_block(request_id, tool, existing, binding=binding)
-        raise AssertionError("unreachable")  # _raise_hard_block always raises
+        return self._raise_hard_block(request_id, tool, existing, binding=binding)
 
     def claim_side_effecting(
         self,
@@ -1628,9 +1730,20 @@ class ActionLedger:
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
-                    return self._reconcile_or_hard_block(
+                    entry = self._reconcile_or_hard_block(
                         request_id, tool, args, kwargs, existing, binding
                     )
+                    if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
+                        if getattr(_reconcile_cas_lost, 'val', False):
+                            _reconcile_cas_lost.val = False
+                            self._poll_side_effecting(
+                                request_id,
+                                tool=tool,
+                                interval=interval,
+                                poll_deadline=poll_deadline,
+                            )
+                            continue
+                    return entry
                 if gate == TransitionGate.POLL:
                     self._poll_side_effecting(
                         request_id,
@@ -1682,9 +1795,20 @@ class ActionLedger:
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
-                    return self._reconcile_or_hard_block(
+                    entry = self._reconcile_or_hard_block(
                         request_id, tool, args, kwargs, existing, binding
                     )
+                    if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
+                        if getattr(_reconcile_cas_lost, 'val', False):
+                            _reconcile_cas_lost.val = False
+                            self._poll_side_effecting(
+                                request_id,
+                                tool=tool,
+                                interval=interval,
+                                poll_deadline=poll_deadline,
+                            )
+                            continue
+                    return entry
                 if gate == TransitionGate.ALLOW and self._reclaim_requires_death_signal:
                     if not has_worker_death_evidence(
                         existing,
@@ -1709,9 +1833,21 @@ class ActionLedger:
                 claimed = self.get(request_id)
                 return claimed if claimed is not None else entry
             if existing is not None:
-                return self._reconcile_or_hard_block(
+                entry = self._reconcile_or_hard_block(
                     request_id, tool, args, kwargs, existing, binding
                 )
+                if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
+                    if getattr(_reconcile_cas_lost, 'val', False):
+                        _reconcile_cas_lost.val = False
+                        self._poll_side_effecting(
+                            request_id,
+                            tool=tool,
+                            interval=interval,
+                            poll_deadline=poll_deadline,
+                        )
+                        continue
+                    return entry
+                return entry
             raise LedgerError(
                 f"Unexpected claim outcome {outcome!r} for side-effecting tool {tool!r}"
             )
@@ -1804,9 +1940,20 @@ class ActionLedger:
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
-                    return await self._reconcile_or_hard_block_async(
+                    entry = await self._reconcile_or_hard_block_async(
                         request_id, tool, args, kwargs, existing, binding
                     )
+                    if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
+                        if getattr(_reconcile_cas_lost, 'val', False):
+                            _reconcile_cas_lost.val = False
+                            await self._poll_side_effecting_async(
+                                request_id,
+                                tool=tool,
+                                interval=interval,
+                                poll_deadline=poll_deadline,
+                            )
+                            continue
+                    return entry
                 if gate == TransitionGate.POLL:
                     await self._poll_side_effecting_async(
                         request_id,
@@ -1858,9 +2005,20 @@ class ActionLedger:
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
-                    return await self._reconcile_or_hard_block_async(
+                    entry = await self._reconcile_or_hard_block_async(
                         request_id, tool, args, kwargs, existing, binding
                     )
+                    if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
+                        if getattr(_reconcile_cas_lost, 'val', False):
+                            _reconcile_cas_lost.val = False
+                            await self._poll_side_effecting_async(
+                                request_id,
+                                tool=tool,
+                                interval=interval,
+                                poll_deadline=poll_deadline,
+                            )
+                            continue
+                    return entry
                 if gate == TransitionGate.ALLOW and self._reclaim_requires_death_signal:
                     if not has_worker_death_evidence(
                         existing,
@@ -1885,9 +2043,21 @@ class ActionLedger:
                 claimed = self.get(request_id)
                 return claimed if claimed is not None else entry
             if existing is not None:
-                return await self._reconcile_or_hard_block_async(
+                entry = await self._reconcile_or_hard_block_async(
                     request_id, tool, args, kwargs, existing, binding
                 )
+                if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
+                    if getattr(_reconcile_cas_lost, 'val', False):
+                        _reconcile_cas_lost.val = False
+                        await self._poll_side_effecting_async(
+                            request_id,
+                            tool=tool,
+                            interval=interval,
+                            poll_deadline=poll_deadline,
+                        )
+                        continue
+                    return entry
+                return entry
             raise LedgerError(
                 f"Unexpected claim outcome {outcome!r} for side-effecting tool {tool!r}"
             )

--- a/sdk/mycelium/storage/redis_ledger.py
+++ b/sdk/mycelium/storage/redis_ledger.py
@@ -91,13 +91,9 @@ class RedisEntryStorage:
             if outcome == "in_flight":
                 return "in_flight", existing
 
-            leased = with_lease(entry, now=now, lease_ttl=lease_ttl)
-            payload = json.dumps(leased.to_dict(), default=str)
-            if ttl > 0:
-                self._client.set(key, payload, ex=ttl)
-            else:
-                self._client.set(key, payload)
-            return "claimed", None
+            reclaimed = self._try_reclaim(key, entry, ttl, lease_ttl)
+            if reclaimed is not None:
+                return reclaimed
 
         existing_raw = self._client.get(key)
         if existing_raw is None:
@@ -106,6 +102,43 @@ class RedisEntryStorage:
         if existing.status == "completed":
             return "completed", existing
         return "in_flight", existing
+
+    def _try_reclaim(
+        self,
+        key: str,
+        entry: E,
+        ttl: int,
+        lease_ttl: float,
+    ) -> tuple[ClaimOutcome, E | None] | None:
+        """CAS reclaim: only overwrite if the stored entry is still
+        reclaimable per :func:`claim_inflight_outcome`. Returns ``None``
+        when the watch fires (caller retries from the top)."""
+        from redis.exceptions import WatchError
+
+        from mycelium.storage._helpers import claim_inflight_outcome, with_lease
+
+        now = time.time()
+        leased = with_lease(entry, now=now, lease_ttl=lease_ttl)
+        payload = json.dumps(leased.to_dict(), default=str)
+        try:
+            with self._client.pipeline(transaction=True) as pipe:
+                pipe.watch(key)
+                raw = pipe.get(key)
+                if raw is None:
+                    return ("claimed", None)
+                current = self._from_dict(json.loads(raw))
+                rerun = claim_inflight_outcome(current, now=time.time())
+                if rerun != "claimed":
+                    return rerun, current
+                pipe.multi()
+                if ttl > 0:
+                    pipe.set(key, payload, ex=ttl)
+                else:
+                    pipe.set(key, payload)
+                pipe.execute()
+                return ("claimed", None)
+        except WatchError:
+            return None
 
     def try_transition(
         self,

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.18.0"
+version = "1.18.1"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",

--- a/sdk/tests/test_atomicity_contract.py
+++ b/sdk/tests/test_atomicity_contract.py
@@ -15,6 +15,10 @@ See ``sdk/README.md`` § "Atomicity contract" for the full design.
 from __future__ import annotations
 
 import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -24,7 +28,9 @@ from mycelium import (
     InMemoryLedgerStorage,
     LedgerEntry,
     LedgerOutcomeAlreadySetError,
+    ReconcileResult,
     RedisLedgerStorage,
+    SideEffectBoundary,
     SideEffectClass,
     TerminalOutcome,
     ToolTransitionBinding,
@@ -441,6 +447,306 @@ def test_wrapper_owner_fencing_prevents_stale_overwrite(ledger: ActionLedger) ->
         ledger.complete(request_id2, {"ok": True}, _expected_owner="bob")
     stored2 = ledger.get(request_id2)
     assert stored2.terminal_outcome == TerminalOutcome.IN_FLIGHT.value
+
+
+# ---------------------------------------------------------------------------
+# Reclaim race: two threads must not both get "claimed" from try_claim_inflight
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_reclaim_race_inmemory() -> None:
+    """In-memory reclaim race: at most one thread gets ``claimed``."""
+    storage = InMemoryLedgerStorage()
+    request_id = "race-reclaim-mem"
+    now = time.time()
+
+    expired = LedgerEntry(
+        request_id=request_id,
+        tool="t",
+        args=(),
+        kwargs={},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        lease_until=now - 10,
+        idempotency_key=request_id,
+    )
+    storage.set(expired)
+
+    fresh = LedgerEntry(
+        request_id=request_id,
+        tool="t",
+        args=(),
+        kwargs={},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        lease_until=now + 3600,
+        idempotency_key=request_id,
+    )
+
+    results: list[tuple[str, LedgerEntry | None]] = []
+    barrier = threading.Barrier(2, timeout=5)
+
+    def _racer() -> None:
+        barrier.wait()
+        outcome, existing = storage.try_claim_inflight(fresh, lease_ttl=3600.0)
+        results.append((outcome, existing))
+
+    t1 = threading.Thread(target=_racer, daemon=True)
+    t2 = threading.Thread(target=_racer, daemon=True)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    outcomes = [r[0] for r in results]
+    claimed = [o for o in outcomes if o == "claimed"]
+    assert len(claimed) == 1, (
+        f"expected exactly one 'claimed', got {len(claimed)}: {results}"
+    )
+
+
+def test_concurrent_reclaim_race_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redis reclaim race: at most one thread gets ``claimed``."""
+    fakeredis = pytest.importorskip("fakeredis")
+    fake = fakeredis.FakeRedis(decode_responses=True)
+
+    def from_url(url: str, **kwargs: object) -> object:
+        return fake
+
+    import redis as redis_mod
+
+    monkeypatch.setattr(redis_mod.Redis, "from_url", from_url)
+
+    storage = RedisLedgerStorage("redis://test")
+    request_id = "race-reclaim-redis"
+    now = time.time()
+
+    expired = LedgerEntry(
+        request_id=request_id,
+        tool="t",
+        args=(),
+        kwargs={},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        lease_until=now - 10,
+        idempotency_key=request_id,
+    )
+    storage.set(expired)
+
+    fresh = LedgerEntry(
+        request_id=request_id,
+        tool="t",
+        args=(),
+        kwargs={},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        lease_until=now + 3600,
+        idempotency_key=request_id,
+    )
+
+    results: list[tuple[str, LedgerEntry | None]] = []
+    barrier = threading.Barrier(2, timeout=5)
+
+    def _racer() -> None:
+        barrier.wait()
+        outcome, existing = storage.try_claim_inflight(fresh, lease_ttl=3600.0)
+        results.append((outcome, existing))
+
+    t1 = threading.Thread(target=_racer, daemon=True)
+    t2 = threading.Thread(target=_racer, daemon=True)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    outcomes = [r[0] for r in results]
+    claimed = [o for o in outcomes if o == "claimed"]
+    assert len(claimed) == 1, (
+        f"expected exactly one 'claimed', got {len(claimed)}: {results}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reconcile NOT_EXECUTED race: CAS loser polls/returns instead of hard-block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["memory", "file", "redis"])
+def test_concurrent_reconcile_not_executed_race(
+    backend: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two threads racing on reconcile NOT_EXECUTED: the CAS loser re-reads
+    and returns the winner's entry instead of hard-blocking. Both threads
+    see the same completed result and the tool runs exactly once."""
+    if backend == "memory":
+        storage = InMemoryLedgerStorage()
+    elif backend == "file":
+        storage = FileLedgerStorage(tmp_path / "reconcile_race.json")
+    elif backend == "redis":
+        fakeredis = pytest.importorskip("fakeredis")
+        fake = fakeredis.FakeRedis(decode_responses=True)
+        import redis as redis_mod
+        monkeypatch.setattr(redis_mod.Redis, "from_url", lambda url, **kw: fake)
+        storage = RedisLedgerStorage("redis://test")
+
+    class NotExecutedReconciler:
+        def __init__(self) -> None:
+            self.entries: list[str] = []
+
+        def reconcile(self, entry: LedgerEntry) -> ReconcileResult:
+            self.entries.append(entry.request_id)
+            return ReconcileResult.not_executed()
+
+    ledger_inst = ActionLedger(
+        storage=storage,
+        reconciler=NotExecutedReconciler(),
+        poll_interval=0.01,
+        poll_timeout=2.0,
+    )
+    binding = _BINDING
+    request_id = "race-reconcile-not-exec"
+
+    entry = _make_entry(
+        request_id=request_id,
+        terminal_outcome=TerminalOutcome.BLOCKED.value,
+    )
+    _set_entry_on_storage(ledger_inst, request_id, entry)
+    stored = ledger_inst.get(request_id)
+    from dataclasses import replace
+
+    ledger_inst._set_entry(
+        replace(stored, external_operation_ref="pi_race")
+    )
+
+    exec_count = 0
+    results: list[tuple[str, Any]] = []
+    barrier = threading.Barrier(2, timeout=5)
+
+    def _racer() -> None:
+        nonlocal exec_count
+        barrier.wait()
+        entry = ledger_inst.claim_side_effecting(
+            request_id, "test_tool", (), {}, binding,
+        )
+        if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+            results.append(("completed", entry.result))
+        elif entry.terminal_outcome == TerminalOutcome.IN_FLIGHT.value:
+            exec_count += 1
+            result_value = {"ran": True}
+            ledger_inst.complete(request_id, result_value)
+            results.append(("ran_tool", result_value))
+        else:
+            results.append((entry.terminal_outcome or "unknown", None))
+
+    t1 = threading.Thread(target=_racer, daemon=True)
+    t2 = threading.Thread(target=_racer, daemon=True)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert exec_count == 1, (
+        f"expected exactly 1 tool execution, got {exec_count}"
+    )
+    statuses = [r[0] for r in results]
+    assert "ran_tool" in statuses, f"nobody ran the tool: {results}"
+    assert "completed" in statuses, f"nobody saw the completed result: {results}"
+    result_values = [r[1] for r in results]
+    assert result_values[0] == result_values[1], (
+        f"both threads should see the same result: {results}"
+    )
+
+
+@pytest.mark.parametrize("backend", ["memory", "file", "redis"])
+def test_concurrent_reconcile_not_executed_race_expired_seed(
+    backend: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same race as above but seeded from EXPIRED (lease-expired IN_FLIGHT
+    with not_crossed boundary + external_operation_ref)."""
+    import time as time_mod
+
+    if backend == "memory":
+        storage = InMemoryLedgerStorage()
+    elif backend == "file":
+        storage = FileLedgerStorage(tmp_path / "reconcile_race_expired.json")
+    elif backend == "redis":
+        fakeredis = pytest.importorskip("fakeredis")
+        fake = fakeredis.FakeRedis(decode_responses=True)
+        import redis as redis_mod
+        monkeypatch.setattr(redis_mod.Redis, "from_url", lambda url, **kw: fake)
+        storage = RedisLedgerStorage("redis://test")
+
+    class NotExecutedReconciler:
+        def reconcile(self, entry: LedgerEntry) -> ReconcileResult:
+            return ReconcileResult.not_executed()
+
+    ledger_inst = ActionLedger(
+        storage=storage,
+        reconciler=NotExecutedReconciler(),
+        poll_interval=0.01,
+        poll_timeout=2.0,
+    )
+    binding = _BINDING
+    request_id = "race-reconcile-not-exec-expired"
+
+    _seed_owner = str(uuid.uuid4())
+    storage.set(
+            LedgerEntry(
+                request_id=request_id,
+                tool="test_tool",
+                args=[],
+                kwargs={},
+                status="in-flight",
+                terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+                owner=_seed_owner,
+                lease_until=time_mod.time() - 1,
+                side_effect_boundary=SideEffectBoundary.NOT_CROSSED.value,
+                external_operation_ref="pi_expired_race",
+                idempotency_key=request_id,
+            )
+        )
+
+    exec_count = 0
+    results: list[tuple[str, Any]] = []
+    barrier = threading.Barrier(2, timeout=5)
+
+    def _racer() -> None:
+        nonlocal exec_count
+        barrier.wait()
+        entry = ledger_inst.claim_side_effecting(
+            request_id, "test_tool", (), {}, binding,
+        )
+        if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+            results.append(("completed", entry.result))
+        elif entry.terminal_outcome == TerminalOutcome.IN_FLIGHT.value:
+            exec_count += 1
+            result_value = {"ran": True}
+            ledger_inst.complete(request_id, result_value)
+            results.append(("ran_tool", result_value))
+        else:
+            results.append((entry.terminal_outcome or "unknown", None))
+
+    t1 = threading.Thread(target=_racer, daemon=True)
+    t2 = threading.Thread(target=_racer, daemon=True)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert exec_count == 1, (
+        f"expected exactly 1 tool execution, got {exec_count}"
+    )
+    statuses = [r[0] for r in results]
+    assert "ran_tool" in statuses, f"nobody ran the tool: {results}"
+    assert "completed" in statuses, f"nobody saw the completed result: {results}"
+    result_values = [r[1] for r in results]
+    assert result_values[0] == result_values[1], (
+        f"both threads should see the same result: {results}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the TOCTOU window between `mark_blocked` and `_try_transition` in the NOT_EXECUTED reconcile path where both threads could claim IN_FLIGHT when racing on an EXPIRED seed.

- Added `_expected_owner` fence to `mark_blocked` in both `_raise_hard_block` and `_apply_reconcile_result`
- CAS-loss now polls the winner instead of hard-blocking or double-executing
- New test `test_concurrent_reconcile_not_executed_race_expired_seed`