### PR TITLE
feat: fail-closed Gmail sent-log reconciler (v1.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.19.0 (2026-07-30)
+
+Minor: fail-closed Gmail sent-log reconciler (design-partner patch from Shadow / agent-contracts).
+
+### Features
+
+- New `GmailReconciler(service)` — read-only reconciler that queries the Gmail
+  API sent-log by RFC 2822 Message-ID to resolve ambiguous email-send transitions.
+  Injected ``service`` is duck-typed (no hard google dep); behavior: missing ref →
+  `UNKNOWN`, 1 match → `COMPLETED` + provider receipt, 0 matches → `UNKNOWN`
+  (indexing lag, never `NOT_EXECUTED`), 2+ matches → `UNKNOWN`, API error →
+  propagate (fail-closed).
+- New provider sub-package `mycelium/providers/` — home for first-party
+  reconcilers (`GmailReconciler`) with room for more providers.
+- Exported from package root: `from mycelium import GmailReconciler`.
+
+### Docs
+
+- `sdk/README.md`: worked example of Gmail sent-log reconciliation under the
+  Reconciler section, next to the existing Stripe example.
+
+### Tests
+
+- `tests/test_gmail_reconciler.py`: 6 tests covering missing/empty ref, 0/1/2+
+  matches, and API error propagation — all using a fake Gmail API service.
+
 ## 1.16.0 (2026-07-27)
 
 Minor: worker-death / stream-loss signal — reclaim requires affirmative death evidence when opted in.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -483,6 +483,36 @@ def send_payment(amount, recipient):
 
 Reconciliation is **fail-closed**: no ref, no reconciler, or a reconciler that raises/times out all resolve to a hard-block — an exception in the reconciler never propagates. Async tools can implement `reconcile_async`; the async claim path prefers it and falls back to `reconcile`. Wire a reconciler via `@ledger` / `@ledger_sync` or `ActionLedger(reconciler=...)`.
 
+#### Gmail sent-log reconciler (`GmailReconciler`)
+
+Email send tools often fail after the provider accepts the message but before the 250 OK reaches the agent. The ambiguous transition hard-blocks. A `GmailReconciler` resolves them automatically by checking the Gmail sent-log:
+
+```python
+from mycelium import ledger_sync, GmailReconciler, ReconcileResult
+
+reconciler = GmailReconciler(service=gmail_client)  # duck-typed Gmail API
+
+@ledger_sync(transition_binding=binding, reconciler=reconciler)
+def send_email(to, subject, body):
+    message_id = str(uuid4())  # RFC 2822 Message-ID generated before transport
+    with side_effect():
+        record_external_operation(message_id)
+        mime_msg = build_mime(to, subject, body, message_id)
+        smtp.sendmail(from_addr, to, mime_msg.as_string())
+    return {"message_id": message_id}
+```
+
+The reconciler queries `users.messages.list(q='in:sent rfc822msgid:<Message-ID>')`:
+
+| Matches | Result | Reasoning |
+|---------|--------|-----------|
+| 1 | `COMPLETED` | message landed; return the Gmail message object |
+| 0 | `UNKNOWN` | indexing lag — never authorizes blind retry (`NOT_EXECUTED`) |
+| 2+ | `UNKNOWN` | duplicate may already have occurred |
+| missing ref | `UNKNOWN` | no query made |
+
+Like all reconcilers, `GmailReconciler` is strict about indexing lag: zero matches means "not yet visible," not "never sent." The transition stays hard-blocked so an operator releases it when the provider confirms.
+
 ### Stale lease + reconcile (`EXPIRED + not_crossed`)
 
 When a worker dies or a lease expires while a side-effecting tool is still `IN_FLIGHT`, the transition becomes `EXPIRED`. Resolution depends on boundary and class:

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -47,6 +47,7 @@ from mycelium.config import (
 from mycelium.history_guard import HistoryGuard, HistoryTruncatedError
 from mycelium.message_validator import MessageValidationError, MessageValidator
 from mycelium.protect import protect, protect_sync
+from mycelium.providers import GmailReconciler
 from mycelium.reconcile import Reconciler, ReconcileResult, ReconcileStatus
 from mycelium.session import Session
 from mycelium.state_flush import (
@@ -124,6 +125,7 @@ __all__ = [
     "OPERATOR_RESOLUTION_NOT_EXECUTED",
     "UNCLASSIFIED_POLICY_WARN",
     "UNCLASSIFIED_POLICY_STRICT",
+    "GmailReconciler",
     "get_ledger",
     "ledger",
     "ledger_sync",

--- a/sdk/mycelium/providers/__init__.py
+++ b/sdk/mycelium/providers/__init__.py
@@ -1,0 +1,3 @@
+from mycelium.providers.gmail import GmailReconciler
+
+__all__ = ["GmailReconciler"]

--- a/sdk/mycelium/providers/gmail.py
+++ b/sdk/mycelium/providers/gmail.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from mycelium.reconcile import ReconcileResult
+
+if TYPE_CHECKING:
+    from mycelium.action_ledger import LedgerEntry
+
+
+class GmailReconciler:
+    """Fail-closed reconciler for Gmail sent-email operations.
+
+    Injected ``service`` must expose a ``users().messages().list(userId='me',
+    q=...).execute()`` interface compatible with the Google Gmail API client
+    (duck-typed; no hard google dep).
+
+    Reconciliation is read-only — never sends, never retries.
+    """
+
+    def __init__(self, service: Any) -> None:
+        self._service = service
+
+    def reconcile(self, entry: LedgerEntry) -> ReconcileResult:
+        ref = entry.external_operation_ref
+        if not ref:
+            return ReconcileResult.unknown()
+
+        try:
+            result = (
+                self._service.users()
+                .messages()
+                .list(userId="me", q=f"in:sent rfc822msgid:{ref}")
+                .execute()
+            )
+        except Exception:
+            raise
+
+        messages = result.get("messages", [])
+        if len(messages) == 1:
+            return ReconcileResult.completed(messages[0])
+        return ReconcileResult.unknown()

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.18.2"
+version = "1.19.0"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",

--- a/sdk/tests/test_gmail_reconciler.py
+++ b/sdk/tests/test_gmail_reconciler.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mycelium.providers.gmail import GmailReconciler
+from mycelium.reconcile import ReconcileResult, ReconcileStatus
+
+
+@dataclass
+class FakeEntry:
+    external_operation_ref: str | None
+
+
+class FakeGmailService:
+    def __init__(self) -> None:
+        self._store: dict[str, list[dict[str, Any]]] = {}
+        self.list_called: list[str] = []
+
+    def _list(self, q: str) -> dict[str, Any]:
+        self.list_called.append(q)
+        msgs = self._store.get(q, [])
+        if not msgs:
+            return {"messages": [], "resultSizeEstimate": 0}
+        return {"messages": msgs, "resultSizeEstimate": len(msgs)}
+
+    def users(self) -> FakeGmailService:
+        return self
+
+    def messages(self) -> FakeGmailService:
+        return self
+
+    def list(self, userId: str = "me", q: str = "") -> FakeGmailService:
+        self._pending_q = q
+        return self
+
+    def execute(self) -> dict[str, Any]:
+        return self._list(self._pending_q)
+
+
+def test_missing_external_operation_ref_returns_unknown() -> None:
+    service = FakeGmailService()
+    reconciler = GmailReconciler(service)
+    entry = FakeEntry(external_operation_ref=None)
+    result = reconciler.reconcile(entry)
+    assert result == ReconcileResult.unknown()
+    assert service.list_called == []
+
+
+def test_empty_external_operation_ref_returns_unknown() -> None:
+    service = FakeGmailService()
+    reconciler = GmailReconciler(service)
+    entry = FakeEntry(external_operation_ref="")
+    result = reconciler.reconcile(entry)
+    assert result == ReconcileResult.unknown()
+    assert service.list_called == []
+
+
+def test_zero_matches_returns_unknown() -> None:
+    service = FakeGmailService()
+    service._store = {}
+    reconciler = GmailReconciler(service)
+    entry = FakeEntry(external_operation_ref="msg-123")
+    result = reconciler.reconcile(entry)
+    assert result == ReconcileResult.unknown()
+    assert service.list_called == ["in:sent rfc822msgid:msg-123"]
+
+
+def test_one_match_returns_completed() -> None:
+    service = FakeGmailService()
+    service._store = {"in:sent rfc822msgid:msg-1": [{"id": "18472", "threadId": "t-1"}]}
+    reconciler = GmailReconciler(service)
+    entry = FakeEntry(external_operation_ref="msg-1")
+    result = reconciler.reconcile(entry)
+    assert result.status == ReconcileStatus.COMPLETED
+    assert result.result == {"id": "18472", "threadId": "t-1"}
+    assert service.list_called == ["in:sent rfc822msgid:msg-1"]
+
+
+def test_two_matches_returns_unknown() -> None:
+    service = FakeGmailService()
+    service._store = {
+        "in:sent rfc822msgid:msg-2": [
+            {"id": "a", "threadId": "t-1"},
+            {"id": "b", "threadId": "t-2"},
+        ]
+    }
+    reconciler = GmailReconciler(service)
+    entry = FakeEntry(external_operation_ref="msg-2")
+    result = reconciler.reconcile(entry)
+    assert result == ReconcileResult.unknown()
+    assert service.list_called == ["in:sent rfc822msgid:msg-2"]
+
+
+def test_api_error_propagates() -> None:
+    class _BrokenService:
+        def users(self) -> _BrokenService:
+            return self
+
+        def messages(self) -> _BrokenService:
+            return self
+
+        def list(self, userId: str = "me", q: str = "") -> _BrokenService:
+            return self
+
+        def execute(self) -> dict[str, Any]:
+            raise RuntimeError("Gmail API unavailable")
+
+    service = _BrokenService()
+    reconciler = GmailReconciler(service)
+    entry = FakeEntry(external_operation_ref="msg-3")
+    import pytest
+
+    with pytest.raises(RuntimeError, match="Gmail API unavailable"):
+        reconciler.reconcile(entry)


### PR DESCRIPTION
## Summary

New `GmailReconciler` — read-only reconciler that queries the Gmail API sent-log by RFC 2822 Message-ID to resolve ambiguous email-send transitions. This is the design-partner patch from Shadow / agent-contracts (Mail 7), accepted with test and docs fixes.

## Changes

- **`mycelium/providers/`** — new sub-package for first-party reconcilers. Contains `gmail.py` with `GmailReconciler(service)` (duck-typed Gmail API client).
- **Behavior:** missing ref → `UNKNOWN`, 1 match → `COMPLETED` + provider receipt, 0 matches → `UNKNOWN` (indexing lag, never `NOT_EXECUTED`), 2+ matches → `UNKNOWN`, API error → propagate (fail-closed).
- **Export:** `from mycelium import GmailReconciler`.
- **Tests:** 6 tests in `tests/test_gmail_reconciler.py` using a fake Gmail API service — covers missing/empty ref, 0/1/2+ matches, and API error propagation.
- **Docs:** worked example in `sdk/README.md` under the Reconciler section, adjacent to the existing Stripe example.
- **Version:** bumped to 1.19.0 (minor: new reconciler, no breaking changes).

## Related

Closes the 7-day design-partner patch request from Shadow (agent-contracts). See `notes/design-partners/shadow-agent-contracts.md` for context.