### PR TITLE
feat: mycelium demo DX pass (ASCII-safe, visible HARD_BLOCK, clear labels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### CLI
+
+- `mycelium demo` demo-DX pass (design-partner feedback from Akash /
+  Thskyshield):
+  - ASCII-safe output: em dashes / arrows removed and every print routed
+    through an ASCII-safe writer, so the tour no longer crashes on Windows
+    consoles (cp1252).
+  - New explicit HARD_BLOCK section: an ambiguous mutating transition is
+    redispatched and the tour visibly shows `LedgerHardBlockError` + the
+    `HARD_BLOCK` gate (the product moment) before the operator-release step.
+  - Disambiguated metric labels: "Unguarded executions" (bug) vs "Ledgered
+    executions" vs "Tool body executions" so identical counts no longer read
+    as the same thing.
+  - Single-process story: the default tour now states it runs one process on
+    an in-memory ledger and points to `mycelium demo --redis` for the
+    two-worker cross-process proof (Redis not required for the default tour).
+
 ### Docs
 
 - Identity semantics documented: transition key compounds scope + tool + args

--- a/docs/index.html
+++ b/docs/index.html
@@ -466,7 +466,7 @@ pip install 'mycelium-runtime[postgres]'
 mycelium init              # on-ramp (transition + one ledgered tool)
 mycelium init --full       # reference: all guards (fill TODOs; not default)
 mycelium init --minimal    # smaller multi-guard scaffold
-mycelium demo              # feature tour: without/with Mycelium + gates / release
+mycelium demo              # feature tour: unguarded vs ledgered + gates / hard-block / release
 mycelium demo --redis      # optional Cloud-style 2-worker Redis proof
 mycelium run --config mycelium.yaml -- python -m my_agent</pre>
       <p>

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -17,7 +17,7 @@ On LangGraph Cloud, long tool calls can be redispatched on the order of **~180s*
 pip install 'mycelium-runtime[langgraph]'  # Python 3.10+; automatic runtime IDs
 mycelium init                  # on-ramp scaffold (transition + one ledgered tool)
 mycelium init --full           # reference scaffold (all guards; fill TODOs)
-mycelium demo                  # feature tour (envelope, lease, repair, reconcile, release)
+mycelium demo                  # feature tour (envelope, lease, hard-block, repair, reconcile, release)
 mycelium demo --redis          # optional 2-worker Redis proof
 ```
 
@@ -69,7 +69,7 @@ pip install 'mycelium-runtime[langgraph]'  # optional automatic LangGraph IDs
 mycelium init              # on-ramp: duplicate-tool fix → ./mycelium.yaml
 mycelium init --full       # reference: every guard section (not the default)
 mycelium init --minimal    # smaller multi-guard scaffold
-mycelium demo              # feature tour: without/with Mycelium + gates / release
+mycelium demo              # feature tour: unguarded vs ledgered + gates / hard-block / release
 mycelium demo --redis      # optional Cloud-style 2-worker Redis proof
 ```
 

--- a/sdk/mycelium/proofs/feature_demo.py
+++ b/sdk/mycelium/proofs/feature_demo.py
@@ -226,8 +226,48 @@ def prove_read_unknown_safe_retry() -> dict[str, Any]:
     return {"executions": attempts["count"], "class": "read"}
 
 
+def prove_hard_block() -> dict[str, Any]:
+    """Ambiguous mutate cannot re-execute: redispatch raises LedgerHardBlockError."""
+    storage = InMemoryLedgerStorage()
+    binding = _mutate_binding(agent_id="hardblock-demo")
+    calls: list[float] = []
+
+    @ledger_sync(storage=storage, transition_binding=binding)
+    def charge(amount: float) -> dict[str, bool]:
+        calls.append(amount)
+        with side_effect():
+            record_external_operation("pi_hardblock_demo")
+            raise RuntimeError("provider timeout")
+
+    with execution_scope(_scope()):
+        try:
+            charge(amount=10.0, tool_call_id="hardblock_call")
+        except RuntimeError:
+            pass
+        entries = storage.list_all()
+        assert len(entries) == 1, f"expected one ledger entry after fail, got {entries!r}"
+        request_id = entries[0].request_id
+        try:
+            charge(amount=10.0, tool_call_id="hardblock_call")
+            raise AssertionError("expected LedgerHardBlockError on ambiguous redispatch")
+        except LedgerHardBlockError as exc:
+            message = str(exc)
+        final = storage.get(request_id)
+        assert final is not None
+
+    assert calls == [10.0], f"expected no re-exec after hard block, got {calls!r}"
+    assert final.resolved_terminal_outcome() == TerminalOutcome.UNKNOWN
+    return {
+        "executions": len(calls),
+        "gate": TransitionGate.HARD_BLOCK.value,
+        "raised": "LedgerHardBlockError",
+        "terminal_outcome": final.resolved_terminal_outcome().value,
+        "message": message,
+    }
+
+
 def prove_operator_release() -> dict[str, Any]:
-    """Hard-block after ambiguous mutate → operator release → one re-exec."""
+    """Hard-block after ambiguous mutate, operator release, one re-exec."""
     storage = InMemoryLedgerStorage()
     binding = _mutate_binding(agent_id="release-demo")
     calls: list[float] = []

--- a/sdk/mycelium/quickstart.py
+++ b/sdk/mycelium/quickstart.py
@@ -8,6 +8,7 @@ import time
 from typing import Any, Literal
 
 from mycelium.proofs.feature_demo import (
+    prove_hard_block,
     prove_lease_auto_renew,
     prove_operator_release,
     prove_read_unknown_safe_retry,
@@ -26,6 +27,17 @@ _SLOW_SECTION_PAUSE = 2.8
 _SLOW_EXEC_PAUSE = 1.2
 
 _SectionKind = Literal["danger", "ok", "info"]
+
+
+def _ascii_safe(text: Any) -> str:
+    """Render ``text`` so it cannot crash a non-UTF-8 console (e.g. Windows).
+
+    Windows consoles (cp1252) raise ``UnicodeEncodeError`` on characters like
+    em dashes or ``->`` arrows. Demo output is ASCII-only so the tour runs
+    identically everywhere; any unexpected non-ASCII is replaced rather than
+    crashing the demo.
+    """
+    return str(text).encode("ascii", errors="replace").decode("ascii")
 
 
 def _color_enabled(stream: Any = None) -> bool:
@@ -92,8 +104,11 @@ class _Pace:
         if self.slow and seconds > 0:
             time.sleep(seconds)
 
+    def _print(self, msg: str, *, file: Any = None) -> None:
+        print(_ascii_safe(msg), file=file, flush=True)
+
     def say(self, msg: str = "", *, pause: float | None = None) -> None:
-        print(msg, flush=True)
+        self._print(msg)
         if pause is None:
             pause = _SLOW_LINE_PAUSE if self.slow else 0.0
         self._pause(pause)
@@ -106,21 +121,21 @@ class _Pace:
 
     def section(self, title: str, *, kind: _SectionKind = "info") -> None:
         self._pause(_SLOW_SECTION_PAUSE if self.slow else 0.0)
-        print(flush=True)
+        self._print("")
         if kind == "danger":
             painted = self.style.bold_red(title)
         elif kind == "ok":
             painted = self.style.bold_green(title)
         else:
             painted = self.style.bold_cyan(title)
-        print(painted, flush=True)
-        print(self.style.dim("-" * len(title)), flush=True)
+        self._print(painted)
+        self._print(self.style.dim("-" * len(title)))
         self._pause(_SLOW_LINE_PAUSE if self.slow else 0.0)
 
     def execute(self, tool_name: str, record: dict[str, Any]) -> None:
         self._pause(_SLOW_EXEC_PAUSE if self.slow else 0.0)
         tag = self.style.bold_yellow("[EXECUTING]")
-        print(f"  {tag} {tool_name}({record!r})", flush=True)
+        self._print(f"  {tag} {tool_name}({record!r})")
         self._pause(_SLOW_LINE_PAUSE if self.slow else 0.0)
 
     def metric(self, label: str, value: Any, *, emphasize: bool = False) -> None:
@@ -128,19 +143,18 @@ class _Pace:
         self.say(f"{label}{painted}")
 
     def passed(self, msg: str) -> None:
-        print(f"{self.style.bold_green('PASS')}: {msg}", flush=True)
+        self._print(f"{self.style.bold_green('PASS')}: {msg}")
         self._pause((_SLOW_LINE_PAUSE + 0.6) if self.slow else 0.0)
 
     def bug(self, msg: str) -> None:
         """Highlight the intentional failure case (without Mycelium)."""
-        print(f"{self.style.bold_red('BUG')}: {msg}", flush=True)
+        self._print(f"{self.style.bold_red('BUG')}: {msg}")
         self._pause((_SLOW_LINE_PAUSE + 0.6) if self.slow else 0.0)
 
     def failed(self, msg: str) -> None:
-        print(
+        self._print(
             f"{self.style.bold_red('FAIL')}: {msg}",
             file=sys.stderr,
-            flush=True,
         )
 
 
@@ -157,14 +171,17 @@ def run_demo(*, redis: bool = False, slow: bool = False) -> int:
     pace = _Pace(slow=slow)
     fixture = load_fixture()
     scenario = fixture["scenario"]
-    total = 8 if redis else 7
+    total = 9 if redis else 8
 
     pace.title("Mycelium feature demo")
     pace.muted(
-        "Pitch: unified reliability at the tool boundary — "
+        "Pitch: unified reliability at the tool boundary - "
         "transition envelope, class-aware gates, lease, repair, "
         "reconcile, and operator release."
     )
+    pace.muted("This tour runs in ONE process (in-memory ledger). The real risk")
+    pace.muted("is cross-process redispatch: run `mycelium demo --redis` for the")
+    pace.muted("two-worker Cloud-style proof (requires Redis).")
     pace.muted(f"Fixture: {fixture['id']}")
     pace.muted(f"Source:  {fixture['source_url']}")
     pace.muted(f"Pattern: {fixture['pattern']}")
@@ -175,7 +192,7 @@ def run_demo(*, redis: bool = False, slow: bool = False) -> int:
         f"(runtime={scenario['runtime']!r}, no transition envelope)"
     )
     baseline = reproduce_baseline_duplicate(fixture, on_execute=pace.execute)
-    pace.metric("Executions: ", len(baseline), emphasize=True)
+    pace.metric("Unguarded executions: ", len(baseline), emphasize=True)
     if len(baseline) == 2:
         pace.bug("duplicate side effect reproduced (this is the bug)")
     else:
@@ -192,7 +209,7 @@ def run_demo(*, redis: bool = False, slow: bool = False) -> int:
     except AssertionError as exc:
         pace.failed(str(exc))
         return 1
-    pace.metric("Executions: ", len(result["executions"]), emphasize=True)
+    pace.metric("Ledgered executions: ", len(result["executions"]), emphasize=True)
     pace.say(f"r1 == r2:   {result['r1'] == result['r2']}")
     pace.say(f"side_effect_class: {result['side_effect_class']}")
     pace.passed("redispatch resolved existing transition; side effect ran once")
@@ -216,7 +233,7 @@ def run_demo(*, redis: bool = False, slow: bool = False) -> int:
     except AssertionError as exc:
         pace.failed(str(exc))
         return 1
-    pace.metric("Executions: ", repair["executions"], emphasize=True)
+    pace.metric("Tool body executions: ", repair["executions"], emphasize=True)
     pace.say(f"Repaired key present: {bool(repair['repaired_idempotency_key'])}")
     pace.passed("REPAIR healed the record; body did not run twice")
 
@@ -240,19 +257,33 @@ def run_demo(*, redis: bool = False, slow: bool = False) -> int:
         pace.failed(str(exc))
         return 1
     pace.say(f"side_effect_class: {read['class']}")
-    pace.metric("Executions after UNKNOWN: ", read["executions"], emphasize=True)
+    pace.metric("Tool body executions after UNKNOWN: ", read["executions"], emphasize=True)
     pace.passed("READ UNKNOWN re-executed once (safe by class)")
 
-    pace.section(f"[7/{total}] Operator release: unblock stuck mutate", kind="ok")
-    pace.say("Hard-block after ambiguous payment → human verifies not_executed →")
-    pace.say("exactly one re-execution, then RETURN.")
+    pace.section(f"[7/{total}] HARD_BLOCK: ambiguous mutate cannot re-execute", kind="danger")
+    pace.say("Payment accepted by provider, then timeout - outcome is ambiguous.")
+    pace.say("Redispatch must NOT run the side effect again: gate = HARD_BLOCK.")
+    try:
+        hardblock = prove_hard_block()
+    except AssertionError as exc:
+        pace.failed(str(exc))
+        return 1
+    pace.metric("Redispatch gate:     ", hardblock["gate"], emphasize=True)
+    pace.say(f"Raised:               {hardblock['raised']}")
+    pace.say(f"Terminal outcome:     {hardblock['terminal_outcome']}")
+    pace.metric("Tool body executions: ", hardblock["executions"], emphasize=True)
+    pace.passed("ambiguous mutate hard-blocked; no blind re-execution")
+
+    pace.section(f"[8/{total}] Operator release: unblock stuck mutate", kind="ok")
+    pace.say("Same hard-block recovered: operator verifies not_executed,")
+    pace.say("then exactly one re-execution, then RETURN.")
     try:
         release = prove_operator_release()
     except AssertionError as exc:
         pace.failed(str(exc))
         return 1
     pace.metric(
-        "Executions: ",
+        "Tool body executions: ",
         f"{release['executions']} (fail + one re-exec)",
         emphasize=True,
     )
@@ -268,7 +299,7 @@ def run_demo(*, redis: bool = False, slow: bool = False) -> int:
             resolve_redis_url,
         )
 
-        pace.section(f"[8/{total}] Cloud-style: 2 workers + real Redis", kind="ok")
+        pace.section(f"[9/{total}] Cloud-style: 2 workers + real Redis", kind="ok")
         url = resolve_redis_url()
         pace.say(f"Redis URL: {url} (override with {ENV_REDIS_URL})")
         if not redis_reachable(url):
@@ -280,7 +311,7 @@ def run_demo(*, redis: bool = False, slow: bool = False) -> int:
             pace.failed(str(exc))
             return 1
         pace.say(f"Workers:     {multi['workers']}")
-        pace.metric("Executions:  ", multi["executions"], emphasize=True)
+        pace.metric("Ledgered executions (2 workers): ", multi["executions"], emphasize=True)
         pace.say(f"request_id:  {multi['request_id']}")
         pace.passed("second worker polled; side effect ran once on shared Redis ledger")
 

--- a/sdk/tests/test_feature_demo.py
+++ b/sdk/tests/test_feature_demo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from mycelium.proofs.feature_demo import (
+    prove_hard_block,
     prove_lease_auto_renew,
     prove_operator_release,
     prove_read_unknown_safe_retry,
@@ -44,5 +45,22 @@ def test_prove_operator_release() -> None:
     assert result["final_outcome"] == "COMPLETED"
 
 
+def test_prove_hard_block() -> None:
+    result = prove_hard_block()
+    assert result["gate"] == "HARD_BLOCK"
+    assert result["raised"] == "LedgerHardBlockError"
+    assert result["terminal_outcome"] == "UNKNOWN"
+    assert result["executions"] == 1
+    assert "UNKNOWN" in result["message"]
+    assert "manual reconciliation required" in result["message"]
+
+
 def test_run_demo_exits_zero() -> None:
     assert run_demo(redis=False) == 0
+
+
+def test_run_demo_output_is_ascii_safe(capsys) -> None:
+    assert run_demo(redis=False) == 0
+    captured = capsys.readouterr()
+    for ch in captured.out:
+        assert ord(ch) < 128, f"non-ASCII demo output: {ch!r}"


### PR DESCRIPTION
## Summary

Demo-DX pass on `mycelium demo` from design-partner feedback (Akash / Thskyshield). Demo UX only — no ledger/reconcile semantics changed.

## Changes

**1. Windows Unicode crash (ASCII-safe output)**
- Removed em dashes / `->` arrows from printed demo text.
- Every print in `_Pace` now routes through an `_ascii_safe()` writer, so even unexpected provider data replaces non-ASCII instead of raising `UnicodeEncodeError` on cp1252 consoles.

**2. HARD_BLOCK visible**
- New explicit section `[7/N] HARD_BLOCK: ambiguous mutate cannot re-execute` — an ambiguous mutating transition is redispatched and the tour visibly shows `Redispatch gate: HARD_BLOCK`, `Raised: LedgerHardBlockError`, `Terminal outcome: UNKNOWN` before the operator-release step. New `prove_hard_block()` proof in `feature_demo.py`.

**3. Unambiguous metric labels**
- `Unguarded executions:` (the bug), `Ledgered executions:`, `Tool body executions:`, `Tool body executions after UNKNOWN:`, `Ledgered executions (2 workers):`.

**4. Single-process story**
- Default tour now opens by stating it runs one process on an in-memory ledger and points to `mycelium demo --redis` for the two-worker cross-process proof (Redis not required for the default tour).

**Docs:** `sdk/README.md` + `docs/index.html` demo blurbs updated; CHANGELOG Unreleased entry.

## Tests
- `test_prove_hard_block` (new), `test_run_demo_output_is_ascii_safe` (new).
- Full suite: 507 passed, 3 skipped. Ruff clean.

## Out of scope
No ledger/reconcile behavior change. No version bump.