### PR TITLE
docs: port Mengchheang's public repro as regression tests (v1.18.1 CAS probes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ Minor: worker-death / stream-loss signal — reclaim requires affirmative death 
 
 ## Unreleased
 
+### Regression tests from Mengchheang's public repro
+
+- Ported the three probes from `notes/design-partners/mycelium_1_16_0_public_repro.py`
+  into `tests/test_mengchheang_public_repro.py`:
+  1. **Semantic identity** — same caller `request_id` + changed args produces
+     a different transition key (intentional; documented).
+  2. **Concurrent NOT_EXECUTED reconcile** — BarrierReconciler forces both
+     threads to return NOT_EXECUTED simultaneously; CAS loser polls winner.
+  3. **Concurrent expired Redis reclaim** — BarrierClient forces both readers
+     to see the same stale value; `_try_reclaim` (WATCH/MULTI) gives at most
+     one `"claimed"`.
+- Pre-1.18.1 bug baselines preserved in module docstring.
+- Identity-conflict note added to `sdk/README.md` transition-key docs.
+
 ### NOT\_EXECUTED CAS-loss path polls instead of hard-blocking
 
 - `_apply_reconcile_result` CAS loss on NOT\_EXECUTED: re-reads the entry

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -308,7 +308,8 @@ async def send_payment(amount: float, recipient: str) -> dict:
 ## What `@ledger` / `ledger_sync` do
 
 - Record every tool invocation in a durable `ActionLedger`
