### PR TITLE
docs: identity-conflict semantics (Mengchheang probe 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Docs
+
+- Identity semantics documented: transition key compounds scope + tool + args
+  + class + policy (not `request_id` alone). Same `request_id` + changed args
+  = new transition (intentional). Opt-in identity-conflict rejection mode
+  discussed but not shipped. (Mengchheang probe 1 / `dp-identity-conflict`
+  closed as decided + documented.)
+
 ## 1.19.0 (2026-07-30)
 
 Minor: fail-closed Gmail sent-log reconciler (design-partner patch from Shadow / agent-contracts).

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -308,10 +308,43 @@ async def send_payment(amount: float, recipient: str) -> dict:
 ## What `@ledger` / `ledger_sync` do
 
 - Record every tool invocation in a durable `ActionLedger`
-- Deduplicate retries and redispatches via a rich **transition key** (scope + tool + args + `side_effect_class` + policy), not only `tool_call_id`  
-  Same caller `request_id` with different args → **different** transition key (by design — `request_id` alone is not an identity-conflict guard; see `test_mengchheang_public_repro.py::test_semantic_identity`).
+- Deduplicate retries and redispatches via a rich **transition key** (scope + tool + args + `side_effect_class` + policy), not only `tool_call_id`
 - Resolve redispatches through **gates** (see [Resolution gates](#resolution-gates)) instead of re-running blindly
 - Persist failed attempts with **terminal outcomes** (`FAILED_BEFORE_EFFECT`, `FAILED_AFTER_EFFECT`, `UNKNOWN`, `EXPIRED`, etc.) for audit and reconciliation
+
+### Transition identity and the `request_id` caveat
+
+The transition key is a compound of runtime scope + tool name + canonicalised
+args + `side_effect_class` + policy version — not `request_id` alone (or
+`tool_call_id` alone):
+
+| Inputs | → | Transition key |
+|--------|---|----------------|
+| Same `request_id` + same args | → | Same key — deduplicated, replayed, or polled as usual |
+| Same `request_id` + **changed** args | → | **Different** key — the tool may execute again |
+
+This is **intentional**: `request_id` records *which dispatch ticket* the
+framework sent; it does not mean *what the tool is supposed to do*. Two
+dispatches with the same ticket but different instructions are different
+operations, not a conflict.
+
+Some systems reject "same ticket, different meaning" as an identity conflict
+(see our design partner Mengchheang Long's continuity harness). Mycelium does
+**not** — not yet. An opt-in identity-conflict rejection mode (same
+`request_id`, different args → reject) has been discussed but is **not
+shipped**. If this gap matters for your deployment, open a GitHub issue.
+
+The current contract is pinned in
+`tests/test_mengchheang_public_repro.py::test_semantic_identity`:
+
+```python
+kwargs_a = {"amount": 10, "request_id": "intent-1"}
+kwargs_b = {"amount": 11, "request_id": "intent-1"}
+key_a = derive_transition_key_for_call("charge", (), kwargs_a, _BINDING)
+key_b = derive_transition_key_for_call("charge", (), kwargs_b, _BINDING)
+assert key_a != key_b       # changed args → different key
+assert executions == [10, 11]  # both calls execute
+```
 
 ### Resolution gates
 


### PR DESCRIPTION
## Summary

Close identity-conflict decision (Mengchheang probe 1) — docs only, retain current default.

Current behavior stays default: same caller `request_id` + different args → new transition key → may execute again. `request_id` alone is not an identity-conflict mechanism. Optional opt-in conflict-reject mode discussed but not shipped.

## Changes

- **`sdk/README.md`**: Replaced the one-line note with a dedicated **Transition identity and the `request_id` caveat** subsection under `## What @ledger / ledger_sync do` (between the bullet list and Resolution gates). States the three bullets: transition key = compound identity; same `request_id` + same args → dedupe; same `request_id` + changed args → new transition. Points at the pinned test.
- **`CHANGELOG.md`**: `## Unreleased` docs bullet.
- **Partner note** (`notes/design-partners/mengchheang-continuity.md`) updated locally — `dp-identity-conflict` marked decided + documented; cannot be committed (`notes/` is gitignored).

## Out of scope

No gate, no API flag, no code change, no default change. Version unchanged at 1.19.0.

505 passed, 3 skipped, ruff clean.