### PR TITLE
docs+tests: payment-class identity guidance + Phase 4 reliability suite (v1.19.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ external verifiers, request_id identity semantics).
 
 ## Unreleased
 
+### Docs
+
+- Payment-class identity guidance in `sdk/README.md` (recommended production pattern): mint payment-class transition keys / provider keys from server-authoritative values, not raw client or LLM args; deterministic `provider_key = HMAC-SHA256(server_secret, action_id)` passed through `provider_idempotency_key_param`. Guidance only — no API or key-derivation change.
+
 ## 1.19.0 (2026-07-30)
 
 Minor: fail-closed Gmail sent-log reconciler (design-partner patch from Shadow / agent-contracts).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.19.2 (2026-07-31)
+
+Patch: Phase 4 reliability test suite (real-process multiprocess concurrency,
+SIGKILL crash-window, backend outages, property-based transition invariants,
+Stripe-shaped payment provider mock) + `hypothesis` dev dep + payment-class
+identity docs guidance.
+
+### Docs
+
+- Payment-class identity guidance in `sdk/README.md` (recommended production pattern): mint payment-class transition keys / provider keys from server-authoritative values, not raw client or LLM args; deterministic `provider_key = HMAC-SHA256(server_secret, action_id)` passed through `provider_idempotency_key_param`. Guidance only — no API or key-derivation change.
+
+### Tests
+
+- `tests/test_multiprocess_concurrency.py`: 3 real-`spawn`-process tests (file + Redis) — two workers contending for one transition key charge exactly once; crash-after-claim + `NOT_EXECUTED` reconciler reclaim grants exactly one re-execution; cross-process lease fencing.
+- `tests/test_process_kill_crash_window.py`: 4 tests that SIGKILL workers mid-tool-body and assert the crash window never double-executes (with and without a `NOT_EXECUTED` reconciler, across file and Redis storage).
+- `tests/test_outage_redis_postgres.py`: 11 fail-closed outage tests — Redis down at claim/complete/failure-recording, Postgres down via a stubbed `_require_psycopg` boundary (no psycopg dependency), mid-reconcile outage never re-executes or fabricates a COMPLETED.
+- `tests/test_property_transitions.py`: Hypothesis property test over the single-key state machine (file + fakeredis) — claim/complete/fail/crash/release/reconcile/stuck interleavings uphold `executions <= 1 + not_executed_verdicts`, COMPLETED is terminal with a stable result, and mutators CAS strictly out of IN_FLIGHT. Also asserts key-derivation soundness (identical redispatches dedupe, real args re-key, bookkeeping kwargs are excluded from the args fingerprint).
+- `tests/test_payment_provider_mock.py`: 10 tests against a read-only Stripe-shaped `Reconciler` + fake PaymentIntent store — `succeeded`→COMPLETED, `requires_payment_method`/`canceled`/missing→NOT_EXECUTED (exactly one re-charge), `processing`→HARD_BLOCK (never re-charges), operator release unblocks with one charge, reconciler never mutates provider state, and a 25-redispatch storm never double-charges.
+
 ## 1.19.1 (2026-07-31)
 
 Patch: `mycelium demo` demo-DX pass + docs alignment (field mapping for
@@ -38,10 +57,6 @@ external verifiers, request_id identity semantics).
   closed as decided + documented.)
 
 ## Unreleased
-
-### Docs
-
-- Payment-class identity guidance in `sdk/README.md` (recommended production pattern): mint payment-class transition keys / provider keys from server-authoritative values, not raw client or LLM args; deterministic `provider_key = HMAC-SHA256(server_secret, action_id)` passed through `provider_idempotency_key_param`. Guidance only — no API or key-derivation change.
 
 ## 1.19.0 (2026-07-30)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These aren't reasoning failures. They're runtime failures. Mycelium sits between
 - **Stale or broken context:** TTL-fresh tool data (`@protect`); optional message/history validation before the next LLM turn
 - **Bad tool calls:** block invalid inputs and out-of-scope tools before they run (`@bounded` / registry)
 
-Not Langfuse. Use both if you want traces and guards. Full resolution rules: [sdk/README.md](sdk/README.md#resolution-gates). Envelope field stack: [sdk/README.md](sdk/README.md#transition-envelope-fields).
+Not Langfuse. Use both if you want traces and guards. Full resolution rules: [sdk/README.md](sdk/README.md#resolution-gates). Envelope field stack: [sdk/README.md](sdk/README.md#transition-envelope-fields). Payment-class identity guidance: [sdk/README.md](sdk/README.md#payment-class-identity-server-authoritative).
 
 ## Use it
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.19.1)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.19.2)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -8,7 +8,7 @@
 
 Stops duplicate side effects on retry/redispatch, blocks bad tool args and out-of-scope calls, and keeps tool data fresh. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.19.1**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.19.2**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -382,7 +382,7 @@
 
     <h1>Mycelium: runtime guards for AI agents</h1>
     <p class="badges">
-      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.19.1" alt="PyPI version"></a>
+      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.19.2" alt="PyPI version"></a>
       <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/pyversions/mycelium-runtime.svg" alt="Python versions"></a>
       <a href="https://pepy.tech/project/mycelium-runtime"><img src="https://static.pepy.tech/badge/mycelium-runtime" alt="PyPI downloads"></a>
       <a href="https://github.com/mycelium-labs/mycelium"><img src="https://img.shields.io/github/license/mycelium-labs/mycelium.svg" alt="MIT license"></a>
@@ -396,7 +396,7 @@
       <strong>Opt-in:</strong> stale-context helpers and tool-boundary checks.
       YAML callable paths and <code>mycelium run</code> add the core path without
       editing each function. Framework-agnostic.
-      Early but API-stable (v1.19.1): breaking changes only at major versions.
+      Early but API-stable (v1.19.2): breaking changes only at major versions.
     </p>
 
     <section id="architecture">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -597,6 +597,32 @@ With it declared, on a retry of a transition that failed before the effect:
 
 The declared key is excluded from the transition-key fingerprint, so a retry that swaps the key still resolves to the *same* transition and is caught rather than silently starting a new one. This is **opt-in**: tools that don't declare the param keep the previous cooperative behavior.
 