-- Deduplicate retries and redispatches via a rich **transition key** (scope + tool + args + `side_effect_class` + policy), not only `tool_call_id`
+- Deduplicate retries and redispatches via a rich **transition key** (scope + tool + args + `side_effect_class` + policy), not only `tool_call_id`  
+  Same caller `request_id` with different args → **different** transition key (by design — `request_id` alone is not an identity-conflict guard; see `test_mengchheang_public_repro.py::test_semantic_identity`).
 - Resolve redispatches through **gates** (see [Resolution gates](#resolution-gates)) instead of re-running blindly
 - Persist failed attempts with **terminal outcomes** (`FAILED_BEFORE_EFFECT`, `FAILED_AFTER_EFFECT`, `UNKNOWN`, `EXPIRED`, etc.) for audit and reconciliation
 

--- a/sdk/tests/test_mengchheang_public_repro.py
+++ b/sdk/tests/test_mengchheang_public_repro.py
@@ -1,0 +1,265 @@
+"""Regression tests for the three probes from Mengchheang's public repro.
+
+Source: notes/design-partners/mycelium_1_16_0_public_repro.py
+Port: three probes ported into pytest.
+
+Scope (same as original):
+- In-memory / fakeredis only; not a real-Redis certification.
+- Public API only (no internal implementation traps).
+- No external side effects.
+
+Pre-1.18.1 baselines (buggy — documented here for historical reference):
+
+    Probe 1 — Semantic identity (same caller request_id, changed args):
+        expected_1_16_0 = {"keys_equal": false, "executions": [10, 11]}
+        post-1.18.1 assertion: unchanged — intentional design, not a bug.
+
+    Probe 2 — Concurrent NOT_EXECUTED reconcile:
+        expected_1_16_0 = {"executions": 2, "results": [30, 30], "errors": []}
+        post-1.18.1 assertion: executions == 1 (CAS loser polls winner).
+
+    Probe 3 — Concurrent expired Redis reclaim:
+        expected_1_16_0 = {"claim_results": ["claimed", "claimed"]}
+        post-1.18.1 assertion: at most one "claimed"; other is non-claiming.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from mycelium import (
+    InMemoryLedgerStorage,
+    LedgerEntry,
+    ReconcileResult,
+    RedisLedgerStorage,
+    SideEffectBoundary,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    derive_transition_key_for_call,
+    ledger_sync,
+)
+
+# ---------------------------------------------------------------------------
+# Probe 1 — Semantic identity
+# ---------------------------------------------------------------------------
+# Same caller request_id with different args derives a different transition
+# key. This is intentional: request_id alone is not an identity-conflict
+# guard. The transition key also encodes side-effect class, agent, policy
+# version, and RFC 8785-normalised args.
+
+_BINDING = ToolTransitionBinding.for_tool(
+    agent_id="public-repro",
+    policy_version="1",
+    side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+)
+
+
+def test_semantic_identity() -> None:
+    """Same caller request_id + changed args → different transition key."""
+    storage = InMemoryLedgerStorage()
+    executions: list[int] = []
+
+    @ledger_sync(storage=storage, transition_binding=_BINDING)
+    def charge(amount: int) -> int:
+        executions.append(amount)
+        return amount
+
+    kwargs_a = {"amount": 10, "request_id": "intent-1"}
+    kwargs_b = {"amount": 11, "request_id": "intent-1"}
+    key_a = derive_transition_key_for_call("charge", (), kwargs_a, _BINDING)
+    key_b = derive_transition_key_for_call("charge", (), kwargs_b, _BINDING)
+    charge(**kwargs_a)
+    charge(**kwargs_b)
+
+    # Same caller request_id, but keys differ because args differ
+    assert key_a != key_b, "changed args should produce different transition key"
+    assert executions == [10, 11], (
+        f"both calls should execute, got {executions}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Probe 2 — Concurrent NOT_EXECUTED reconcile
+# ---------------------------------------------------------------------------
+# Two threads both reconcile UNKNOWN → NOT_EXECUTED at the same time.
+# Pre-1.18.1 both claimed IN_FLIGHT and both executed the tool.
+# Post-1.18.1 the CAS loser polls the winner's result.
+
+class BarrierReconciler:
+    """Holds both threads at a barrier before returning NOT_EXECUTED."""
+
+    def __init__(self) -> None:
+        self.barrier = threading.Barrier(2, timeout=5)
+        self.calls = 0
+        self.lock = threading.Lock()
+
+    def reconcile(self, entry: LedgerEntry) -> ReconcileResult:
+        with self.lock:
+            self.calls += 1
+        self.barrier.wait()
+        return ReconcileResult.not_executed()
+
+
+def test_concurrent_reconcile_not_executed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two threads race on reconcile NOT_EXECUTED: at most one executes."""
+    fakeredis = pytest.importorskip("fakeredis")
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    import redis as redis_mod
+    monkeypatch.setattr(redis_mod.Redis, "from_url", lambda url, **kw: fake)
+    storage = RedisLedgerStorage("redis://test")
+
+    reconciler = BarrierReconciler()
+    executions: list[int] = []
+    execution_lock = threading.Lock()
+
+    @ledger_sync(
+        storage=storage,
+        transition_binding=_BINDING,
+        reconciler=reconciler,
+        poll_interval=0.001,
+        poll_timeout=2,
+    )
+    def charge(amount: int) -> int:
+        with execution_lock:
+            executions.append(amount)
+        time.sleep(0.02)
+        return amount
+
+    kwargs = {"amount": 30, "request_id": "reconcile-race"}
+    transition_key = derive_transition_key_for_call(
+        "charge", (), kwargs, _BINDING
+    )
+    storage.set(
+        LedgerEntry(
+            request_id=transition_key,
+            tool="charge",
+            args=[],
+            kwargs={"amount": 30},
+            status="failed",
+            terminal_outcome=TerminalOutcome.UNKNOWN.value,
+            side_effect_boundary=SideEffectBoundary.MAYBE_CROSSED.value,
+            external_operation_ref="provider:op-30",
+        )
+    )
+
+    start = threading.Barrier(2, timeout=5)
+    results: list[int] = []
+    errors: list[str] = []
+
+    def run() -> None:
+        try:
+            start.wait()
+            results.append(charge(**kwargs))
+        except BaseException as exc:
+            errors.append(f"{type(exc).__name__}: {exc}")
+
+    threads = [threading.Thread(target=run) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    # Post-1.18.1 assertion: at most one execution
+    assert len(executions) == 1, (
+        f"expected exactly 1 tool execution, got {len(executions)}"
+    )
+    assert errors == [], f"unexpected errors: {errors}"
+    assert len(results) == 2, (
+        f"both callers should get a result, got {results}"
+    )
+    # Both callers see the same completed result (30)
+    assert sorted(results) == [30, 30], (
+        f"both callers should see 30, got {results}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Probe 3 — Concurrent expired Redis reclaim
+# ---------------------------------------------------------------------------
+# Two threads both reclaim the same lease-expired in-flight entry.
+# Pre-1.18.1: both got "claimed" (bare SET in the stale branch).
+# Post-1.18.1: _try_reclaim uses WATCH/MULTI; exactly one "claimed".
+
+
+class BarrierClient:
+    """Force two Redis-adapter readers to see the same stale value first."""
+
+    def __init__(self, inner: Any) -> None:
+        self.inner = inner
+        self.read_barrier = threading.Barrier(2, timeout=5)
+
+    def get(self, key: str) -> Any:
+        value = self.inner.get(key)
+        self.read_barrier.wait()
+        return value
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.inner, name)
+
+
+def test_concurrent_expired_redis_reclaim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two threads reclaim an expired IN_FLIGHT: exactly one 'claimed'."""
+    fakeredis = pytest.importorskip("fakeredis")
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    import redis as redis_mod
+    monkeypatch.setattr(redis_mod.Redis, "from_url", lambda url, **kw: fake)
+
+    storage = RedisLedgerStorage("redis://test")
+    request_id = "redis-stale-race"
+    storage.set(
+        LedgerEntry(
+            request_id=request_id,
+            tool="search_docs",
+            args=[],
+            kwargs={"query": "x"},
+            status="in-flight",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+            lease_until=time.time() - 1,
+        )
+    )
+
+    storage._inner._client = BarrierClient(fake)
+
+    claim_entry = LedgerEntry(
+        request_id=request_id,
+        tool="search_docs",
+        args=[],
+        kwargs={"query": "x"},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+    )
+    outcomes: list[str] = []
+    errors: list[str] = []
+
+    def reclaim() -> None:
+        try:
+            outcome, _ = storage.try_claim_inflight(claim_entry, lease_ttl=60)
+            outcomes.append(outcome)
+        except BaseException as exc:
+            errors.append(f"{type(exc).__name__}: {exc}")
+
+    threads = [threading.Thread(target=reclaim) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    claimed = [o for o in outcomes if o == "claimed"]
+    non_claimed = [o for o in outcomes if o != "claimed"]
+    assert errors == [], f"unexpected errors: {errors}"
+    assert len(claimed) == 1, (
+        f"expected exactly 1 'claimed', got {len(claimed)}: {outcomes}"
+    )
+    assert len(non_claimed) == 1 and non_claimed[0] in (
+        "in_flight",
+        "completed",
+    ), (
+        f"expected non-claiming outcome, got {non_claimed}"
+    )


### PR DESCRIPTION
Ports the three probes from `notes/design-partners/mycelium_1_16_0_public_repro.py` into the test suite, verifying the v1.18.1 CAS fixes.

**Probes:**
1. **Semantic identity** (unchanged from 1.16.0 — intentional design) — same `request_id` + changed args → different transition key.
2. **Concurrent NOT_EXECUTED reconcile** (was buggy in 1.16.0: `executions: 2`) — now at most 1 execution; CAS loser polls winner.
3. **Concurrent expired Redis reclaim** (was buggy in 1.16.0: `["claimed", "claimed"]`) — now exactly one `"claimed"`; `_try_reclaim` WATCH/MULTI path prevents the double-claim.

**Deliverables:**
- `sdk/tests/test_mengchheang_public_repro.py` — 3 tests, 30/30 stress pass on each probe.
- `sdk/README.md` — identity-conflict note under transition-key docs.
- `CHANGELOG.md` — Unreleased entry.
- Pre-1.18.1 bug baselines in module docstring.
- Full suite: 499 passed, 3 skipped, ruff clean.
- Original script under `notes/design-partners/` left intact.