### PR TITLE
docs: release authority honesty (Igor's seam)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Docs
+
+- Document release authority honesty: ``--by`` is audit-only; backend write access
+  is the real privilege. Expanded the one-line warning into a dedicated subsection
+  under the operator runbook covering release, mark-dead, and the Python API.
+  No authentication hook shipped — governance is a separate layer (per
+  Igor/ThumbGate seam).
+
 ## 1.19.0 (2026-07-30)
 
 Minor: fail-closed Gmail sent-log reconciler (design-partner patch from Shadow / agent-contracts).

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -606,9 +606,54 @@ ledger.release(request_id, verified="not_executed",
                by="ops@example.com", reason="provider shows no charge")
 ```
 
-> **Warning: backend access = release authority.** Anyone who can write to the ledger backend can release transitions — `--by` is an audit stamp, not authentication. Protect Redis/Postgres/file access like you protect production credentials, and prefer signed audit receipts (`audit_receipt:`) so releases are tamper-evident.
+### Release authority (what Mycelium does not authenticate)
 
-**4. (When `reclaim_requires_death_signal: true`) Assert worker death:**
+Mycelium records *what* happened and *who* said so, but it does not verify
+*whether that who is allowed to say so*. This is a deliberate seam, called out by
+our design partner Igor (ThumbGate): Mycelium owns durable execution truth;
+governance and authentication belong in a separate layer.
+
+**Anyone who can write to the ledger backend or call the CLI / Python API can
+settle a stuck transition.** There is no login, SSO, RBAC, or proof of identity
+under the hood:
+
+| Privilege | What it lets you do |
+|-----------|---------------------|
+| Backend write access (Redis/Postgres/file) | Release any transition, mark any worker dead, or write directly to storage |
+| `mycelium transitions release` | Record a human verification that settles a hard-blocked transition |
+| `mycelium transitions mark-dead` | Assert a worker is dead so reclaim can proceed |
+| `ActionLedger.release()` / `mark_worker_dead_for()` | Same operations via the Python API |
+
+The ``--by`` / ``by=`` argument is an **audit stamp** recorded on the entry
+so operators can answer *who recorded this decision?* after the fact. It is not
+a login, a signature, or an identity-provider assertion:
+
+```bash
+# --by records WHO said so, not PROOF that they are allowed to.
+mycelium transitions release <request_id> --verified completed \
+  --by ops@example.com --reason "confirmed in Stripe dashboard"
+```
+
+The same applies to ``mark-dead``: ``--by`` identifies the operator who asserted
+death, and the heartbeat/liveness check is a **safety guard** (prevents claiming
+a transition from a worker that may still be alive), not an authentication gate.
+
+**Practical guidance for production deployments:**
+
+1. **Protect backend credentials like production secrets.** Anyone with the Redis
+   URL, Postgres DSN, or file path can release transitions. Store them in a
+   secret manager, restrict network access, and audit access logs.
+2. **Enable signed audit receipts** (``audit_receipt:`` in YAML or pass an
+   ``AuditReceiptEmitter`` to ``ActionLedger``) so every release and death
+   assertion is tamper-evident. This does not prevent unauthorized releases,
+   but it makes them detectable.
+3. **If you need real allow/deny — put it outside Mycelium.** A gateway, IAM
+   policy, or proxy that gates access to the backend is the right layer. An
+   optional pluggable authorization hook on ``release`` / ``mark-dead`` /
+   ``reconcile`` has been discussed but is **not yet shipped**. Open a
+   GitHub issue if this gap blocks your deployment.
+
+### Assert worker death (`reclaim_requires_death_signal: true`)
 
 When the death-signal gate is on, EXPIRED entries cannot be reclaimed or released until the operator asserts the worker is dead. This prevents reclaiming a transition from a worker that is merely paused (GC, storage partition, failing auto-renew).
 


### PR DESCRIPTION
## Summary

Document that backend write access is the real privilege — `--by` is an audit stamp only, not authentication. This is the seam Igor (ThumbGate) called out in his design-partner review.

## Changes

- **`sdk/README.md`**: Replaced the one-line warning with a dedicated **Release authority** subsection under the operator runbook (after the Python release example, before the mark-dead section).
  - States plainly: anyone who can write the backend or run CLI/Python API can settle transitions.
  - `--by` / `by=` is an audit stamp, not login/SSO/RBAC.
  - `mark-dead` same: death assertion is an operator claim; liveness check is a safety guard, not authentication.
  - Practical guidance: protect backend creds, enable signed audit receipts, gate outside Mycelium if you need real allow/deny.
  - Explicit: no pluggable authorization hook shipped ("not yet — open an issue if this gap blocks you").
- **`CHANGELOG.md`**: Added `## Unreleased` with docs note.

## Out of scope

No `authorization_hook` / protocol / callback on `release` / `mark-dead` / `reconcile`. No ThumbGate integration. No new dependencies. No version bump. No tests changed (505/505, 3 skipped, ruff clean).