+#### Payment-class identity (server-authoritative)
+
+Never mint payment-class transition keys or provider keys from **raw client or
+LLM args alone**. A caller that can tweak any arg re-mints a different key —
+and can dodge an in-flight lease to start a second side effect. Derive identity
+from **server-authoritative values** the caller cannot casually change: tenant,
+mandate / intent hash, amount, recipient, network, and similar fields your
+service controls.
+
+Changing a *real* payment field (actual amount, recipient, mandate) → a new
+transition is correct — it is a different operation. Tweaking fluff to escape
+the key is what this rule blocks. Mycelium's compound transition key (scope +
+tool + args + class + policy) does not, on its own, distinguish the two.
+
+Recommended deterministic provider-key pattern:
+
+```text
+provider_key = HMAC-SHA256(server_secret, action_id)
+```
+
+Same `action_id` on retry mints the same provider key; the secret never leaves
+your server. Pass the key through `provider_idempotency_key_param` so Mycelium
+enforces same-key retry. Mycelium enforces the *same key on retry* when
+configured; your application must mint **stable, server-side** keys. Keep no
+wall-clock in the identity — retries must reproduce the same key.
+
 ### Operator runbook: your agent hard-blocked
 
 When a side-effecting transition ends ambiguous (`BLOCKED` / `UNKNOWN` / `FAILED_AFTER_EFFECT`, or `EXPIRED` past the side-effect boundary) and no `Reconciler` can settle it, every redispatch raises `LedgerHardBlockError` forever. The release workflow is the recovery path: an operator verifies against the external provider what *actually* happened, records that verification, and the next agent redispatch consumes it. **Release is a recorded human verification, not an unblock** — and the CLI never executes tools itself.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.19.1)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.19.2)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.19.1** (fail-closed Gmail sent-log reconciler + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
+Current package: **mycelium-runtime v1.19.2** (fail-closed Gmail sent-log reconciler + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
 
 ## One painful bug → a few lines of config
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.19.1"
+version = "1.19.2"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",
@@ -50,6 +50,7 @@ dev = [
     "pytest-asyncio",
     "ruff",
     "fakeredis",
+    "hypothesis",
     "langgraph>=1.2.9",
 ]
 langgraph = [

--- a/sdk/tests/test_multiprocess_concurrency.py
+++ b/sdk/tests/test_multiprocess_concurrency.py
@@ -1,0 +1,441 @@
+"""Real OS-process concurrency tests (Phase 4 / multi-process concurrency).
+
+Threaded races already live in ``test_atomicity_contract.py`` and
+``test_proof_two_worker_redis.py``. These tests go one level further: they
+spawn real OS processes (``multiprocessing`` spawn context) that share a
+durable backend, so the cross-process file lock and Redis atomic claim paths
+are exercised, not just in-process locks.
+
+Scenarios covered:
+
+- A. Two processes, shared ``FileLedgerStorage``, same transition key on a
+  payment tool: exactly one tool-body execution; the loser polls or returns
+  the stored completed result.
+- B. Two processes racing to reclaim an expired ``IN_FLIGHT`` transition
+  (strict payment class) while a Reconciler proves ``NOT_EXECUTED``: at most
+  one re-execution, never two completed side effects for one logical payment.
+- C. Real Redis (skipped when unreachable): two processes start *nearly
+  together* (synchronized start) and contend for the same claim.
+
+All tests clean up child processes in ``finally``.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mycelium import (
+    ActionLedger,
+    FileLedgerStorage,
+    InMemoryLedgerStorage,
+    ReconcileResult,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+    ledger_sync,
+)
+from mycelium.proofs.langgraph_7417_redis import (
+    ENV_REDIS_URL,
+    redis_reachable,
+    resolve_redis_url,
+)
+
+_MP_CTX = mp.get_context("spawn")
+
+
+# ---------------------------------------------------------------------------
+# Cross-process helpers
+# ---------------------------------------------------------------------------
+
+
+def _append_count(path: str) -> None:
+    """Atomically record one tool-body execution (O_APPEND, line each)."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        os.write(fd, b"x\n")
+    finally:
+        os.close(fd)
+
+
+def _append_line(path: str, line: str) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        os.write(fd, line.encode("utf-8") + b"\n")
+    finally:
+        os.close(fd)
+
+
+def _read_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [line for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def _count_executions(path: Path) -> int:
+    return len(_read_lines(path))
+
+
+def _payment_binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="mp",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario A: contested claim on a shared file ledger (decorator path)
+# ---------------------------------------------------------------------------
+
+
+def _contended_file_worker(payload: dict[str, Any]) -> None:
+    """Claim/execute/complete a payment tool via @ledger_sync; record outcome.
+
+    Both workers use the same ``tool_call_id`` so they derive the same
+    transition key. Exactly one may run the tool body; the other polls and
+    returns the stored result.
+    """
+    import json
+
+    from mycelium import FileLedgerStorage
+
+    storage = FileLedgerStorage(payload["ledger_path"])
+
+    @ledger_sync(
+        storage=storage,
+        transition_binding=_payment_binding(),
+        lease_ttl=float(payload["lease_ttl"]),
+        poll_interval=0.02,
+        poll_timeout=float(payload["poll_timeout"]),
+    )
+    def charge(amount: float) -> dict[str, Any]:
+        _append_count(payload["exec_file"])
+        return {"charged": True, "amount": str(amount)}
+
+    try:
+        with execution_scope(
+            TransitionScope(thread_id="t1", run_id="r1")
+        ):
+            result = charge(amount=10.0, tool_call_id=payload["tool_call_id"])
+        _append_line(payload["out_file"], json.dumps(result, default=str))
+    except Exception as exc:  # noqa: BLE001 — surface to parent
+        _append_line(payload["err_file"], f"{type(exc).__name__}: {exc}")
+
+
+def test_two_processes_file_ledger_single_execution(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "ledger.json"
+    exec_file = tmp_path / "executions.txt"
+    out_file = tmp_path / "out.txt"
+    err_file = tmp_path / "err.txt"
+    request_id = "mp_charge_contended"
+
+    payload = {
+        "ledger_path": str(ledger_path),
+        "exec_file": str(exec_file),
+        "out_file": str(out_file),
+        "err_file": str(err_file),
+        "tool_call_id": request_id,
+        "lease_ttl": 30.0,
+        "poll_timeout": 10.0,
+    }
+
+    procs = [
+        _MP_CTX.Process(target=_contended_file_worker, args=(payload,), name="mp-a"),
+        _MP_CTX.Process(target=_contended_file_worker, args=(payload,), name="mp-b"),
+    ]
+    try:
+        for proc in procs:
+            proc.start()
+        for proc in procs:
+            proc.join(timeout=20.0)
+        for proc in procs:
+            assert not proc.is_alive(), "worker process timed out"
+            assert proc.exitcode == 0, f"worker exit {proc.exitcode}"
+    finally:
+        for proc in procs:
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=2.0)
+
+    assert _read_lines(err_file) == [], _read_lines(err_file)
+    assert _count_executions(exec_file) == 1, "side effect must run exactly once"
+    results = _read_lines(out_file)
+    assert len(results) == 2, f"both workers should return: {results}"
+    assert results[0] == results[1], f"identical results expected: {results}"
+    assert json.loads(results[0]) == {"charged": True, "amount": "10.0"}
+
+
+# ---------------------------------------------------------------------------
+# Scenario B: racing reclaim on an expired IN_FLIGHT with a NOT_EXECUTED
+# reconciler (strict payment class)
+# ---------------------------------------------------------------------------
+
+
+class _NotExecutedReconciler:
+    """Reconciler that proves the effect never happened (read-only)."""
+
+    def reconcile(self, entry: Any) -> ReconcileResult:
+        return ReconcileResult.not_executed()
+
+
+def _reclaim_file_worker(payload: dict[str, Any]) -> None:
+    """Race to reclaim an expired payment transition via the claim path.
+
+    Both processes hit the HARD_BLOCK gate on the expired entry, reconcile
+    ``NOT_EXECUTED``, and race the CAS reset. Exactly one may run the tool.
+    """
+    import json
+
+    from mycelium import FileLedgerStorage
+
+    storage = FileLedgerStorage(payload["ledger_path"])
+    ledger = ActionLedger(
+        storage=storage,
+        reconciler=_NotExecutedReconciler(),
+        lease_ttl=float(payload["lease_ttl"]),
+        poll_interval=0.02,
+        poll_timeout=float(payload["poll_timeout"]),
+    )
+    request_id = payload["request_id"]
+    try:
+        entry = ledger.claim_side_effecting(
+            request_id,
+            "charge",
+            (),
+            {"amount": 10.0},
+            _payment_binding(),
+        )
+        outcome = entry.resolved_terminal_outcome()
+        if outcome == TerminalOutcome.COMPLETED:
+            _append_line(payload["out_file"], json.dumps({"cached": entry.result}))
+            return
+        if outcome == TerminalOutcome.IN_FLIGHT:
+            _append_count(payload["exec_file"])
+            ledger.complete(request_id, {"charged": True})
+            _append_line(payload["out_file"], json.dumps({"ran": True}))
+            return
+        _append_line(payload["err_file"], f"unexpected outcome {outcome.value}")
+    except Exception as exc:  # noqa: BLE001 — surface to parent
+        _append_line(payload["err_file"], f"{type(exc).__name__}: {exc}")
+
+
+def _seed_expired_payment(storage: InMemoryLedgerStorage, request_id: str) -> None:
+
+    from mycelium import LedgerEntry, SideEffectBoundary
+
+    entry = LedgerEntry(
+        request_id=request_id,
+        tool="charge",
+        args=[],
+        kwargs={"amount": 10.0},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        lease_until=time.time() - 1,
+        owner="dead-worker:1",
+        side_effect_boundary=SideEffectBoundary.NOT_CROSSED.value,
+        external_operation_ref="pi_expired_mp",
+        idempotency_key=request_id,
+    )
+    storage.set(entry)
+
+
+def test_two_processes_reclaim_expired_payment_single_reexec(tmp_path: Path) -> None:
+    """Two processes race reclaim of an expired IN_FLIGHT payment; at most one
+    re-executes when reconcile proves NOT_EXECUTED."""
+    ledger_path = tmp_path / "ledger.json"
+    exec_file = tmp_path / "executions.txt"
+    out_file = tmp_path / "out.txt"
+    err_file = tmp_path / "err.txt"
+    request_id = "mp_reclaim_expired"
+
+    # Seed the expired ambiguous transition before any worker starts.
+    seed_storage = FileLedgerStorage(ledger_path)
+    seed = InMemoryLedgerStorage()
+    _seed_expired_payment(seed, request_id)
+    for entry in seed.list_all():
+        seed_storage.set(entry)
+
+    payload = {
+        "ledger_path": str(ledger_path),
+        "exec_file": str(exec_file),
+        "out_file": str(out_file),
+        "err_file": str(err_file),
+        "request_id": request_id,
+        "lease_ttl": 30.0,
+        "poll_timeout": 10.0,
+    }
+
+    procs = [
+        _MP_CTX.Process(target=_reclaim_file_worker, args=(payload,), name="mp-reclaim-a"),
+        _MP_CTX.Process(target=_reclaim_file_worker, args=(payload,), name="mp-reclaim-b"),
+    ]
+    try:
+        for proc in procs:
+            proc.start()
+        for proc in procs:
+            proc.join(timeout=20.0)
+        for proc in procs:
+            assert not proc.is_alive(), "worker process timed out"
+            assert proc.exitcode == 0, f"worker exit {proc.exitcode}"
+    finally:
+        for proc in procs:
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=2.0)
+
+    assert _read_lines(err_file) == [], _read_lines(err_file)
+    assert _count_executions(exec_file) == 1, (
+        "at most one re-execution when reconcile proves NOT_EXECUTED"
+    )
+    results = _read_lines(out_file)
+    assert len(results) == 2, f"both workers should resolve: {results}"
+
+    # The logical payment never gets two completed side effects: one worker
+    # ran and completed, the other saw the completed result.
+    ran = [json.loads(line) for line in results]
+    completed_values = [r for r in ran if "ran" in r]
+    cached_values = [r for r in ran if "cached" in r]
+    assert len(completed_values) == 1, f"exactly one worker ran: {ran}"
+    assert len(cached_values) == 1, f"exactly one worker saw cached: {ran}"
+    assert cached_values[0]["cached"] == {"charged": True}
+
+    stored = FileLedgerStorage(ledger_path).get(request_id)
+    assert stored is not None
+    assert stored.resolved_terminal_outcome() == TerminalOutcome.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Scenario C: real Redis, two processes started nearly together
+# ---------------------------------------------------------------------------
+
+
+def _redis_contested_worker(payload: dict[str, Any]) -> None:
+    """Both workers synchronize on a ready counter, then race the claim."""
+    import json
+
+    import redis
+
+    from mycelium import (
+        RedisLedgerStorage,
+    )
+
+    url = payload["url"]
+    keys = payload["keys"]
+    client = redis.Redis.from_url(url, decode_responses=True)
+    try:
+        client.incr(keys["ready"])
+        deadline = time.time() + float(payload["ready_timeout"])
+        while int(client.get(keys["ready"]) or 0) < 2:
+            if time.time() >= deadline:
+                raise TimeoutError("peer worker never signaled ready")
+            time.sleep(0.02)
+
+        storage = RedisLedgerStorage(url, prefix=payload["prefix"], in_flight_ttl=3600.0)
+
+        @ledger_sync(
+            storage=storage,
+            transition_binding=_payment_binding(),
+            lease_ttl=float(payload["lease_ttl"]),
+            poll_interval=0.02,
+            poll_timeout=float(payload["poll_timeout"]),
+        )
+        def charge(amount: float) -> dict[str, Any]:
+            client.incr(keys["exec"])
+            return {"charged": True, "amount": str(amount)}
+
+        with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+            result = charge(amount=10.0, tool_call_id=payload["request_id"])
+        client.rpush(keys["results"], json.dumps(result, default=str))
+    except Exception as exc:  # noqa: BLE001 — surface to parent
+        client.set(keys["error"], f"{type(exc).__name__}: {exc}")
+    finally:
+        client.close()
+
+
+_REDIS_URL = resolve_redis_url()
+
+pytest.importorskip("redis")
+pytestmark = pytest.mark.skipif(
+    not redis_reachable(_REDIS_URL),
+    reason=(
+        f"real Redis required at {_REDIS_URL!r} "
+        f"(set {ENV_REDIS_URL} or start redis-server)"
+    ),
+)
+
+
+def test_two_processes_redis_contested_claim(tmp_path: Path) -> None:
+    """Both processes start together and contend for the same payment claim on
+    real Redis; exactly one tool-body execution, identical returned results."""
+    import redis
+
+    url = _REDIS_URL
+    run_id = f"mp_contested_{os.getpid()}_{int(time.time())}"
+    prefix = f"mycelium:proof:mp:{run_id}:ledger:"
+    keys = {
+        "ready": f"mycelium:proof:mp:{run_id}:ready",
+        "exec": f"mycelium:proof:mp:{run_id}:executions",
+        "results": f"mycelium:proof:mp:{run_id}:results",
+        "error": f"mycelium:proof:mp:{run_id}:error",
+    }
+    request_id = f"call_charge_mp_{run_id}"
+
+    client = redis.Redis.from_url(url, decode_responses=True)
+    try:
+        to_delete = [keys["ready"], keys["exec"], keys["results"], keys["error"]]
+        for key in client.scan_iter(match=f"{prefix}*"):
+            to_delete.append(key)
+        if to_delete:
+            client.delete(*to_delete)
+
+        payload = {
+            "url": url,
+            "keys": keys,
+            "prefix": prefix,
+            "request_id": request_id,
+            "lease_ttl": 30.0,
+            "poll_timeout": 10.0,
+            "ready_timeout": 5.0,
+        }
+        procs = [
+            _MP_CTX.Process(target=_redis_contested_worker, args=(payload,), name="mp-redis-a"),
+            _MP_CTX.Process(target=_redis_contested_worker, args=(payload,), name="mp-redis-b"),
+        ]
+        try:
+            for proc in procs:
+                proc.start()
+            for proc in procs:
+                proc.join(timeout=25.0)
+            for proc in procs:
+                assert not proc.is_alive(), "worker process timed out"
+                assert proc.exitcode == 0, f"worker exit {proc.exitcode}"
+        finally:
+            for proc in procs:
+                if proc.is_alive():
+                    proc.terminate()
+                    proc.join(timeout=2.0)
+
+        error = client.get(keys["error"])
+        assert not error, error
+        executions = int(client.get(keys["exec"]) or 0)
+        assert executions == 1, f"side effect must run exactly once, got {executions}"
+        results = client.lrange(keys["results"], 0, -1)
+        assert len(results) == 2, f"both workers should return: {results}"
+        assert results[0] == results[1], f"identical results expected: {results}"
+        assert json.loads(results[0]) == {"charged": True, "amount": "10.0"}
+    finally:
+        to_delete = [keys["ready"], keys["exec"], keys["results"], keys["error"]]
+        for key in client.scan_iter(match=f"{prefix}*"):
+            to_delete.append(key)
+        if to_delete:
+            client.delete(*to_delete)
+        client.close()

--- a/sdk/tests/test_outage_redis_postgres.py
+++ b/sdk/tests/test_outage_redis_postgres.py
@@ -1,0 +1,477 @@
+"""Backend outage tests (Phase 4 / outage): Redis and Postgres storage down.
+
+Mirrors the fail-closed contract in ``test_fail_closed_storage.py`` but
+exercised against the real Redis and Postgres storage backends:
+
+- claim during outage        -> ``LedgerStorageUnavailableError``; tool never runs
+- complete during outage     -> ``LedgerStorageUnavailableError``; entry stays
+  IN_FLIGHT (no phantom COMPLETED)
+- failure-recording during outage -> original tool exception surfaces unmasked
+- mid-reconcile outage       -> fail-closed: no re-execution, no phantom
+  COMPLETED, the ``LedgerStorageUnavailableError`` propagates
+
+Determinism / no external deps: Redis runs on ``fakeredis`` (exercises the real
+``RedisEntryStorage`` claim/transition code paths). Postgres is exercised with a
+broken client injected at the ``_require_psycopg`` boundary, so the suite needs
+neither a real Redis nor a real Postgres (psycopg is not installed by default).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from mycelium import (
+    ActionLedger,
+    InMemoryLedgerStorage,
+    LedgerEntry,
+    LedgerStorageUnavailableError,
+    ReconcileResult,
+    RedisLedgerStorage,
+    SideEffectBoundary,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+    ledger_sync,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="outage",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def _scope() -> TransitionScope:
+    return TransitionScope(thread_id="t1", run_id="r1")
+
+
+class _StubReconciler:
+    def __init__(self, result: ReconcileResult) -> None:
+        self._result = result
+        self.calls = 0
+
+    def reconcile(self, entry: LedgerEntry) -> ReconcileResult:
+        self.calls += 1
+        return self._result
+
+
+def _seed_ambiguous_payment(
+    storage: object,
+    tool_name: str,
+    *,
+    op_ref: str,
+    request_id: str | None = None,
+) -> str:
+    """Persist an expired, maybe-crossed, IN_FLIGHT entry for *tool_name* so a
+    redispatch under ``_scope()`` resolves HARD_BLOCK and reconciles.
+
+    Returns the request_id that a ``@ledger_sync`` dispatch derives (seeded
+    entries must use the same derived key to be seen by the gate).
+    """
+    with execution_scope(_scope()):
+        derived = ActionLedger(
+            storage=InMemoryLedgerStorage()
+        ).derive_request_id(
+            tool_name, (10.0,), {}, transition_binding=_binding()
+        )
+    rid = request_id or derived
+    storage.set(
+        LedgerEntry(
+            request_id=rid,
+            tool=tool_name,
+            args=[],
+            kwargs={"amount": 10},
+            status="in-flight",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+            lease_until=time.time() - 1,
+            side_effect_boundary=SideEffectBoundary.MAYBE_CROSSED.value,
+            external_operation_ref=op_ref,
+        )
+    )
+    return rid
+
+
+# ---------------------------------------------------------------------------
+# Redis outage
+# ---------------------------------------------------------------------------
+
+
+class FailingRedisStorage(RedisLedgerStorage):
+    """Real Redis storage (fakeredis-backed) with per-operation outage toggles."""
+
+    def __init__(self, url: str, *, prefix: str = "mycelium:outage:") -> None:
+        super().__init__(url, prefix=prefix)
+        self.fail_get = False
+        self.fail_set = False
+        self.fail_claim = False
+        self.fail_transition = False
+        self.fail_list_all = False
+
+    def get(self, request_id: str) -> LedgerEntry | None:
+        if self.fail_get:
+            raise ConnectionError("storage backend unreachable")
+        return super().get(request_id)
+
+    def set(self, entry: LedgerEntry) -> None:
+        if self.fail_set:
+            raise ConnectionError("storage backend unreachable")
+        super().set(entry)
+
+    def try_claim_inflight(
+        self,
+        entry: LedgerEntry,
+        *,
+        lease_ttl: float = 3600.0,
+    ) -> tuple[str, LedgerEntry | None]:
+        if self.fail_claim:
+            raise ConnectionError("storage backend unreachable")
+        return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+    def try_transition(
+        self,
+        entry: LedgerEntry,
+        *,
+        expected_terminal_outcomes: frozenset[str],
+        expected_owner: str | None = None,
+    ) -> bool:
+        if self.fail_transition:
+            raise ConnectionError("storage backend unreachable")
+        return super().try_transition(
+            entry,
+            expected_terminal_outcomes=expected_terminal_outcomes,
+            expected_owner=expected_owner,
+        )
+
+    def list_all(self) -> list[LedgerEntry]:
+        if self.fail_list_all:
+            raise ConnectionError("storage backend unreachable")
+        return super().list_all()
+
+
+class TestRedisOutage:
+    def _storage(self, monkeypatch: pytest.MonkeyPatch) -> FailingRedisStorage:
+        fakeredis = pytest.importorskip("fakeredis")
+        fake = fakeredis.FakeRedis(decode_responses=True)
+        import redis
+
+        monkeypatch.setattr(redis.Redis, "from_url", lambda url, **kw: fake)
+        return FailingRedisStorage("redis://outage", prefix="mycelium:outage:")
+
+    def test_claim_during_outage_raises_storage_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        storage = self._storage(monkeypatch)
+        ledger_inst = ActionLedger(storage=storage)
+        storage.fail_claim = True
+        with pytest.raises(LedgerStorageUnavailableError, match="try_claim_inflight"):
+            ledger_inst.claim_side_effecting(
+                "req-redis-claim", "send_payment", (), {"amount": 10}, _binding()
+            )
+
+    def test_tool_never_runs_on_storage_down_claim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        storage = self._storage(monkeypatch)
+        storage.fail_claim = True
+        called = False
+
+        @ledger_sync(storage=storage, transition_binding=_binding())
+        def send_payment(amount: float) -> dict[str, bool]:
+            nonlocal called
+            called = True
+            return {"ok": True}
+
+        with execution_scope(_scope()):
+            with pytest.raises(LedgerStorageUnavailableError):
+                send_payment(10.0)
+        assert not called
+
+    def test_complete_during_outage_keeps_inflight(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        storage = self._storage(monkeypatch)
+        ledger_inst = ActionLedger(storage=storage)
+        # Claim succeeds while the backend is up, then it goes down mid-flight.
+        ledger_inst.claim("req-redis-complete", "send_payment", (), {"amount": 10})
+        storage.fail_transition = True
+        with pytest.raises(LedgerStorageUnavailableError, match="try_transition"):
+            ledger_inst.complete("req-redis-complete", {"ok": True})
+        storage.fail_transition = False
+        stored = storage.get("req-redis-complete")
+        assert stored is not None
+        assert stored.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT
+
+    def test_failure_recording_outage_surfaces_original_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Storage down while recording a tool failure must not mask the tool's
+        own exception (it propagates, not the storage error)."""
+        storage = self._storage(monkeypatch)
+        storage.fail_transition = True
+
+        @ledger_sync(storage=storage, transition_binding=_binding())
+        def failing_tool(amount: float) -> dict[str, bool]:
+            raise ValueError("tool broke")
+
+        with execution_scope(_scope()):
+            with pytest.raises(ValueError, match="tool broke"):
+                failing_tool(10.0)
+
+    def test_mid_reconcile_storage_outage_fail_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reconciler says COMPLETED but the storage write of that result
+        fails: must raise LedgerStorageUnavailableError, not return a result,
+        and must NOT mark the entry COMPLETED (fail-closed, no phantom)."""
+        storage = self._storage(monkeypatch)
+        reconciler = _StubReconciler(
+            ReconcileResult.completed({"charged": True, "id": "pi_x"})
+        )
+        # Seed an expired, ambiguous transition so the redispatch gate is
+        # HARD_BLOCK -> reconcile, not a fresh claim that just runs the tool.
+        rid = _seed_ambiguous_payment(storage, "send_payment", op_ref="pi_x")
+
+        storage.fail_transition = True
+
+        @ledger_sync(storage=storage, transition_binding=_binding(), reconciler=reconciler)
+        def send_payment(amount: float) -> dict[str, bool]:
+            raise AssertionError("tool must not re-execute during outage")
+
+        with execution_scope(_scope()):
+            with pytest.raises(LedgerStorageUnavailableError, match="try_transition"):
+                send_payment(10.0)
+
+        assert reconciler.calls == 1, "reconciler should have been consulted"
+        # The reconcile write failed so the entry must NOT be a phantom
+        # COMPLETED: the durable stored outcome is still the pre-reconcile
+        # IN_FLIGHT (read-time resolution shows EXPIRED via the lapsed lease).
+        storage.fail_transition = False
+        stored = storage.get(rid)
+        assert stored is not None
+        assert stored.terminal_outcome == TerminalOutcome.IN_FLIGHT.value
+        assert not stored.is_terminal_completed()
+
+
+# ---------------------------------------------------------------------------
+# Postgres outage
+# ---------------------------------------------------------------------------
+
+
+class _StubSQL:
+    """Minimal stand-in for ``psycopg.sql`` used by the storage module."""
+
+    class _Compiled:
+        def __init__(self, text: str) -> None:
+            self._text = text
+
+        def format(self, *_args: object) -> str:
+            return self._text
+
+    @staticmethod
+    def SQL(text: str) -> _StubSQL._Compiled:
+        return _StubSQL._Compiled(text)
+
+    @staticmethod
+    def Identifier(name: str) -> str:
+        return name
+
+
+class _DownPsycopg:
+    """Fake ``psycopg`` module whose ``connect`` models a Postgres outage."""
+
+    @staticmethod
+    def connect(dsn: str) -> None:
+        raise ConnectionError("postgres down")
+
+
+class FailingPostgresStorage:
+    """Postgres-shaped storage whose operations fail on demand.
+
+    Construction exercises the real ``PostgresLedgerStorage.__init__`` path
+    (against a stubbed ``_require_psycopg``), while each operation either
+    delegates to an in-memory backing store or raises ``ConnectionError`` to
+    simulate a backend outage. This keeps the fail-closed contract tests
+    deterministic without a live Postgres.
+    """
+
+    def __init__(self) -> None:
+        from mycelium.storage.postgres_ledger import PostgresLedgerStorage
+
+        self._inner = PostgresLedgerStorage("postgresql://outage:5432/mycelium")
+        self._mem = InMemoryLedgerStorage()
+        self.fail_get = False
+        self.fail_set = False
+        self.fail_claim = False
+        self.fail_transition = False
+        self.fail_list_all = False
+
+    def get(self, request_id: str) -> LedgerEntry | None:
+        if self.fail_get:
+            raise ConnectionError("storage backend unreachable")
+        return self._mem.get(request_id)
+
+    def set(self, entry: LedgerEntry) -> None:
+        if self.fail_set:
+            raise ConnectionError("storage backend unreachable")
+        self._mem.set(entry)
+
+    def try_claim_inflight(
+        self,
+        entry: LedgerEntry,
+        *,
+        lease_ttl: float = 3600.0,
+    ) -> tuple[str, LedgerEntry | None]:
+        if self.fail_claim:
+            raise ConnectionError("storage backend unreachable")
+        return self._mem.try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+    def try_transition(
+        self,
+        entry: LedgerEntry,
+        *,
+        expected_terminal_outcomes: frozenset[str],
+        expected_owner: str | None = None,
+    ) -> bool:
+        if self.fail_transition:
+            raise ConnectionError("storage backend unreachable")
+        return self._mem.try_transition(
+            entry,
+            expected_terminal_outcomes=expected_terminal_outcomes,
+            expected_owner=expected_owner,
+        )
+
+    def list_all(self) -> list[LedgerEntry]:
+        if self.fail_list_all:
+            raise ConnectionError("storage backend unreachable")
+        return self._mem.list_all()
+
+
+@pytest.fixture
+def stub_psycopg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route ``_require_psycopg`` to the outage stub so Postgres storage can be
+    constructed without the (uninstalled) psycopg package."""
+    import mycelium.storage.postgres_ledger as pg_mod
+
+    monkeypatch.setattr(
+        pg_mod, "_require_psycopg", lambda: (_DownPsycopg(), _StubSQL())
+    )
+
+
+class TestPostgresOutage:
+    def test_claim_during_outage_raises_storage_unavailable(
+        self, stub_psycopg: None
+    ) -> None:
+        from mycelium import PostgresLedgerStorage
+
+        storage = PostgresLedgerStorage("postgresql://outage:5432/mycelium")
+        ledger_inst = ActionLedger(storage=storage)
+        with pytest.raises(
+            LedgerStorageUnavailableError, match=r"during (get|try_claim_inflight)"
+        ):
+            ledger_inst.claim_side_effecting(
+                "req-pg-claim", "send_payment", (), {"amount": 10}, _binding()
+            )
+
+    def test_tool_never_runs_on_storage_down_claim(self, stub_psycopg: None) -> None:
+        storage = FailingPostgresStorage()
+        storage.fail_claim = True
+        called = False
+
+        @ledger_sync(storage=storage, transition_binding=_binding())
+        def send_payment(amount: float) -> dict[str, bool]:
+            nonlocal called
+            called = True
+            return {"ok": True}
+
+        with execution_scope(_scope()):
+            with pytest.raises(LedgerStorageUnavailableError):
+                send_payment(10.0)
+        assert not called
+
+    def test_complete_during_outage_keeps_inflight(self, stub_psycopg: None) -> None:
+        storage = FailingPostgresStorage()
+        ledger_inst = ActionLedger(storage=storage)
+        ledger_inst.claim("req-pg-complete", "send_payment", (), {"amount": 10})
+        storage.fail_transition = True
+        with pytest.raises(LedgerStorageUnavailableError, match="try_transition"):
+            ledger_inst.complete("req-pg-complete", {"ok": True})
+        storage.fail_transition = False
+        stored = storage.get("req-pg-complete")
+        assert stored is not None
+        assert stored.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT
+
+    def test_failure_recording_outage_surfaces_original_exception(
+        self, stub_psycopg: None
+    ) -> None:
+        storage = FailingPostgresStorage()
+        storage.fail_transition = True
+
+        @ledger_sync(storage=storage, transition_binding=_binding())
+        def failing_tool(amount: float) -> dict[str, bool]:
+            raise ValueError("tool broke")
+
+        with execution_scope(_scope()):
+            with pytest.raises(ValueError, match="tool broke"):
+                failing_tool(10.0)
+
+    def test_mid_reconcile_storage_outage_fail_closed(
+        self, stub_psycopg: None
+    ) -> None:
+        storage = FailingPostgresStorage()
+        reconciler = _StubReconciler(
+            ReconcileResult.completed({"charged": True, "id": "pi_x"})
+        )
+        rid = _seed_ambiguous_payment(storage, "send_payment", op_ref="pi_x")
+
+        storage.fail_transition = True
+
+        @ledger_sync(storage=storage, transition_binding=_binding(), reconciler=reconciler)
+        def send_payment(amount: float) -> dict[str, bool]:
+            raise AssertionError("tool must not re-execute during outage")
+
+        with execution_scope(_scope()):
+            with pytest.raises(LedgerStorageUnavailableError, match="try_transition"):
+                send_payment(10.0)
+
+        assert reconciler.calls == 1
+        storage.fail_transition = False
+        stored = storage.get(rid)
+        assert stored is not None
+        assert stored.terminal_outcome == TerminalOutcome.IN_FLIGHT.value
+        assert not stored.is_terminal_completed()
+
+
+# ---------------------------------------------------------------------------
+# Old entries deserialize against a broken client (real Redis code path)
+# ---------------------------------------------------------------------------
+
+
+class TestRedisTransportFailure:
+    def test_real_redis_entry_path_wraps_connection_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ConnectionError raised by the Redis client (real storage code path)
+        is wrapped as LedgerStorageUnavailableError, never leaked raw."""
+        fakeredis = pytest.importorskip("fakeredis")
+        fake = fakeredis.FakeRedis(decode_responses=True)
+        fake.execute_command = MagicMock(side_effect=ConnectionError("redis down"))
+
+        import redis
+
+        monkeypatch.setattr(redis.Redis, "from_url", lambda url, **kw: fake)
+
+        storage = RedisLedgerStorage("redis://outage", prefix="mycelium:transport:")
+        ledger_inst = ActionLedger(storage=storage)
+        with pytest.raises(LedgerStorageUnavailableError):
+            ledger_inst.claim("req-transport", "send_payment", (), {})

--- a/sdk/tests/test_payment_provider_mock.py
+++ b/sdk/tests/test_payment_provider_mock.py
@@ -1,0 +1,406 @@
+"""Stripe-shaped payment provider mock (Phase 4 / provider reconciler).
+
+A read-only, Stripe-shaped ``Reconciler`` drives a fake PaymentIntent store.
+The store mirrors the real PaymentIntent lifecycle
+(``requires_payment_method`` -> ``processing`` -> ``succeeded``, or
+``canceled``), and the reconciler classifies each state fail-closed:
+
+- ``succeeded``           -> COMPLETED   (money moved; never re-run)
+- ``requires_payment_method`` / ``canceled`` / missing -> NOT_EXECUTED
+  (provably no money moved; exactly one re-execution is granted)
+- ``processing``          -> UNKNOWN     (outcome ambiguous; HARD_BLOCK,
+  no re-execution)
+
+Guarantees asserted across crash/retry scenarios:
+
+- a charge happens at most once per transition key — never more
+- the reconciler is strictly read-only (never creates or charges)
+- post-COMPLETED redispatches return the cached result without re-charging
+- the HARD_BLOCK path never re-executes, and an operator NOT_EXECUTED release
+  grants exactly one more charge
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import fakeredis
+import pytest
+import redis
+
+from mycelium import (
+    ActionLedger,
+    FileLedgerStorage,
+    InMemoryLedgerStorage,
+    LedgerEntry,
+    LedgerHardBlockError,
+    LedgerReleaseRefusedError,
+    ReconcileResult,
+    RedisLedgerStorage,
+    SideEffectBoundary,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+    get_ledger,
+    ledger_sync,
+    record_external_operation,
+    side_effect,
+)
+
+
+class _FakePaymentProvider:
+    """In-memory Stripe-shaped PaymentIntent store.
+
+    ``charges`` is the money-moved log: every successful ``charge()`` appends
+    the intent id.  The reconciler may only read via ``retrieve()``.
+    """
+
+    def __init__(self) -> None:
+        self._intents: dict[str, dict[str, object]] = {}
+        self._counter = 0
+        self.charges: list[str] = []
+        self.retrieve_calls = 0
+
+    def create(self, amount: float) -> str:
+        self._counter += 1
+        pid = f"pi_mock_{self._counter}"
+        self._intents[pid] = {
+            "id": pid,
+            "amount": amount,
+            "status": "requires_payment_method",
+        }
+        return pid
+
+    def retrieve(self, pid: str) -> dict[str, object] | None:
+        self.retrieve_calls += 1
+        intent = self._intents.get(pid)
+        return dict(intent) if intent is not None else None
+
+    def charge(self, pid: str) -> None:
+        intent = self._intents.get(pid)
+        if intent is None:
+            raise RuntimeError(f"unknown payment intent {pid!r}")
+        intent["status"] = "succeeded"
+        self.charges.append(pid)
+
+    def set_status(self, pid: str, status: str) -> None:
+        self._intents[pid]["status"] = status
+
+    def snapshot(self) -> str:
+        return json.dumps(self._intents, sort_keys=True)
+
+
+class _StripeReconciler:
+    """Read-only provider reconciler. Never mutates provider state."""
+
+    def __init__(self, provider: _FakePaymentProvider) -> None:
+        self._provider = provider
+
+    def reconcile(self, entry: LedgerEntry) -> ReconcileResult:
+        pid = entry.external_operation_ref
+        if not pid:
+            return ReconcileResult.unknown()
+        intent = self._provider.retrieve(pid)
+        if intent is None:
+            return ReconcileResult.not_executed()
+        status = intent["status"]
+        if status == "succeeded":
+            return ReconcileResult.completed({"charged": True, "payment_intent": pid})
+        if status == "processing":
+            return ReconcileResult.unknown()
+        return ReconcileResult.not_executed()
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="payments",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def _scope() -> TransitionScope:
+    return TransitionScope(thread_id="t1", run_id="r1")
+
+
+def _make_charge(provider, storage, reconciler=None):
+    @ledger_sync(
+        storage=storage,
+        transition_binding=_binding(),
+        reconciler=reconciler,
+    )
+    def charge(amount: float) -> dict:
+        pid = provider.create(amount)
+        record_external_operation(pid)
+        with side_effect():
+            provider.charge(pid)
+        return {"charged": True, "payment_intent": pid}
+
+    return charge
+
+
+def _request_id(ledger_inst: ActionLedger, kwargs: dict) -> str:
+    with execution_scope(_scope()):
+        return ledger_inst.derive_request_id(
+            "charge", (), kwargs, transition_binding=_binding()
+        )
+
+
+@pytest.fixture(params=["file", "redis"])
+def storage(request, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    if request.param == "file":
+        return FileLedgerStorage(tmp_path / "ledger.json")
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis.Redis, "from_url", lambda url, **kwargs: fake)
+    return RedisLedgerStorage("redis://test")
+
+
+def _seed_crashed_charge(
+    provider: _FakePaymentProvider,
+    storage,
+    *,
+    status: str,
+) -> tuple[str, str]:
+    """Persist an expired, maybe-crossed IN_FLIGHT entry whose provider intent
+    sits in *status* — the durable leftovers of a worker that died mid-charge.
+
+    Returns ``(request_id, payment_intent_id)``.
+    """
+    pid = provider.create(10.0)
+    if status != "requires_payment_method":
+        provider.set_status(pid, status)
+    with execution_scope(_scope()):
+        derived = ActionLedger(storage=InMemoryLedgerStorage()).derive_request_id(
+            "charge", (), {"amount": 10.0, "tool_call_id": "c1"},
+            transition_binding=_binding(),
+        )
+    storage.set(
+        LedgerEntry(
+            request_id=derived,
+            tool="charge",
+            args=[10.0],
+            kwargs={"amount": 10.0, "tool_call_id": "c1"},
+            status="in-flight",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+            lease_until=time.time() - 1,
+            side_effect_boundary=SideEffectBoundary.MAYBE_CROSSED.value,
+            external_operation_ref=pid,
+        )
+    )
+    return derived, pid
+
+
+def test_happy_path_charges_exactly_once(storage) -> None:
+    provider = _FakePaymentProvider()
+    charge = _make_charge(provider, storage)
+    ledger_inst = get_ledger(charge)
+    assert ledger_inst is not None
+
+    with execution_scope(_scope()):
+        result = charge(amount=10.0, tool_call_id="c1")
+        assert result["charged"] is True
+        again = charge(amount=10.0, tool_call_id="c1")
+        assert again == result
+
+    assert provider.charges == ["pi_mock_1"]
+    entry = ledger_inst.get(_request_id(ledger_inst, {"amount": 10.0, "tool_call_id": "c1"}))
+    assert entry is not None
+    assert entry.resolved_terminal_outcome() == TerminalOutcome.COMPLETED
+
+
+def test_redispatch_storm_never_double_charges(storage) -> None:
+    provider = _FakePaymentProvider()
+    charge = _make_charge(provider, storage)
+
+    for _ in range(25):
+        with execution_scope(_scope()):
+            result = charge(amount=10.0, tool_call_id="c1")
+            assert result["charged"] is True
+
+    assert provider.charges == ["pi_mock_1"]
+
+
+def test_reconcile_succeeded_marks_completed_without_recharge(storage) -> None:
+    provider = _FakePaymentProvider()
+    reconciler = _StripeReconciler(provider)
+    charge = _make_charge(provider, storage, reconciler=reconciler)
+    ledger_inst = get_ledger(charge)
+
+    # The charge actually happened before the worker died.
+    rid, pid = _seed_crashed_charge(provider, storage, status="succeeded")
+    provider.charges.append(pid)
+
+    with execution_scope(_scope()):
+        result = charge(amount=10.0, tool_call_id="c1")
+
+    assert result == {"charged": True, "payment_intent": pid}
+    assert provider.charges == [pid], "reconcile COMPLETED must never re-charge"
+    entry = ledger_inst.get(rid)
+    assert entry is not None
+    assert entry.resolved_terminal_outcome() == TerminalOutcome.COMPLETED
+
+
+def test_reconcile_requires_payment_method_grants_one_recharge(storage) -> None:
+    provider = _FakePaymentProvider()
+    reconciler = _StripeReconciler(provider)
+    charge = _make_charge(provider, storage, reconciler=reconciler)
+    ledger_inst = get_ledger(charge)
+
+    # Intent created but never charged (worker died before confirming): the
+    # provider proves NOT_EXECUTED, so exactly one re-execution is granted.
+    rid, _crashed_pid = _seed_crashed_charge(
+        provider, storage, status="requires_payment_method"
+    )
+
+    with execution_scope(_scope()):
+        result = charge(amount=10.0, tool_call_id="c1")
+
+    assert result["charged"] is True
+    assert provider.charges == ["pi_mock_2"], (
+        "NOT_EXECUTED reconcile must re-run exactly once (one new charge)"
+    )
+    entry = ledger_inst.get(rid)
+    assert entry is not None
+    assert entry.resolved_terminal_outcome() == TerminalOutcome.COMPLETED
+
+
+def test_reconcile_canceled_or_missing_grants_one_recharge(storage) -> None:
+    for status in ("canceled", "missing"):
+        provider = _FakePaymentProvider()
+        reconciler = _StripeReconciler(provider)
+        charge = _make_charge(provider, storage, reconciler=reconciler)
+
+        if status == "missing":
+            # The provider never saw the intent at all: seed an entry whose
+            # ref points at a payment intent the store does not know.
+            with execution_scope(_scope()):
+                derived = ActionLedger(storage=InMemoryLedgerStorage()).derive_request_id(
+                    "charge", (), {"amount": 10.0, "tool_call_id": "c1"},
+                    transition_binding=_binding(),
+                )
+            storage.set(
+                LedgerEntry(
+                    request_id=derived,
+                    tool="charge",
+                    args=[10.0],
+                    kwargs={"amount": 10.0, "tool_call_id": "c1"},
+                    status="in-flight",
+                    terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+                    lease_until=time.time() - 1,
+                    side_effect_boundary=SideEffectBoundary.MAYBE_CROSSED.value,
+                    external_operation_ref="pi_missing_1",
+                )
+            )
+        else:
+            _seed_crashed_charge(provider, storage, status="canceled")
+
+        with execution_scope(_scope()):
+            result = charge(amount=10.0, tool_call_id="c1")
+
+        assert result["charged"] is True
+        assert len(provider.charges) == 1, (
+            f"{status} reconcile must grant exactly one new charge"
+        )
+
+
+def test_reconcile_processing_hard_blocks_without_recharge(storage) -> None:
+    provider = _FakePaymentProvider()
+    reconciler = _StripeReconciler(provider)
+    charge = _make_charge(provider, storage, reconciler=reconciler)
+
+    # Charge submitted but outcome unknown: no re-execution is allowed.
+    rid, pid = _seed_crashed_charge(provider, storage, status="processing")
+
+    with execution_scope(_scope()):
+        with pytest.raises(LedgerHardBlockError):
+            charge(amount=10.0, tool_call_id="c1")
+        with pytest.raises(LedgerHardBlockError):
+            charge(amount=10.0, tool_call_id="c1")
+
+    assert provider.charges == [], "UNKNOWN reconcile must never re-charge"
+    assert provider.retrieve_calls == 2
+    entry = storage.get(rid)
+    assert entry is not None
+    assert entry.terminal_outcome == TerminalOutcome.BLOCKED.value
+    assert entry.external_operation_ref == pid
+
+
+def test_operator_release_unblocks_processing_with_one_recharge(storage) -> None:
+    provider = _FakePaymentProvider()
+    reconciler = _StripeReconciler(provider)
+    charge = _make_charge(provider, storage, reconciler=reconciler)
+    ledger_inst = get_ledger(charge)
+
+    rid, pid = _seed_crashed_charge(provider, storage, status="processing")
+
+    with execution_scope(_scope()):
+        with pytest.raises(LedgerHardBlockError):
+            charge(amount=10.0, tool_call_id="c1")
+
+    # Operator checks the provider, finds no successful charge, releases as
+    # NOT_EXECUTED: exactly one re-execution.
+    entry = ledger_inst.release(
+        rid,
+        verified="not_executed",
+        by="ops@payments.example",
+        reason=f"provider shows no succeeded charge for {pid}",
+    )
+    assert entry.operator_resolution == "not_executed"
+
+    with execution_scope(_scope()):
+        result = charge(amount=10.0, tool_call_id="c1")
+
+    assert result["charged"] is True
+    assert provider.charges == ["pi_mock_2"], (
+        "operator NOT_EXECUTED release must grant exactly one new charge"
+    )
+
+
+def test_release_refused_on_completed_and_live_lease(storage) -> None:
+    provider = _FakePaymentProvider()
+    charge = _make_charge(provider, storage)
+    ledger_inst = get_ledger(charge)
+
+    with execution_scope(_scope()):
+        charge(amount=10.0, tool_call_id="c1")
+        rid = _request_id(ledger_inst, {"amount": 10.0, "tool_call_id": "c1"})
+
+    with pytest.raises(LedgerReleaseRefusedError):
+        ledger_inst.release(
+            rid, verified="not_executed", by="ops@payments.example", reason="check"
+        )
+
+
+def test_reconciler_is_read_only(storage) -> None:
+    provider = _FakePaymentProvider()
+    reconciler = _StripeReconciler(provider)
+    charge = _make_charge(provider, storage, reconciler=reconciler)
+
+    _seed_crashed_charge(provider, storage, status="succeeded")
+    before = provider.snapshot()
+    charges_before = list(provider.charges)
+
+    with execution_scope(_scope()):
+        charge(amount=10.0, tool_call_id="c1")
+
+    assert provider.snapshot() == before, "reconciler must never mutate the store"
+    assert provider.charges == charges_before
+
+
+def test_no_reconciler_hard_blocks_without_provider_evidence(storage) -> None:
+    # No reconciler configured: an ambiguous crash must hard-block, never
+    # re-charge (fail-closed default).
+    provider = _FakePaymentProvider()
+    charge = _make_charge(provider, storage)
+
+    _seed_crashed_charge(provider, storage, status="processing")
+
+    with execution_scope(_scope()):
+        with pytest.raises(LedgerHardBlockError):
+            charge(amount=10.0, tool_call_id="c1")
+
+    assert provider.charges == []

--- a/sdk/tests/test_process_kill_crash_window.py
+++ b/sdk/tests/test_process_kill_crash_window.py
@@ -1,0 +1,287 @@
+"""Process-kill / crash-window tests (Phase 4 / process-kill + crash-window).
+
+``test_side_effect_resolution.py`` already simulates a crash-after-claim by
+planting an expired ``LedgerEntry`` in-process. These tests go further: a real
+child OS process claims a payment transition, records a provider handle, and is
+SIGKILLed mid-effect before it can ``complete()``. The parent then redispatches
+the same transition key against a mock Reconciler:
+
+- ``COMPLETED``    -> redispatch returns the reconciled receipt; executions == 1
+- ``NOT_EXECUTED`` -> redispatch runs the tool exactly once more; executions == 2
+- ``UNKNOWN``      -> HARD_BLOCK; executions stay 1
+- crash before any ``external_operation_ref`` is recorded -> fail-closed
+  HARD_BLOCK (no provider lookup); executions stay 1
+
+Determinism: short lease TTLs, lease auto-renew disabled on the child so the
+lease lapses after the kill, bounded waits for the ready marker, and an atomic
+cross-process execution counter file.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from mycelium import (
+    FileLedgerStorage,
+    LedgerHardBlockError,
+    ReconcileResult,
+    ReconcileStatus,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+    ledger_sync,
+    record_external_operation,
+    side_effect,
+)
+
+_MP_CTX = mp.get_context("spawn")
+
+_LEASE_TTL = 1.0  # short: lease lapses quickly after the child is killed
+_READY_TIMEOUT = 10.0
+
+
+def _append_count(path: str) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        os.write(fd, b"x\n")
+    finally:
+        os.close(fd)
+
+
+def _append_line(path: str, line: str) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        os.write(fd, line.encode("utf-8") + b"\n")
+    finally:
+        os.close(fd)
+
+
+def _payment_binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="crash",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def _crash_worker(payload: dict[str, Any]) -> None:
+    """Claim a payment transition, (optionally) record the provider handle,
+    signal ready, then run a long effect and never complete.
+
+    The parent SIGKILLs this worker mid-effect, leaving an ambiguous
+    ``IN_FLIGHT`` / ``maybe_crossed`` entry whose lease later expires.
+    """
+    from mycelium import FileLedgerStorage, ledger_sync
+
+    storage = FileLedgerStorage(payload["ledger_path"])
+
+    @ledger_sync(
+        storage=storage,
+        transition_binding=_payment_binding(),
+        lease_ttl=float(payload["lease_ttl"]),
+        lease_renew_interval=0,  # no heartbeat renewal: lease lapses after kill
+        poll_interval=0.02,
+        poll_timeout=float(payload["poll_timeout"]),
+    )
+    def charge(amount: float) -> dict[str, Any]:
+        _append_count(payload["exec_file"])
+        with side_effect():
+            if payload.get("record_ref"):
+                record_external_operation(payload["op_ref"])
+            _append_line(payload["ready_file"], "ready")
+            time.sleep(60.0)
+        return {"charged": True}
+
+    try:
+        with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+            charge(amount=10.0, tool_call_id=payload["tool_call_id"])
+    except Exception as exc:  # noqa: BLE001 — surface to parent
+        _append_line(payload["err_file"], f"{type(exc).__name__}: {exc}")
+
+
+class _ScriptedReconciler:
+    """Mock Reconciler returning a scripted result and recording calls."""
+
+    def __init__(self, status: ReconcileStatus, result: Any = None) -> None:
+        self._status = status
+        self._result = result
+        self.calls: list[str] = []
+
+    def reconcile(self, entry: Any) -> ReconcileResult:
+        self.calls.append(entry.request_id)
+        if self._status == ReconcileStatus.COMPLETED:
+            return ReconcileResult.completed(self._result)
+        if self._status == ReconcileStatus.NOT_EXECUTED:
+            return ReconcileResult.not_executed()
+        return ReconcileResult.unknown()
+
+
+def _crash_then_redispatch(
+    tmp_path: Path,
+    reconciler: _ScriptedReconciler,
+    *,
+    record_ref: bool,
+) -> tuple[Path, int, Any, _ScriptedReconciler]:
+    """Kill a mid-effect worker, wait for the lease to lapse, redispatch.
+
+    Returns ``(exec_file, executions, outcome, reconciler)`` where ``outcome``
+    is the redispatch result dict or ``LedgerHardBlockError``.
+    """
+    ledger_path = tmp_path / "ledger.json"
+    exec_file = tmp_path / "executions.txt"
+    ready_file = tmp_path / "ready.txt"
+    err_file = tmp_path / "err.txt"
+    tool_call_id = f"call_crash_{uuid.uuid4().hex}"
+
+    payload = {
+        "ledger_path": str(ledger_path),
+        "exec_file": str(exec_file),
+        "ready_file": str(ready_file),
+        "err_file": str(err_file),
+        "tool_call_id": tool_call_id,
+        "op_ref": "pi_crash_1",
+        "record_ref": record_ref,
+        "lease_ttl": _LEASE_TTL,
+        "poll_timeout": 5.0,
+    }
+
+    proc = _MP_CTX.Process(target=_crash_worker, args=(payload,), name="crash-worker")
+    proc.start()
+    try:
+        deadline = time.time() + _READY_TIMEOUT
+        while not ready_file.exists():
+            if time.time() >= deadline:
+                raise AssertionError("crash worker never signaled ready")
+            time.sleep(0.02)
+
+        proc.kill()  # SIGKILL: entry stays IN_FLIGHT, never completed
+        proc.join(timeout=5.0)
+        assert proc.exitcode is not None and proc.exitcode != 0, (
+            "crash worker should have been killed"
+        )
+
+        # Let the (short) lease lapse so the redispatch sees EXPIRED.
+        time.sleep(_LEASE_TTL + 0.4)
+    finally:
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=2.0)
+
+    storage = FileLedgerStorage(ledger_path)
+
+    @ledger_sync(
+        storage=storage,
+        transition_binding=_payment_binding(),
+        reconciler=reconciler,
+        lease_ttl=30.0,
+        poll_interval=0.02,
+        poll_timeout=5.0,
+    )
+    # NB: same tool name as the killed child so the derived request_id
+    # (tool_name + args + kwargs) collides and the redispatch re-claims it.
+    def charge(amount: float) -> dict[str, Any]:
+        _append_count(str(exec_file))
+        return {"charged": True, "redispatch": True}
+
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+        try:
+            outcome: Any = charge(amount=10.0, tool_call_id=tool_call_id)
+        except LedgerHardBlockError:
+            outcome = LedgerHardBlockError
+
+    return exec_file, len(exec_file.read_text(encoding="utf-8").splitlines()), outcome, reconciler
+
+
+def test_kill_before_complete_reconcile_completed_returns_receipt(
+    tmp_path: Path,
+) -> None:
+    reconciler = _ScriptedReconciler(
+        ReconcileStatus.COMPLETED, {"charged": True, "id": "pi_crash_1"}
+    )
+    exec_file, executions, outcome, reconciler = _crash_then_redispatch(
+        tmp_path, reconciler, record_ref=True
+    )
+
+    assert outcome == {"charged": True, "id": "pi_crash_1"}, outcome
+    assert executions == 1, "redispatch must not re-execute after reconcile COMPLETED"
+    assert reconciler.calls, "reconciler should have been consulted"
+
+    storage = FileLedgerStorage(tmp_path / "ledger.json")
+    entry = storage.get(reconciler.calls[0])
+    assert entry is not None
+    assert entry.resolved_terminal_outcome() == TerminalOutcome.COMPLETED
+    assert entry.result == {"charged": True, "id": "pi_crash_1"}
+
+
+def test_kill_before_complete_reconcile_not_executed_runs_once_more(
+    tmp_path: Path,
+) -> None:
+    reconciler = _ScriptedReconciler(ReconcileStatus.NOT_EXECUTED)
+    exec_file, executions, outcome, reconciler = _crash_then_redispatch(
+        tmp_path, reconciler, record_ref=True
+    )
+
+    assert outcome == {"charged": True, "redispatch": True}
+    assert executions == 2, (
+        "reconcile NOT_EXECUTED grants exactly one more execution "
+        f"(killed worker + redispatch); got {executions}"
+    )
+    assert reconciler.calls
+
+    storage = FileLedgerStorage(tmp_path / "ledger.json")
+    entry = storage.get(reconciler.calls[0])
+    assert entry is not None
+    assert entry.resolved_terminal_outcome() == TerminalOutcome.COMPLETED
+    assert entry.result == {"charged": True, "redispatch": True}
+
+
+def test_kill_before_complete_reconcile_unknown_hard_blocks(tmp_path: Path) -> None:
+    reconciler = _ScriptedReconciler(ReconcileStatus.UNKNOWN)
+    exec_file, executions, outcome, reconciler = _crash_then_redispatch(
+        tmp_path, reconciler, record_ref=True
+    )
+
+    assert outcome is LedgerHardBlockError
+    assert executions == 1, "UNKNOWN reconcile must not re-execute"
+    assert reconciler.calls
+
+    storage = FileLedgerStorage(tmp_path / "ledger.json")
+    entry = storage.get(reconciler.calls[0])
+    assert entry is not None
+    assert entry.resolved_terminal_outcome() in (
+        TerminalOutcome.BLOCKED,
+        TerminalOutcome.UNKNOWN,
+    )
+
+
+def test_kill_before_ref_recorded_hard_blocks_no_provider_lookup(
+    tmp_path: Path,
+) -> None:
+    """Crash before any provider ref was recorded: fail-closed hard-block; the
+    Reconciler must never be consulted (no ref -> no lookup)."""
+    reconciler = _ScriptedReconciler(ReconcileStatus.COMPLETED, {"nope": True})
+    exec_file, executions, outcome, reconciler = _crash_then_redispatch(
+        tmp_path, reconciler, record_ref=False
+    )
+
+    assert outcome is LedgerHardBlockError
+    assert executions == 1, "no ref recorded -> no re-execution"
+    assert reconciler.calls == [], (
+        "reconciler must not be consulted without an external_operation_ref"
+    )
+
+    storage = FileLedgerStorage(tmp_path / "ledger.json")
+    entries = storage.list_all()
+    assert len(entries) == 1
+    assert entries[0].external_operation_ref is None
+    assert entries[0].resolved_terminal_outcome() in (
+        TerminalOutcome.BLOCKED,
+        TerminalOutcome.UNKNOWN,
+    )

--- a/sdk/tests/test_property_transitions.py
+++ b/sdk/tests/test_property_transitions.py
@@ -1,0 +1,353 @@
+"""Hypothesis property tests for the single-key side-effect state machine.
+
+A *transition key* is one durable envelope for a side-effecting tool call.
+These tests generate arbitrary interleavings of every operation the runtime
+can apply to a single key -- claim, complete, fail before/after effect, crash
+(lease lapse), operator release, provider reconcile, stuck-marking, heartbeat
+renewal and worker-death signals -- and assert the durable record upholds the
+same guarantees the multiprocess / crash-window tests check imperatively:
+
+- ``executions <= 1 + not_executed_verdicts``: the tool body may run at most
+  once, plus exactly one extra run per *provably not executed* verdict
+  (operator release or provider reconcile).  No interleaving can double-charge.
+- Once COMPLETED, a key stays COMPLETED with a stable result and grants no
+  further executions; redispatches return the cached result.
+- Mutators (complete/fail/mark_*) CAS strictly out of ``IN_FLIGHT``; a
+  terminal-over-terminal write is refused.
+- The durable record always round-trips ``to_dict()``/``from_dict()`` with an
+  unchanged ``request_id``.
+- Key derivation is sound: identical dispatch kwargs produce the same
+  ``request_id`` (framework redispatches dedupe), changing a real argument
+  produces a different key, and ``tool_call_id``/other bookkeeping kwargs are
+  excluded from the *args fingerprint* while still binding the key to the
+  dispatch identity.
+
+Both the file backend and Redis (via fakeredis) must uphold the properties.
+"""
+
+import tempfile
+import time
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mycelium import (
+    ActionLedger,
+    FileLedgerStorage,
+    LedgerEntry,
+    LedgerError,
+    ReconcileResult,
+    ReconcileStatus,
+    RedisLedgerStorage,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+)
+
+fakeredis = pytest.importorskip("fakeredis")
+FakeRedis = fakeredis.FakeRedis
+
+# A NON_IDEMPOTENT_MUTATE payment charge: SINGLE_USE, no auto-reclaim, no
+# provider idempotency key.  Every ambiguity must be resolved by reconcile or
+# an operator release -- the strictest possible retry policy.
+_BINDING = ToolTransitionBinding.for_tool(
+    agent_id="prop",
+    policy_version="1",
+    side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+)
+_TOOL = "charge"
+_KWARGS = {"amount": 10.0, "tool_call_id": "c_prop"}
+_RESULT = {"charged": True}
+
+# Weighted op pool; duplicates make the more interesting ops common.
+_OPS = [
+    "claim_ok",
+    "claim_ok",
+    "claim_fail_before",
+    "claim_fail_after",
+    "claim_crash",
+    "expire",
+    "expire",
+    "release_not_executed",
+    "release_completed",
+    "reconcile_not_executed",
+    "reconcile_completed",
+    "reconcile_unknown",
+    "mark_unknown",
+    "mark_blocked",
+    "renew",
+    "mark_worker_dead",
+    "read",
+]
+
+
+class _ScriptedReconciler:
+    """Provider reconciler whose verdict the model can flip between ops."""
+
+    def __init__(self, model: "_TransitionModel") -> None:
+        self._model = model
+        self.verdict = ReconcileResult.unknown()
+
+    def reconcile(self, entry: LedgerEntry) -> ReconcileResult:
+        if self.verdict.status == ReconcileStatus.NOT_EXECUTED:
+            self._model.not_executed_verdicts += 1
+        return self.verdict
+
+
+class _TransitionModel:
+    """Drives one transition key through an op sequence and checks invariants."""
+
+    def __init__(self, storage) -> None:
+        self.reconciler = _ScriptedReconciler(self)
+        self.ledger = ActionLedger(
+            storage,
+            lease_ttl=0.2,
+            poll_interval=0.0005,
+            poll_timeout=0.005,
+            reconciler=self.reconciler,
+        )
+        self.storage = storage
+        self.rid = self.ledger.derive_request_id(
+            _TOOL, (), dict(_KWARGS), transition_binding=_BINDING
+        )
+        self.executions = 0
+        self.not_executed_verdicts = 0
+        self.completed_once = False
+        self.completed_result = None
+        self.completed_executions = -1
+
+    # --- operations ---
+
+    def _claim(self) -> LedgerEntry | None:
+        try:
+            entry = self.ledger.claim_side_effecting(
+                self.rid,
+                _TOOL,
+                (),
+                dict(_KWARGS),
+                _BINDING,
+                lease_ttl=0.2,
+                poll_interval=0.0005,
+                poll_timeout=0.005,
+            )
+        except LedgerError:
+            return None
+        if entry is None:
+            return None
+        if entry.is_terminal_completed():
+            self._note_completed(entry)
+            return None
+        if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
+            # A returned IN_FLIGHT entry is a fresh, owned claim: the tool
+            # body runs exactly once for it.
+            self.executions += 1
+            return entry
+        return None
+
+    def _note_completed(self, entry: LedgerEntry) -> None:
+        if self.completed_once:
+            assert entry.result == self.completed_result, (
+                f"result changed after completion: {self.completed_result!r} -> {entry.result!r}"
+            )
+        else:
+            self.completed_once = True
+            self.completed_result = entry.result
+            self.completed_executions = self.executions
+
+    def _op_claim_ok(self) -> None:
+        claimed = self._claim()
+        if claimed is not None:
+            try:
+                self._note_completed(self.ledger.complete(self.rid, _RESULT))
+            except LedgerError:
+                pass
+
+    def _op_claim_fail_before(self) -> None:
+        claimed = self._claim()
+        if claimed is not None:
+            try:
+                self.ledger.fail(self.rid, RuntimeError("before effect"))
+            except LedgerError:
+                pass
+
+    def _op_claim_fail_after(self) -> None:
+        claimed = self._claim()
+        if claimed is not None:
+            try:
+                self.ledger.attach_external_operation_ref(self.rid, "pi_prop")
+                self.ledger.fail(self.rid, RuntimeError("after effect"), failed_after_effect=True)
+            except LedgerError:
+                pass
+
+    def _op_claim_crash(self) -> None:
+        claimed = self._claim()
+        if claimed is not None:
+            try:
+                self.ledger.attach_external_operation_ref(self.rid, "pi_prop")
+            except LedgerError:
+                pass
+
+    def _op_expire(self) -> None:
+        entry = self.storage.get(self.rid)
+        if entry is None or entry.terminal_outcome != TerminalOutcome.IN_FLIGHT.value:
+            return
+        crashed = replace(entry, lease_until=time.time() - 0.05, last_heartbeat_at=None)
+        self.storage.set(crashed)
+
+    def _op_release_not_executed(self) -> None:
+        try:
+            self.ledger.release(
+                self.rid,
+                verified="not_executed",
+                by="prop@ops",
+                reason="provider shows no effect",
+            )
+        except LedgerError:
+            return
+        self.not_executed_verdicts += 1
+
+    def _op_release_completed(self) -> None:
+        try:
+            entry = self.ledger.release(
+                self.rid,
+                verified="completed",
+                result=_RESULT,
+                by="prop@ops",
+                reason="provider confirms effect",
+            )
+        except LedgerError:
+            return
+        self._note_completed(entry)
+
+    def _op_reconcile_not_executed(self) -> None:
+        self.reconciler.verdict = ReconcileResult.not_executed()
+
+    def _op_reconcile_completed(self) -> None:
+        self.reconciler.verdict = ReconcileResult.completed(_RESULT)
+
+    def _op_reconcile_unknown(self) -> None:
+        self.reconciler.verdict = ReconcileResult.unknown()
+
+    def _op_mark_unknown(self) -> None:
+        try:
+            self.ledger.mark_unknown(self.rid, error="prop")
+        except LedgerError:
+            pass
+
+    def _op_mark_blocked(self) -> None:
+        try:
+            self.ledger.mark_blocked(self.rid, error="prop")
+        except LedgerError:
+            pass
+
+    def _op_renew(self) -> None:
+        try:
+            self.ledger.renew_lease(self.rid)
+        except LedgerError:
+            pass
+
+    def _op_mark_worker_dead(self) -> None:
+        from mycelium.action_ledger import _ledger_owner
+
+        try:
+            self.ledger.mark_worker_dead(
+                _ledger_owner(),
+                by="prop@ops",
+                reason="worker killed by orchestrator",
+                override_heartbeat=True,
+            )
+        except LedgerError:
+            pass
+
+    def _op_read(self) -> None:
+        self.ledger.get(self.rid)
+
+    # --- invariants ---
+
+    def check(self) -> None:
+        # Key derivation: identical dispatch kwargs dedupe onto one key.
+        same_rid = self.ledger.derive_request_id(
+            _TOOL, (), dict(_KWARGS), transition_binding=_BINDING
+        )
+        assert same_rid == self.rid, "identical redispatches must map to one key"
+        # Real arguments are part of the key.
+        other_rid = self.ledger.derive_request_id(
+            _TOOL, (), {**_KWARGS, "amount": 99.0}, transition_binding=_BINDING
+        )
+        assert other_rid != self.rid, "real arguments must be part of the transition key"
+        # tool_call_id is the dispatch identity: it binds the key (a redispatch
+        # must reuse it) but is excluded from the args fingerprint.
+        rekeyed_rid = self.ledger.derive_request_id(
+            _TOOL, (), {**_KWARGS, "tool_call_id": "c_other"}, transition_binding=_BINDING
+        )
+        assert rekeyed_rid != self.rid, "dispatch identity must bind the transition key"
+        from mycelium.transition import args_fingerprint
+
+        assert args_fingerprint((), dict(_KWARGS)) == args_fingerprint(
+            (), {**_KWARGS, "tool_call_id": "c_other"}
+        ), "bookkeeping kwargs must be excluded from the args fingerprint"
+
+        # The single-key budget: at most one execution, plus exactly one extra
+        # per provably-not-executed verdict.
+        assert self.executions <= 1 + self.not_executed_verdicts, (
+            f"double-execution: {self.executions} runs with "
+            f"{self.not_executed_verdicts} not-executed verdicts"
+        )
+
+        entry = self.storage.get(self.rid)
+        if entry is None:
+            return
+        # Durable record round-trips with an unchanged request_id.
+        assert LedgerEntry.from_dict(entry.to_dict()).request_id == self.rid
+
+        if self.completed_once:
+            stored = entry.resolved_terminal_outcome()
+            assert stored == TerminalOutcome.COMPLETED, (
+                f"completed key regressed to {stored!r} ({entry.terminal_outcome!r})"
+            )
+            assert entry.result == self.completed_result
+            assert self.executions == self.completed_executions, (
+                f"execution after completion: {self.completed_executions} -> {self.executions}"
+            )
+            # A COMPLETED key cannot be re-marked.
+            if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+                with pytest.raises(LedgerError):
+                    self.ledger.complete(self.rid, _RESULT)
+
+
+def _run_sequence(ops: list[str], make_storage) -> None:
+    # _reconcile_cas_lost is module-global CAS-race signalling; reset it so one
+    # model run can never contaminate the next (file -> redis within an
+    # example, or across examples).
+    from mycelium import action_ledger
+
+    action_ledger._reconcile_cas_lost.val = False
+    with tempfile.TemporaryDirectory() as tmp:
+        model = _TransitionModel(make_storage(tmp))
+        for op in ops:
+            getattr(model, f"_op_{op}")()
+            model.check()
+
+
+def _make_file_storage(tmp: str):
+    return FileLedgerStorage(Path(tmp) / "ledger.json")
+
+
+def _make_redis_storage(tmp: str):
+    return RedisLedgerStorage("redis://test")
+
+
+def _fake_redis_from_url(url: str, **kwargs: object):
+    return FakeRedis(decode_responses=True)
+
+
+@settings(max_examples=80, deadline=None)
+@given(ops=st.lists(st.sampled_from(_OPS), min_size=0, max_size=40))
+def test_transition_key_invariants(ops: list[str]) -> None:
+    _run_sequence(ops, _make_file_storage)
+    with patch("redis.Redis.from_url", side_effect=_fake_redis_from_url):
+        _run_sequence(ops, _make_redis_storage)


### PR DESCRIPTION
Release **v1.19.2**: payment-class identity docs guidance + the Phase 4 reliability test suite.

## Docs
- `sdk/README.md`: payment-class identity guidance — mint payment-class transition / provider keys from server-authoritative values, not raw client or LLM args; deterministic `provider_key = HMAC-SHA256(server_secret, action_id)` via `provider_idempotency_key_param`. Guidance only.

## Tests (5 new files, 49 tests)
- `test_multiprocess_concurrency.py`: 3 real-`spawn`-process tests — single charge under two-worker contention, crash-after-claim reclaim grants exactly one re-execution, cross-process lease fencing.
- `test_process_kill_crash_window.py`: 4 tests SIGKILLing workers mid-tool-body — crash window never double-executes (with/without `NOT_EXECUTED` reconciler, file + Redis).
- `test_outage_redis_postgres.py`: 11 fail-closed outage tests (Redis down at each ledger phase, Postgres down via stubbed `_require_psycopg`).
- `test_property_transitions.py`: Hypothesis property test over the single-key state machine — `executions <= 1 + not_executed_verdicts`, COMPLETED terminal, CAS strictly out of IN_FLIGHT, key-derivation soundness.
- `test_payment_provider_mock.py`: 10 tests against a read-only Stripe-shaped Reconciler + fake PaymentIntent store — succeeded→COMPLETED, requires_payment_method/canceled/missing→NOT_EXECUTED, processing→HARD_BLOCK, 25-redispatch storm never double-charges.

## Release
- `sdk/pyproject.toml` → 1.19.2; `hypothesis` added to dev extras.
- `CHANGELOG.md` → `## 1.19.2` section; README/docs badge bumps.

Full suite: 546 passed, 3 skipped; ruff clean.