### PR TITLE
chore: bump v1.18.2 (regression tests + docs sync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ Minor: worker-death / stream-loss signal — reclaim requires affirmative death 
 - `reclaim_requires_death_signal` and `presumed_dead_after` wired through `ledger()` / `ledger_sync()` decorators and `config.py` `_ledger_timing_kwargs()`.
 - 26 tests in `tests/test_worker_death_signal.py` covering field serialization, `has_worker_death_evidence()`, gate behavior (on/off), `mark_worker_dead` with heartbeat guard and override, release strengthening, `presumed_dead_after` defaults, claim-path gating (read-only RECLAIM, side-effecting ALLOW), heartbeat maintenance on claim/renew, Redis TTL floor, and CLI mark-dead + release round-trip.
 
-## Unreleased
+## 1.18.2 (2026-07-30)
 
-### Regression tests from Mengchheang's public repro
+Patch: regression tests from Mengchheang's public repro (no code changes).
+
+### Tests
 
 - Ported the three probes from `notes/design-partners/mycelium_1_16_0_public_repro.py`
   into `tests/test_mengchheang_public_repro.py`:
@@ -30,6 +32,9 @@ Minor: worker-death / stream-loss signal — reclaim requires affirmative death 
      to see the same stale value; `_try_reclaim` (WATCH/MULTI) gives at most
      one `"claimed"`.
 - Pre-1.18.1 bug baselines preserved in module docstring.
+
+### Docs
+
 - Identity-conflict note added to `sdk/README.md` transition-key docs.
 
 ### NOT\_EXECUTED CAS-loss path polls instead of hard-blocking

--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ pip install 'mycelium-runtime[redis]'      # multi-worker / cloud ledger
 pip install 'mycelium-runtime[postgres]'   # Postgres ledger backend
 mycelium demo --slow       # feature tour, paced for screen recording
 mycelium demo              # same tour, fast
+mycelium demo --redis      # optional Cloud-style two-worker Redis proof (#7417)
 mycelium init              # on-ramp: transition + one ledgered tool → mycelium.yaml
 mycelium init --full       # reference: all guards (fill TODOs; not the default)
 mycelium init --minimal    # smaller multi-guard scaffold
 ```
+
+`mycelium demo --redis` runs two OS processes against a real Redis ledger — Worker B redispatches while A is in-flight; B polls and returns A's result. Needs Redis (`MYCELIUM_TEST_REDIS_URL` or `redis://127.0.0.1:6379/15`) and `pip install 'mycelium-runtime[redis]'`.
 
 `mycelium init` is the real start path (duplicate-tool fix). Use `--full` when you want every section documented in one file.
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.18.0)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.18.0** (atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
+Current package: **mycelium-runtime v1.18.2** (atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
 
 ## One painful bug → a few lines of config
 
@@ -808,7 +808,7 @@ Legacy per-tool style still works. Start with `mycelium init`; use `mycelium ini
 
 ---
 
-## Atomicity contract (v1.18.0)
+## Atomicity contract (v1.18+)
 
 **Problem:** Two workers claim the same transition. Worker A completes. Worker B's stale `IN_FLIGHT` entry resolves later and silently overwrites A's `COMPLETED` result with a `FAILED_*` outcome. The operation's terminal state is lost.
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.18.1"
+version = "1.18.2"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",


### PR DESCRIPTION
Bumps pyproject.toml to 1.18.2 and releases the changes from PR #45 under the 1.18.2 header.

- Tests: Mengchheang's three public-repro probes as regression tests
- Docs: identity-conflict note in README, version badge bumped to v1.18.2
- Full suite: 499 passed, 3 skipped, ruff clean
- No code changes to the runtime library