### PR TITLE
feat: outcome emitter + DTTR telemetry (v1.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 1.20.0 (2026-08-01)
+
+Minor: opt-in resolution telemetry (`OutcomeEmitter`) + a pinned **Duplicate
+Tool Transition Rate (DTTR)** metric computed after the fact from flat,
+append-only rows — a single number that makes the no-double-execute guarantee
+observable in production.
+
+### Feature
+
+- `OutcomeEmitter` + `OutcomeRow` (`sdk/mycelium/outcome_emit.py`): flat,
+  warehouse-friendly telemetry rows (one JSON object per NDJSON line) emitted
+  only on resolution events — a dispatch resolving to a gate
+  (`ALLOW`/`RETURN`/`HARD_BLOCK`/`SOFT_BLOCK`), tool-body
+  start/complete/fail, and operator release. Poll ticks never emit. Storage is
+  memory or file only (no analytics SaaS deps); emission is fault-tolerant —
+  a storage failure is logged and swallowed so telemetry can never break the
+  tool path or alter claim/CAS/reconcile semantics.
+- Wired through `@ledger` / `@ledger_sync` (new `outcome_emitter=` kwarg) and
+  `ActionLedger(outcome_emitter=...)`; `release()` emits a `release` row.
+  A body run that follows a consumed `NOT_EXECUTED` verdict (reconciler
+  `NOT_EXECUTED` or operator release verified `not_executed`) is tagged
+  `authorized_reexec=True` so it is never counted as a silent duplicate.
+- `compute_dttr()` / `compute_dttr_from_storage()`: `DTTR =
+  silent_duplicates / max(long_running_or_redispatched, 1)`, target 0.
+  Silent duplicate = a tool-body execution not authorized by a consumed
+  `NOT_EXECUTED`; long-running/redispatched = ≥2 resolution events or a span
+  longer than `long_running_after` (default `lease_ttl`).
+- YAML `outcome_emit:` section (off by default; `storage: memory|file`,
+  `path:`, `long_running_after:`) wired through `MyceliumConfig` +
+  `config.apply_tool`, plus a commented stub in the full init template.
+- CLI: `mycelium outcomes dttr [--config|--file] [--long-running-after N]
+  [--json]`.
+
+### Docs
+
+- `sdk/README.md` "Outcome telemetry & DTTR" section (definition + examples).
+- `sdk/docs/FAILURE_AND_THREAT_MODEL.md` residual-risk item: silent duplicates
+  are invisible without opt-in telemetry; DTTR is the observability measure.
+
+### Tests
+
+- `tests/test_outcome_emit.py`: 25 tests — row round-trip, NDJSON file
+  storage (incl. malformed-line tolerance), fault-tolerant emission, the DTTR
+  definitions (clean/authorized/redispatched/long-running/empty), `@ledger` /
+  `@ledger_sync` hook points (incl. redispatch returning the cached result
+  without a body row, body-failure rows, hard-block resolution rows), operator
+  release + reconciler `NOT_EXECUTED` authorization, YAML config wiring, and
+  the `mycelium outcomes dttr` CLI.
+
 ## 1.19.2 (2026-07-31)
 
 Patch: Phase 4 reliability test suite (real-process multiprocess concurrency,

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -963,6 +963,75 @@ finds `IN_FLIGHT` with a live lease returns to the claim loop instead of
 raising, and `mark_blocked` is never called on an entry whose lease is
 currently held.
 
+## Outcome telemetry & DTTR (v1.20+)
+
+**Problem:** You run a fleet of agents and want a single number that proves
+the duplicate-side-effect guard is holding in production — and that regresses
+loudly the day it doesn't.
+
+**Solution:** opt-in `OutcomeEmitter` resolution telemetry plus a pinned
+metric, the **Duplicate Tool Transition Rate (DTTR)**, computed after the fact
+from flat append-only rows. Off by default; memory or file storage only in v1
+(no analytics SaaS dependency).
+
+Enable it in YAML and every ledgered tool starts emitting:
+
+```yaml
+outcome_emit:
+  storage: file                 # memory | file
+  path: ./mycelium-outcomes.jsonl
+  long_running_after: 3600      # seconds (default: lease_ttl)
+```
+
+Or pass an emitter directly:
+
+```python
+from mycelium import OutcomeEmitter, ledger_sync
+
+emitter = OutcomeEmitter(agent_id="acme", storage=FileOutcomeStorage("outcomes.jsonl"))
+
+@ledger_sync(storage=..., transition_binding=..., outcome_emitter=emitter)
+def charge(amount):
+    ...
+```
+
+Rows are one JSON object per line, emitted only on resolution events — a
+dispatch resolving to a gate (`ALLOW` / `RETURN` / `HARD_BLOCK` /
+`SOFT_BLOCK`), the tool body starting / completing / failing, and operator
+releases. Poll ticks never emit. Emission is fault-tolerant: a storage
+failure is logged and swallowed, so telemetry can never break the tool path.
+
+Compute the metric with the CLI or the library:
+
+```console
+$ mycelium outcomes dttr --file ./mycelium-outcomes.jsonl
+DTTR: 0.0000  (target: 0.0)
+silent duplicates: 0  long-running or redispatched: 3  transitions: 42
+```
+
+```python
+from mycelium import FileOutcomeStorage, compute_dttr_from_storage
+
+report = compute_dttr_from_storage(FileOutcomeStorage("outcomes.jsonl"), long_running_after=3600)
+```
+
+### DTTR definition
+
+- A **transition** is every row sharing a `request_id` (the transition key).
+- A **silent duplicate** is a tool-body execution for a transition that had
+  already executed, without being authorized by a consumed `NOT_EXECUTED`
+  verdict (reconciler `NOT_EXECUTED` or an operator release verified
+  `not_executed`). The first execution is always authorized; each consumed
+  `NOT_EXECUTED` authorizes exactly one more, so the guarantee to measure is
+  `executions <= 1 + not_executed_verdicts`.
+- A transition is **long-running or redispatched** when it saw ≥2 resolution
+  events (framework redispatches) OR its wall-clock span exceeds
+  `long_running_after`.
+- `DTTR = silent_duplicates / max(long_running_or_redispatched, 1)`. The
+  target is **0.0**. Without Mycelium, two workers racing the same effect
+  produce a silent duplicate (DTTR > 0); with the guard, duplicate body runs
+  only happen through an authorized `NOT_EXECUTED` path.
+
 ## For contributors (repo layout)
 
 Clone the GitHub repo to run proofs and tests. PyPI installs only the `mycelium` package.

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -280,6 +280,16 @@ Still can go wrong — even with everything above configured correctly:
 - **Wall-clock leases.** Leases rely on `time.time()`. Clock skew can renew or
   expire leases early; extreme skew is a deployment concern, not something the
   runtime compensates for.
+- **Silent duplicates are invisible without opt-in telemetry.** The guard
+  prevents unauthorized re-execution, but a violation (lying reconciler,
+  caller escaping the key, bug in the runtime) only surfaces as
+  business-level weirdness unless you can see it. Enable `outcome_emit` and
+  track the **DTTR** (`mycelium outcomes dttr`, target 0.0) to make the
+  guarantee observable: it counts tool-body executions that were *not*
+  authorized by a consumed `NOT_EXECUTED` verdict, over transitions that were
+  long-running or redispatched. See the
+  [README section](../README.md#outcome-telemetry--dttr-v120) for the exact
+  definition.
 
 ---
 

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -46,6 +46,17 @@ from mycelium.config import (
 )
 from mycelium.history_guard import HistoryGuard, HistoryTruncatedError
 from mycelium.message_validator import MessageValidationError, MessageValidator
+from mycelium.outcome_emit import (
+    DttrReport,
+    FileOutcomeStorage,
+    InMemoryOutcomeStorage,
+    OutcomeEmitter,
+    OutcomeRow,
+    OutcomeStorage,
+    TransitionDttr,
+    compute_dttr,
+    compute_dttr_from_storage,
+)
 from mycelium.protect import protect, protect_sync
 from mycelium.providers import GmailReconciler
 from mycelium.reconcile import Reconciler, ReconcileResult, ReconcileStatus
@@ -103,7 +114,7 @@ from mycelium.transition_resolution import (
     transition_needs_repair,
 )
 
-__version__ = "1.17.0"
+__version__ = "1.20.0"
 
 __all__ = [
     "ActionLedger",
@@ -143,6 +154,15 @@ __all__ = [
     "FileAuditReceiptStorage",
     "InMemoryAuditReceiptStorage",
     "verify_receipt",
+    "OutcomeEmitter",
+    "OutcomeRow",
+    "OutcomeStorage",
+    "FileOutcomeStorage",
+    "InMemoryOutcomeStorage",
+    "DttrReport",
+    "TransitionDttr",
+    "compute_dttr",
+    "compute_dttr_from_storage",
     "TaskFileLedgerStorage",
     "TaskInMemoryLedgerStorage",
     "TaskLedger",

--- a/sdk/mycelium/__main__.py
+++ b/sdk/mycelium/__main__.py
@@ -21,6 +21,7 @@ _TEMPLATE_MINIMAL = "mycelium.minimal.yaml"
 _ENV_LEDGER_FILE = "MYCELIUM_LEDGER_FILE"
 _ENV_REDIS_URL = "MYCELIUM_REDIS_URL"
 _ENV_POSTGRES_DSN = "MYCELIUM_POSTGRES_DSN"
+_ENV_OUTCOME_FILE = "MYCELIUM_OUTCOME_FILE"
 
 
 def _load_template(*, full: bool, minimal: bool) -> tuple[str, str]:
@@ -438,6 +439,74 @@ def cmd_transitions_mark_dead(args: argparse.Namespace) -> int:
     return 0
 
 
+def _outcome_storage_config(
+    args: argparse.Namespace,
+) -> tuple[dict[str, Any], float | None]:
+    """Resolve the outcome-log storage config + long_running_after override."""
+    from mycelium.config import ConfigError, load_config
+
+    file_path = args.outcome_file or os.environ.get(_ENV_OUTCOME_FILE)
+    if file_path:
+        return {"storage": "file", "path": str(file_path)}, None
+
+    config_path = args.config if args.config is not None else Path("mycelium.yaml")
+    if not config_path.is_file():
+        raise ConfigError(
+            f"no outcome log specified and config not found: {config_path} "
+            "(pass --file, or --config with an 'outcome_emit' section)"
+        )
+    config = load_config(config_path)
+    if config.outcome_emit is None:
+        raise ConfigError(
+            f"{config_path} declares no 'outcome_emit' section; "
+            "add one (storage: file, path: ...) or pass --file"
+        )
+    long_running_after = config.outcome_emit.get("long_running_after")
+    return config.outcome_emit, long_running_after
+
+
+def cmd_outcomes_dttr(args: argparse.Namespace) -> int:
+    from mycelium.config import ConfigError, MyceliumConfig
+    from mycelium.outcome_emit import compute_dttr
+
+    try:
+        raw, config_long_running = _outcome_storage_config(args)
+        storage = MyceliumConfig._build_outcome_storage(raw)
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    long_running_after = args.long_running_after
+    if long_running_after is None:
+        long_running_after = config_long_running
+    report = compute_dttr(
+        storage.list_all(),
+        long_running_after=(
+            float(long_running_after) if long_running_after is not None else None
+        ),
+    )
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, default=str))
+        return 0
+    print(f"DTTR: {report.dttr:.4f}  (target: 0.0)")
+    print(
+        f"silent duplicates: {report.silent_duplicates}  "
+        f"long-running or redispatched: {report.long_running_or_redispatched}  "
+        f"transitions: {report.transitions}"
+    )
+    for item in report.per_transition:
+        marker = " *" if item.long_running_or_redispatched else ""
+        print(
+            f"  {item.request_id}  {item.tool}  "
+            f"execs={item.body_executions}  silent={item.silent_duplicates}  "
+            f"resolutions={item.resolution_events}  dur={item.duration_seconds:.1f}s"
+            f"{marker}"
+        )
+    if report.long_running_or_redispatched == 0 and report.transitions > 0:
+        print("no long-running or redispatched transitions: DTTR is undefined "
+              "(denominator forced to 1)")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="mycelium",
@@ -576,6 +645,46 @@ def main(argv: list[str] | None = None) -> int:
         "of death — bypass may cause a duplicate effect if worker is alive)",
     )
 
+    outcomes_parser = sub.add_parser(
+        "outcomes",
+        help="Outcome telemetry: compute DTTR over emitted resolution rows",
+    )
+    outcomes_sub = outcomes_parser.add_subparsers(
+        dest="outcomes_command", required=True
+    )
+
+    dttr_parser = outcomes_sub.add_parser(
+        "dttr",
+        help="Compute the Duplicate Tool Transition Rate (DTTR) over an "
+        "outcome log; target is 0.0",
+    )
+    dttr_parser.add_argument(
+        "-c",
+        "--config",
+        type=Path,
+        default=None,
+        help="mycelium.yaml to read the outcome_emit storage from "
+        "(default: ./mycelium.yaml)",
+    )
+    dttr_parser.add_argument(
+        "--file",
+        dest="outcome_file",
+        type=Path,
+        default=None,
+        help=f"NDJSON outcome log path (or ${_ENV_OUTCOME_FILE}); overrides --config",
+    )
+    dttr_parser.add_argument(
+        "--long-running-after",
+        dest="long_running_after",
+        type=float,
+        default=None,
+        help="seconds; transitions older than this count as long-running "
+        "(default: outcome_emit.long_running_after, else disabled)",
+    )
+    dttr_parser.add_argument(
+        "--json", action="store_true", help="Machine-readable JSON output"
+    )
+
     args = parser.parse_args(argv)
     if args.command == "init":
         return cmd_init(args.output, full=args.full, minimal=args.minimal, force=args.force)
@@ -592,6 +701,9 @@ def main(argv: list[str] | None = None) -> int:
             return cmd_transitions_release(args)
         if args.transitions_command == "mark-dead":
             return cmd_transitions_mark_dead(args)
+    if args.command == "outcomes":
+        if args.outcomes_command == "dttr":
+            return cmd_outcomes_dttr(args)
     return 1
 
 

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -52,6 +52,7 @@ from mycelium.transition_resolution import (
 
 if TYPE_CHECKING:
     from mycelium.audit_receipt import AuditReceiptEmitter
+    from mycelium.outcome_emit import OutcomeEmitter
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -295,6 +296,16 @@ _active_transition_var: ContextVar[_ActiveTransition | None] = ContextVar(
 # The claim loop checks this flag: if set, an IN_FLIGHT return means "poll",
 # not "this thread won the fresh claim".
 _reconcile_cas_lost: threading.local = threading.local()
+
+# Set when a claim consumed a NOT_EXECUTED verdict (reconciler NOT_EXECUTED or
+# an operator release verified "not_executed") and won the fresh in-flight
+# claim. The @ledger wrapper reads this right after the claim to tag the
+# resulting tool-body run as an *authorized* re-execution (never a silent
+# duplicate). A ContextVar keeps concurrent async tasks isolated.
+_outcome_reexec_authorized: ContextVar[bool] = ContextVar(
+    "mycelium_outcome_reexec_authorized",
+    default=False,
+)
 
 
 def get_active_transition() -> _ActiveTransition | None:
@@ -823,6 +834,7 @@ class ActionLedger:
         reconciler: Reconciler | None = None,
         defer_read_only_unknown: bool = False,
         audit_emitter: AuditReceiptEmitter | None = None,
+        outcome_emitter: OutcomeEmitter | None = None,
         unclassified_policy: str = UNCLASSIFIED_POLICY_WARN,
         reclaim_requires_death_signal: bool = False,
         presumed_dead_after: float | None = None,
@@ -840,6 +852,8 @@ class ActionLedger:
         self._defer_read_only_unknown = defer_read_only_unknown
         # Optional receipt sink for operator releases (release() emits here).
         self._audit_emitter = audit_emitter
+        # Optional resolution-telemetry sink (see mycelium.outcome_emit).
+        self._outcome_emitter = outcome_emitter
         if unclassified_policy not in (
             UNCLASSIFIED_POLICY_WARN,
             UNCLASSIFIED_POLICY_STRICT,
@@ -908,6 +922,63 @@ class ActionLedger:
     def _list_all_entries(self) -> list[LedgerEntry]:
         with _storage_errors("list_all"):
             return self._storage.list_all()
+
+    # --- resolution telemetry (opt-in; never raises, never disturbs the path) ---
+
+    def _emit_outcome(
+        self,
+        *,
+        request_id: str,
+        tool: str,
+        event: str,
+        gate: str | None = None,
+        terminal_outcome: TerminalOutcome | None = None,
+        boundary: SideEffectBoundary | None = None,
+        side_effect_class: SideEffectClass | None = None,
+        tool_body_executed: bool = False,
+        dispatch_attempt: int | None = None,
+        authorized_reexec: bool = False,
+        owner: str | None = None,
+        error_class: str | None = None,
+    ) -> None:
+        """Emit one outcome row, backfilling state from the stored entry.
+
+        Fault-tolerant by design: any failure (including a storage read) is
+        logged and swallowed so telemetry can never alter claim/CAS/reconcile
+        semantics or break the tool path.
+        """
+        if self._outcome_emitter is None:
+            return
+        try:
+            entry = self.get(request_id)
+        except Exception:
+            entry = None
+        if entry is not None:
+            if terminal_outcome is None:
+                terminal_outcome = entry.resolved_terminal_outcome()
+            if boundary is None:
+                boundary = SideEffectBoundary(entry.side_effect_boundary)
+        try:
+            self._outcome_emitter.emit_event(
+                tool=tool,
+                request_id=request_id,
+                event=event,
+                gate=gate,
+                terminal_outcome=(
+                    terminal_outcome.value if terminal_outcome is not None else None
+                ),
+                side_effect_boundary=boundary.value if boundary is not None else None,
+                side_effect_class=(
+                    side_effect_class.value if side_effect_class is not None else None
+                ),
+                tool_body_executed=tool_body_executed,
+                dispatch_attempt=dispatch_attempt,
+                authorized_reexec=authorized_reexec,
+                owner=owner,
+                error_class=error_class,
+            )
+        except Exception:
+            _logger.exception("failed to emit outcome row for %s", request_id)
 
     # --- one-time operator warnings ---
 
@@ -1118,6 +1189,16 @@ class ActionLedger:
                 released_from_outcome=outcome.value,
             )
         self._set_entry(entry)
+        self._emit_outcome(
+            request_id=request_id,
+            tool=entry.tool,
+            event="release",
+            gate="RELEASE",
+            terminal_outcome=entry.resolved_terminal_outcome(now=now),
+            boundary=SideEffectBoundary(entry.side_effect_boundary),
+            authorized_reexec=(verified == OPERATOR_RESOLUTION_NOT_EXECUTED),
+            owner=by,
+        )
         if self._audit_emitter is not None:
             receipt = self._audit_emitter.emit_release_receipt(
                 entry,
@@ -1551,6 +1632,10 @@ class ActionLedger:
                     return None
                 _reconcile_cas_lost.val = True
                 return self.get(request_id)
+            # The fresh claim was won by this caller, which will run the tool
+            # body exactly once — mark that run as an authorized re-execution
+            # so outcome telemetry can tell it apart from a silent duplicate.
+            _outcome_reexec_authorized.set(True)
             return fresh
         return None
 
@@ -2726,21 +2811,75 @@ def _run_ledgered(
         transition_binding=transition_binding,
     )
     clean_kwargs = _drop_ledger_keys(kwargs)
-    existing = _claim_for_transition(
-        ledger,
-        request_id,
-        tool_name,
-        args,
-        clean_kwargs,
-        transition_binding,
-    )
+    _outcome_reexec_authorized.set(False)
+    try:
+        existing = _claim_for_transition(
+            ledger,
+            request_id,
+            tool_name,
+            args,
+            clean_kwargs,
+            transition_binding,
+        )
+    except LedgerHardBlockError:
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="resolution",
+            gate="HARD_BLOCK",
+            error_class="LedgerHardBlockError",
+        )
+        raise
+    except LedgerSoftBlockError:
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="resolution",
+            gate="SOFT_BLOCK",
+            error_class="LedgerSoftBlockError",
+        )
+        raise
     if existing.is_terminal_completed():
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="resolution",
+            gate="RETURN",
+            terminal_outcome=TerminalOutcome.COMPLETED,
+        )
         return existing.result
+
+    owner = _ledger_owner()
+    authorized_reexec = _outcome_reexec_authorized.get()
+    side_effect_class = (
+        transition_binding.side_effect_class
+        if transition_binding is not None
+        else None
+    )
+    ledger._emit_outcome(
+        request_id=request_id,
+        tool=tool_name,
+        event="resolution",
+        gate="ALLOW",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT,
+        side_effect_class=side_effect_class,
+        authorized_reexec=authorized_reexec,
+        owner=owner,
+    )
+    ledger._emit_outcome(
+        request_id=request_id,
+        tool=tool_name,
+        event="body_start",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT,
+        side_effect_class=side_effect_class,
+        tool_body_executed=True,
+        authorized_reexec=authorized_reexec,
+        owner=owner,
+    )
 
     token = _active_transition_var.set(
         _ActiveTransition(ledger, request_id, transition_binding)
     )
-    owner = _ledger_owner()
     try:
         with _lease_auto_renew(ledger, request_id):
             result = func(*args, **clean_kwargs)
@@ -2765,12 +2904,22 @@ def _run_ledgered(
                 "original tool error follows",
                 request_id,
             )
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="body_fail",
+            side_effect_class=side_effect_class,
+            authorized_reexec=authorized_reexec,
+            owner=owner,
+            error_class=type(exc).__name__,
+        )
         raise
     finally:
         _active_transition_var.reset(token)
 
     try:
         ledger.complete(request_id, result, _expected_owner=owner)
+        complete_ok = True
     except LedgerOutcomeAlreadySetError:
         _logger.warning(
             "outcome already set for %s while completing "
@@ -2778,7 +2927,17 @@ def _run_ledgered(
             "tool result discarded",
             request_id,
         )
+        complete_ok = False
     _emit_tool_receipt(audit_emitter, ledger, request_id)
+    ledger._emit_outcome(
+        request_id=request_id,
+        tool=tool_name,
+        event="body_complete" if complete_ok else "body_fail",
+        side_effect_class=side_effect_class,
+        authorized_reexec=authorized_reexec,
+        owner=owner,
+        error_class=None if complete_ok else "LedgerOutcomeAlreadySetError",
+    )
     return result
 
 
@@ -2798,21 +2957,75 @@ async def _run_ledgered_async(
         transition_binding=transition_binding,
     )
     clean_kwargs = _drop_ledger_keys(kwargs)
-    existing = await _claim_for_transition_async(
-        ledger,
-        request_id,
-        tool_name,
-        args,
-        clean_kwargs,
-        transition_binding,
-    )
+    _outcome_reexec_authorized.set(False)
+    try:
+        existing = await _claim_for_transition_async(
+            ledger,
+            request_id,
+            tool_name,
+            args,
+            clean_kwargs,
+            transition_binding,
+        )
+    except LedgerHardBlockError:
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="resolution",
+            gate="HARD_BLOCK",
+            error_class="LedgerHardBlockError",
+        )
+        raise
+    except LedgerSoftBlockError:
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="resolution",
+            gate="SOFT_BLOCK",
+            error_class="LedgerSoftBlockError",
+        )
+        raise
     if existing.is_terminal_completed():
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="resolution",
+            gate="RETURN",
+            terminal_outcome=TerminalOutcome.COMPLETED,
+        )
         return existing.result
+
+    owner = _ledger_owner()
+    authorized_reexec = _outcome_reexec_authorized.get()
+    side_effect_class = (
+        transition_binding.side_effect_class
+        if transition_binding is not None
+        else None
+    )
+    ledger._emit_outcome(
+        request_id=request_id,
+        tool=tool_name,
+        event="resolution",
+        gate="ALLOW",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT,
+        side_effect_class=side_effect_class,
+        authorized_reexec=authorized_reexec,
+        owner=owner,
+    )
+    ledger._emit_outcome(
+        request_id=request_id,
+        tool=tool_name,
+        event="body_start",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT,
+        side_effect_class=side_effect_class,
+        tool_body_executed=True,
+        authorized_reexec=authorized_reexec,
+        owner=owner,
+    )
 
     token = _active_transition_var.set(
         _ActiveTransition(ledger, request_id, transition_binding)
     )
-    owner = _ledger_owner()
     try:
         with _lease_auto_renew(ledger, request_id):
             result = await func(*args, **clean_kwargs)
@@ -2837,12 +3050,22 @@ async def _run_ledgered_async(
                 "original tool error follows",
                 request_id,
             )
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="body_fail",
+            side_effect_class=side_effect_class,
+            authorized_reexec=authorized_reexec,
+            owner=owner,
+            error_class=type(exc).__name__,
+        )
         raise
     finally:
         _active_transition_var.reset(token)
 
     try:
         ledger.complete(request_id, result, _expected_owner=owner)
+        complete_ok = True
     except LedgerOutcomeAlreadySetError:
         _logger.warning(
             "outcome already set for %s while completing "
@@ -2850,7 +3073,17 @@ async def _run_ledgered_async(
             "tool result discarded",
             request_id,
         )
+        complete_ok = False
     _emit_tool_receipt(audit_emitter, ledger, request_id)
+    ledger._emit_outcome(
+        request_id=request_id,
+        tool=tool_name,
+        event="body_complete" if complete_ok else "body_fail",
+        side_effect_class=side_effect_class,
+        authorized_reexec=authorized_reexec,
+        owner=owner,
+        error_class=None if complete_ok else "LedgerOutcomeAlreadySetError",
+    )
     return result
 
 
@@ -2864,6 +3097,7 @@ def ledger(
     audit_emitter: AuditReceiptEmitter | None = None,
     transition_binding: ToolTransitionBinding | None = None,
     *,
+    outcome_emitter: OutcomeEmitter | None = None,
     lease_ttl: float | None = None,
     lease_renew_interval: float | None = None,
     poll_interval: float | None = None,
@@ -2899,6 +3133,7 @@ def ledger(
         reconciler=reconciler,
         defer_read_only_unknown=defer_read_only_unknown,
         audit_emitter=audit_emitter,
+        outcome_emitter=outcome_emitter,
         unclassified_policy=unclassified_policy,
         **ledger_kwargs,
     )
@@ -2929,6 +3164,7 @@ def ledger_sync(
     audit_emitter: AuditReceiptEmitter | None = None,
     transition_binding: ToolTransitionBinding | None = None,
     *,
+    outcome_emitter: OutcomeEmitter | None = None,
     lease_ttl: float | None = None,
     lease_renew_interval: float | None = None,
     poll_interval: float | None = None,
@@ -2964,6 +3200,7 @@ def ledger_sync(
         reconciler=reconciler,
         defer_read_only_unknown=defer_read_only_unknown,
         audit_emitter=audit_emitter,
+        outcome_emitter=outcome_emitter,
         unclassified_policy=unclassified_policy,
         **ledger_kwargs,
     )

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -35,6 +35,12 @@ from mycelium.integrations.langgraph import (
     instrument_langgraph_tool,
 )
 from mycelium.message_validator import MessageValidator
+from mycelium.outcome_emit import (
+    FileOutcomeStorage,
+    InMemoryOutcomeStorage,
+    OutcomeEmitter,
+    OutcomeStorage,
+)
 from mycelium.protect import protect, protect_sync
 from mycelium.session import Session
 from mycelium.state_flush import (
@@ -216,11 +222,13 @@ class MyceliumConfig:
     tasks: dict[str, TaskConfig] | None = None
     state_flush: dict[str, Any] | None = None
     audit_receipt: dict[str, Any] | None = None
+    outcome_emit: dict[str, Any] | None = None
     transition: TransitionConfig | None = None
     action_ledger: dict[str, Any] | None = None
     task_ledger_defaults: dict[str, Any] | None = None
     integrations: dict[str, dict[str, Any]] | None = None
     _audit_emitter: AuditReceiptEmitter | None = None
+    _outcome_emitter: OutcomeEmitter | None = None
     _state_flush: StateFlush | None = None
     _audit_auto: bool = False
 
@@ -268,6 +276,7 @@ class MyceliumConfig:
         if tool_config.ledger is not None:
             storage = self._build_ledger_storage(tool_config.ledger)
             audit_emitter = self._tool_audit_emitter(tool_config)
+            outcome_emitter = self.build_outcome_emitter()
             transition_binding = self.tool_transition_binding(tool_config)
             ledger_kwargs = self._ledger_timing_kwargs()
             unclassified_policy = (self.action_ledger or {}).get(
@@ -278,6 +287,7 @@ class MyceliumConfig:
                 func = ledger(
                     storage=storage,
                     audit_emitter=audit_emitter,
+                    outcome_emitter=outcome_emitter,
                     transition_binding=transition_binding,
                     **ledger_kwargs,
                 )(func)
@@ -285,6 +295,7 @@ class MyceliumConfig:
                 func = ledger_sync(
                     storage=storage,
                     audit_emitter=audit_emitter,
+                    outcome_emitter=outcome_emitter,
                     transition_binding=transition_binding,
                     **ledger_kwargs,
                 )(func)
@@ -454,6 +465,22 @@ class MyceliumConfig:
             storage=storage,
         )
         return self._audit_emitter
+
+    def build_outcome_emitter(self) -> OutcomeEmitter | None:
+        """Build an OutcomeEmitter if the config declares one."""
+        if self.outcome_emit is None:
+            return None
+        if self._outcome_emitter is not None:
+            return self._outcome_emitter
+        agent_id = "mycelium"
+        if self.transition is not None:
+            agent_id = self.transition.agent_id
+        storage = self._build_outcome_storage(self.outcome_emit)
+        self._outcome_emitter = OutcomeEmitter(
+            agent_id=str(agent_id),
+            storage=storage,
+        )
+        return self._outcome_emitter
 
     def prepare_messages(self, messages: list[Any]) -> list[Any]:
         """
@@ -667,6 +694,18 @@ class MyceliumConfig:
         if storage_type == "memory":
             return InMemoryAuditReceiptStorage()
         raise ConfigError(f"unknown audit_receipt storage type: {storage_type!r}")
+
+    @staticmethod
+    def _build_outcome_storage(raw: dict[str, Any]) -> OutcomeStorage:
+        storage_type = raw.get("storage", "memory")
+        if storage_type == "file":
+            path = raw.get("path")
+            if not path:
+                raise ConfigError("outcome_emit storage 'file' requires a 'path'")
+            return FileOutcomeStorage(path)
+        if storage_type == "memory":
+            return InMemoryOutcomeStorage()
+        raise ConfigError(f"unknown outcome_emit storage type: {storage_type!r}")
 
     def wrap_module(self, module: Any) -> Any:
         """
@@ -1223,6 +1262,15 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
 
     audit_auto = bool(audit_receipt_raw and audit_receipt_raw.get("auto", True))
 
+    outcome_emit_raw = data.get("outcome_emit")
+    if outcome_emit_raw is not None and not isinstance(outcome_emit_raw, dict):
+        raise ConfigError("'outcome_emit' must be a mapping")
+    if outcome_emit_raw is not None and outcome_emit_raw.get("agent_id"):
+        raise ConfigError(
+            "'outcome_emit.agent_id' is no longer supported; "
+            "set 'transition.agent_id' instead"
+        )
+
     tools_raw = data.get("tools", {})
     if not isinstance(tools_raw, dict):
         raise ConfigError("'tools' must be a mapping")
@@ -1299,6 +1347,7 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
         message_validator=message_validator,
         state_flush=state_flush_raw,
         audit_receipt=audit_receipt_raw,
+        outcome_emit=outcome_emit_raw,
         transition=transition,
         action_ledger=action_ledger_raw,
         task_ledger_defaults=task_ledger_raw,

--- a/sdk/mycelium/outcome_emit.py
+++ b/sdk/mycelium/outcome_emit.py
@@ -1,0 +1,395 @@
+"""OutcomeEmitter: compact, append-only resolution telemetry + the DTTR metric.
+
+Rows are flat and warehouse-friendly (one JSON object per line) and are
+emitted only on resolution events — never per poll tick — so a small store
+stays small. Emitters are fault-tolerant by design: an append failure is
+logged and swallowed so telemetry can never break the tool path.
+
+The Duplicate Tool Transition Rate (DTTR) is computed after the fact from
+the rows: it is the number of *silent duplicate* tool-body executions divided
+by the number of transitions that were long-running or redispatched. See
+:func:`compute_dttr` for the exact definitions.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mycelium.storage.file_lock import PathFileLock
+
+_logger = logging.getLogger(__name__)
+
+# Discrete resolution events an emitter row can carry.
+EVENT_RESOLUTION = "resolution"      # a claim/dispatch resolved to a gate
+EVENT_BODY_START = "body_start"      # tool body began executing
+EVENT_BODY_COMPLETE = "body_complete"  # tool body returned successfully
+EVENT_BODY_FAIL = "body_fail"        # tool body raised; failure recorded
+EVENT_RELEASE = "release"            # operator release recorded
+
+# Coarse gate names attached to resolution events.
+GATE_ALLOW = "ALLOW"
+GATE_RETURN = "RETURN"
+GATE_HARD_BLOCK = "HARD_BLOCK"
+GATE_SOFT_BLOCK = "SOFT_BLOCK"
+GATE_RELEASE = "RELEASE"
+
+
+@dataclass(frozen=True)
+class OutcomeRow:
+    """One flat telemetry row describing a transition resolution event.
+
+    ``tool_body_executed`` is True exactly on ``body_start`` rows — counting
+    those rows per transition yields the tool-body execution count used by
+    :func:`compute_dttr`. ``authorized_reexec`` is True only when that body
+    run was authorized by a consumed ``NOT_EXECUTED`` verdict (reconciler or
+    operator release), i.e. it is not a silent duplicate.
+    """
+
+    ts: float
+    agent_id: str
+    tool: str
+    request_id: str
+    event: str
+    gate: str | None = None
+    terminal_outcome: str | None = None
+    side_effect_boundary: str | None = None
+    side_effect_class: str | None = None
+    tool_body_executed: bool = False
+    dispatch_attempt: int | None = None
+    authorized_reexec: bool = False
+    owner: str | None = None
+    error_class: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ts": self.ts,
+            "agent_id": self.agent_id,
+            "tool": self.tool,
+            "request_id": self.request_id,
+            "event": self.event,
+            "gate": self.gate,
+            "terminal_outcome": self.terminal_outcome,
+            "side_effect_boundary": self.side_effect_boundary,
+            "side_effect_class": self.side_effect_class,
+            "tool_body_executed": self.tool_body_executed,
+            "dispatch_attempt": self.dispatch_attempt,
+            "authorized_reexec": self.authorized_reexec,
+            "owner": self.owner,
+            "error_class": self.error_class,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OutcomeRow:
+        return cls(
+            ts=float(data["ts"]),
+            agent_id=str(data["agent_id"]),
+            tool=str(data["tool"]),
+            request_id=str(data["request_id"]),
+            event=str(data["event"]),
+            gate=data.get("gate"),
+            terminal_outcome=data.get("terminal_outcome"),
+            side_effect_boundary=data.get("side_effect_boundary"),
+            side_effect_class=data.get("side_effect_class"),
+            tool_body_executed=bool(data.get("tool_body_executed", False)),
+            dispatch_attempt=data.get("dispatch_attempt"),
+            authorized_reexec=bool(data.get("authorized_reexec", False)),
+            owner=data.get("owner"),
+            error_class=data.get("error_class"),
+        )
+
+
+class OutcomeStorage:
+    def append(self, row: OutcomeRow) -> None:
+        raise NotImplementedError
+
+    def list_all(self) -> list[OutcomeRow]:
+        raise NotImplementedError
+
+
+class InMemoryOutcomeStorage(OutcomeStorage):
+    def __init__(self) -> None:
+        self._rows: list[OutcomeRow] = []
+
+    def append(self, row: OutcomeRow) -> None:
+        self._rows.append(row)
+
+    def list_all(self) -> list[OutcomeRow]:
+        return list(self._rows)
+
+
+class FileOutcomeStorage(OutcomeStorage):
+    """Append-only NDJSON outcome log with ``fcntl`` locking.
+
+    Mirrors :class:`FileAuditReceiptStorage`; rows are one JSON object per
+    line. Malformed lines are skipped with a warning so a torn write never
+    breaks the reader.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = PathFileLock(self._path)
+
+    def append(self, row: OutcomeRow) -> None:
+        with self._lock.acquire():
+            with self._path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(row.to_dict(), default=str) + "\n")
+
+    def list_all(self) -> list[OutcomeRow]:
+        with self._lock.acquire():
+            if not self._path.exists():
+                return []
+            rows: list[OutcomeRow] = []
+            with self._path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rows.append(OutcomeRow.from_dict(json.loads(line)))
+                    except Exception:
+                        _logger.warning(
+                            "skipping malformed outcome row: %s", line
+                        )
+            return rows
+
+
+class OutcomeEmitter:
+    """Fault-tolerant sink for :class:`OutcomeRow` telemetry.
+
+    ``emit``/``emit_event`` never raise: a storage failure is logged and
+    swallowed so emission can never break the tool path.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        storage: OutcomeStorage | None = None,
+    ) -> None:
+        self.agent_id = agent_id
+        self._storage = storage if storage is not None else InMemoryOutcomeStorage()
+
+    @property
+    def storage(self) -> OutcomeStorage:
+        return self._storage
+
+    def emit(self, row: OutcomeRow) -> None:
+        try:
+            self._storage.append(row)
+        except Exception:
+            _logger.exception(
+                "outcome emitter storage failed for %s/%s",
+                row.request_id,
+                row.event,
+            )
+
+    def emit_event(
+        self,
+        *,
+        tool: str,
+        request_id: str,
+        event: str,
+        gate: str | None = None,
+        terminal_outcome: str | None = None,
+        side_effect_boundary: str | None = None,
+        side_effect_class: str | None = None,
+        tool_body_executed: bool = False,
+        dispatch_attempt: int | None = None,
+        authorized_reexec: bool = False,
+        owner: str | None = None,
+        error_class: str | None = None,
+    ) -> None:
+        self.emit(
+            OutcomeRow(
+                ts=time.time(),
+                agent_id=self.agent_id,
+                tool=tool,
+                request_id=request_id,
+                event=event,
+                gate=gate,
+                terminal_outcome=terminal_outcome,
+                side_effect_boundary=side_effect_boundary,
+                side_effect_class=side_effect_class,
+                tool_body_executed=tool_body_executed,
+                dispatch_attempt=dispatch_attempt,
+                authorized_reexec=authorized_reexec,
+                owner=owner,
+                error_class=error_class,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class TransitionDttr:
+    """DTTR breakdown for a single transition (one request_id)."""
+
+    request_id: str
+    tool: str
+    body_executions: int
+    authorized_reexecs: int
+    silent_duplicates: int
+    resolution_events: int
+    duration_seconds: float
+    long_running_or_redispatched: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "tool": self.tool,
+            "body_executions": self.body_executions,
+            "authorized_reexecs": self.authorized_reexecs,
+            "silent_duplicates": self.silent_duplicates,
+            "resolution_events": self.resolution_events,
+            "duration_seconds": round(self.duration_seconds, 3),
+            "long_running_or_redispatched": self.long_running_or_redispatched,
+        }
+
+
+@dataclass(frozen=True)
+class DttrReport:
+    """Aggregate DTTR over a set of transitions."""
+
+    dttr: float
+    silent_duplicates: int
+    long_running_or_redispatched: int
+    transitions: int
+    per_transition: tuple[TransitionDttr, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dttr": self.dttr,
+            "silent_duplicates": self.silent_duplicates,
+            "long_running_or_redispatched": self.long_running_or_redispatched,
+            "transitions": self.transitions,
+            "per_transition": [item.to_dict() for item in self.per_transition],
+        }
+
+
+def _coerce_row(raw: OutcomeRow | dict[str, Any]) -> OutcomeRow:
+    if isinstance(raw, OutcomeRow):
+        return raw
+    return OutcomeRow.from_dict(raw)
+
+
+def compute_dttr(
+    rows: list[OutcomeRow | dict[str, Any]],
+    *,
+    long_running_after: float | None = None,
+) -> DttrReport:
+    """Compute the Duplicate Tool Transition Rate (DTTR) over *rows*.
+
+    Definitions (a *transition* is every row sharing a ``request_id``):
+
+    - A *silent duplicate* is a tool-body execution for a transition that had
+      already executed at least once, without being authorized by a consumed
+      ``NOT_EXECUTED`` verdict (reconciler ``NOT_EXECUTED`` or operator
+      release verified ``not_executed``). The first execution is always
+      authorized, and each consumed ``NOT_EXECUTED`` authorizes exactly one
+      more.
+    - A transition is *long-running or redispatched* when it saw >=2
+      resolution events (framework dispatches that resolved to a gate) OR its
+      wall-clock span exceeds *long_running_after* seconds.
+    - ``DTTR = silent_duplicates / max(long_running_or_redispatched, 1)``;
+      the target is 0.
+
+    *long_running_after* of ``None`` disables the duration rule (only the
+    ``>=2`` resolution rule counts). Pass ``long_running_after=lease_ttl`` to
+    also treat transitions older than the execution lease as long-running.
+    """
+    normalized = [_coerce_row(row) for row in rows]
+    by_transition: dict[str, list[OutcomeRow]] = {}
+    for row in normalized:
+        by_transition.setdefault(row.request_id, []).append(row)
+
+    per_transition: list[TransitionDttr] = []
+    silent_duplicates = 0
+    long_or_redispatched = 0
+    for request_id, group in by_transition.items():
+        ordered = sorted(group, key=lambda row: row.ts)
+        body_rows = [
+            row
+            for row in ordered
+            if row.event == EVENT_BODY_START and row.tool_body_executed
+        ]
+        executions = len(body_rows)
+        authorized = sum(1 for row in body_rows if row.authorized_reexec)
+        allowed = 1 + authorized
+        silent = max(0, executions - allowed)
+        resolution_events = sum(
+            1 for row in ordered if row.event == EVENT_RESOLUTION
+        )
+        duration = (
+            ordered[-1].ts - ordered[0].ts if len(ordered) > 1 else 0.0
+        )
+        is_redispatched = resolution_events >= 2
+        is_long_running = (
+            long_running_after is not None and duration > long_running_after
+        )
+        marked = is_redispatched or is_long_running
+        silent_duplicates += silent
+        if marked:
+            long_or_redispatched += 1
+        per_transition.append(
+            TransitionDttr(
+                request_id=request_id,
+                tool=body_rows[0].tool if body_rows else ordered[0].tool,
+                body_executions=executions,
+                authorized_reexecs=authorized,
+                silent_duplicates=silent,
+                resolution_events=resolution_events,
+                duration_seconds=duration,
+                long_running_or_redispatched=marked,
+            )
+        )
+
+    per_transition.sort(
+        key=lambda item: (not item.long_running_or_redispatched, -item.silent_duplicates)
+    )
+    dttr = silent_duplicates / max(long_or_redispatched, 1)
+    return DttrReport(
+        dttr=dttr,
+        silent_duplicates=silent_duplicates,
+        long_running_or_redispatched=long_or_redispatched,
+        transitions=len(by_transition),
+        per_transition=tuple(per_transition),
+    )
+
+
+def compute_dttr_from_storage(
+    storage: OutcomeStorage,
+    *,
+    long_running_after: float | None = None,
+) -> DttrReport:
+    """Compute DTTR over every row currently held by *storage*."""
+    return compute_dttr(
+        storage.list_all(),
+        long_running_after=long_running_after,
+    )
+
+
+__all__ = [
+    "DttrReport",
+    "EVENT_BODY_COMPLETE",
+    "EVENT_BODY_FAIL",
+    "EVENT_BODY_START",
+    "EVENT_RELEASE",
+    "EVENT_RESOLUTION",
+    "FileOutcomeStorage",
+    "GATE_ALLOW",
+    "GATE_HARD_BLOCK",
+    "GATE_RELEASE",
+    "GATE_RETURN",
+    "GATE_SOFT_BLOCK",
+    "InMemoryOutcomeStorage",
+    "OutcomeEmitter",
+    "OutcomeRow",
+    "OutcomeStorage",
+    "TransitionDttr",
+    "compute_dttr",
+    "compute_dttr_from_storage",
+]

--- a/sdk/mycelium/templates/mycelium.template.yaml
+++ b/sdk/mycelium/templates/mycelium.template.yaml
@@ -4,8 +4,8 @@
 #
 # Required vs optional
 #   Required for transition guards:  transition, action_ledger (+ tools entries you ledger)
-#   Optional:  integrations, task_ledger, state_flush, audit_receipt, registry, runner,
-#              history_guard, message_validator — delete unused sections
+#   Optional:  integrations, task_ledger, state_flush, audit_receipt, outcome_emit,
+#              registry, runner, history_guard, message_validator — delete unused sections
 #
 # Next steps
 #   1. Allowlist first: rename tools: / tasks: stubs, then copy those exact
@@ -119,6 +119,21 @@ audit_receipt:
   storage: file                           # <TODO: memory | file>
   path: ./mycelium-receipts.jsonl
   auto: true
+
+# ---------------------------------------------------------------------------
+# outcome_emit  (opt-in resolution telemetry + DTTR; omit if unused)
+#   Emits one flat NDJSON row per resolution event (gate decision, body start/
+#   complete/fail, operator release) — never per poll tick. Off by default.
+#   storage: memory | file (no analytics SaaS deps; v1 is local-only)
+#   long_running_after: seconds; transitions older than this count as
+#     "long-running" in the DTTR denominator (default: lease_ttl). The metric:
+#     DTTR = silent_duplicates / max(long_running_or_redispatched, 1), target 0.
+#   Inspect with: mycelium outcomes dttr
+# ---------------------------------------------------------------------------
+# outcome_emit:
+#   storage: file
+#   path: ./mycelium-outcomes.jsonl
+#   long_running_after: 3600
 
 # ---------------------------------------------------------------------------
 # tools  (add real function names; then list ledgered ones in

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.19.2"
+version = "1.20.0"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",

--- a/sdk/tests/test_outcome_emit.py
+++ b/sdk/tests/test_outcome_emit.py
@@ -1,0 +1,592 @@
+"""Tests for OutcomeEmitter telemetry and the DTTR metric.
+
+Covers the flat NDJSON row model, fault-tolerant emission, ``compute_dttr``
+definitions (silent duplicates vs authorized re-executions, redispatched /
+long-running denominator), the ``@ledger``/``@ledger_sync`` hook points,
+operator release + reconciler ``NOT_EXECUTED`` authorization, config wiring,
+and the ``mycelium outcomes dttr`` CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mycelium import (
+    InMemoryLedgerStorage,
+    LedgerHardBlockError,
+    ReconcileResult,
+    SideEffectBoundary,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    TransitionScope,
+    compute_dttr,
+    execution_scope,
+    ledger,
+    ledger_sync,
+    load_config,
+    load_config_from_string,
+)
+from mycelium.__main__ import main
+from mycelium.outcome_emit import (
+    EVENT_BODY_COMPLETE,
+    EVENT_BODY_FAIL,
+    EVENT_BODY_START,
+    EVENT_RELEASE,
+    EVENT_RESOLUTION,
+    GATE_ALLOW,
+    GATE_HARD_BLOCK,
+    GATE_RETURN,
+    FileOutcomeStorage,
+    InMemoryOutcomeStorage,
+    OutcomeEmitter,
+    OutcomeRow,
+)
+
+_BINDING = ToolTransitionBinding.for_tool(
+    agent_id="test",
+    policy_version="1",
+    side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+)
+
+_SCOPE = TransitionScope(thread_id="t", run_id="r")
+
+
+# ---------------------------------------------------------------------------
+# Row model + storage
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_row_round_trips_through_dict() -> None:
+    row = OutcomeRow(
+        ts=1.5,
+        agent_id="a",
+        tool="charge",
+        request_id="req-1",
+        event=EVENT_BODY_START,
+        gate=None,
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        side_effect_boundary=SideEffectBoundary.NOT_CROSSED.value,
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE.value,
+        tool_body_executed=True,
+        authorized_reexec=True,
+        owner="w1",
+    )
+    restored = OutcomeRow.from_dict(row.to_dict())
+    assert restored == row
+    assert restored.tool_body_executed is True
+    assert restored.authorized_reexec is True
+
+
+def test_file_outcome_storage_is_append_only_jsonl(tmp_path: Path) -> None:
+    path = tmp_path / "outcomes.jsonl"
+    storage = FileOutcomeStorage(path)
+    emitter = OutcomeEmitter(agent_id="a", storage=storage)
+    emitter.emit_event(tool="t", request_id="r1", event=EVENT_RESOLUTION, gate=GATE_ALLOW)
+    emitter.emit_event(
+        tool="t",
+        request_id="r1",
+        event=EVENT_BODY_START,
+        tool_body_executed=True,
+    )
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event"] == EVENT_RESOLUTION
+    assert len(storage.list_all()) == 2
+
+    reopened = FileOutcomeStorage(path)
+    assert len(reopened.list_all()) == 2
+
+
+def test_file_outcome_storage_skips_malformed_lines(tmp_path: Path) -> None:
+    path = tmp_path / "outcomes.jsonl"
+    path.write_text("{broken}\n", encoding="utf-8")
+    storage = FileOutcomeStorage(path)
+    assert storage.list_all() == []
+
+
+def test_emitter_never_raises_on_storage_failure() -> None:
+    class BrokenStorage(InMemoryOutcomeStorage):
+        def append(self, row: OutcomeRow) -> None:
+            raise OSError("disk full")
+
+    emitter = OutcomeEmitter(agent_id="a", storage=BrokenStorage())
+    emitter.emit_event(tool="t", request_id="r1", event=EVENT_RESOLUTION)
+    assert emitter.storage.list_all() == []
+
+
+# ---------------------------------------------------------------------------
+# compute_dttr
+# ---------------------------------------------------------------------------
+
+
+def _resolution(request_id: str, tool: str = "t", ts: float = 0.0) -> OutcomeRow:
+    return OutcomeRow(
+        ts=ts,
+        agent_id="a",
+        tool=tool,
+        request_id=request_id,
+        event=EVENT_RESOLUTION,
+        gate=GATE_ALLOW,
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+    )
+
+
+def _body_start(
+    request_id: str, tool: str = "t", ts: float = 1.0, authorized: bool = False
+) -> OutcomeRow:
+    return OutcomeRow(
+        ts=ts,
+        agent_id="a",
+        tool=tool,
+        request_id=request_id,
+        event=EVENT_BODY_START,
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        tool_body_executed=True,
+        authorized_reexec=authorized,
+    )
+
+
+def test_dttr_clean_transition_is_zero() -> None:
+    rows = [
+        _resolution("r1"),
+        _body_start("r1"),
+    ]
+    report = compute_dttr(rows)
+    assert report.dttr == 0.0
+    assert report.silent_duplicates == 0
+    assert report.long_running_or_redispatched == 0
+
+
+def test_dttr_counts_silent_duplicate_executions() -> None:
+    # Two body executions, no NOT_EXECUTED authorization anywhere → 1 silent.
+    rows = [
+        _resolution("r1", ts=0.0),
+        _body_start("r1", ts=1.0, authorized=False),
+        _resolution("r1", ts=2.0),
+        _body_start("r1", ts=3.0, authorized=False),
+    ]
+    report = compute_dttr(rows)
+    assert report.silent_duplicates == 1
+    assert report.long_running_or_redispatched == 1
+    assert report.dttr == 1.0
+
+
+def test_dttr_authorized_reexec_is_not_silent() -> None:
+    # Second run followed a consumed NOT_EXECUTED → authorized, not silent.
+    rows = [
+        _resolution("r1", ts=0.0),
+        _body_start("r1", ts=1.0, authorized=False),
+        _resolution("r1", ts=2.0),
+        _body_start("r1", ts=3.0, authorized=True),
+    ]
+    report = compute_dttr(rows)
+    assert report.silent_duplicates == 0
+    # Still redispatched (2 resolution events) so it enters the denominator.
+    assert report.long_running_or_redispatched == 1
+    assert report.dttr == 0.0
+
+
+def test_dttr_redispatched_denominator() -> None:
+    # Two dispatches resolving to RETURN (second redispatch got the cached
+    # result) with a single body execution → 0 silent, 1 long/redispatched.
+    rows = [
+        _resolution("r1", ts=0.0),
+        _body_start("r1", ts=1.0),
+        OutcomeRow(
+            ts=2.0,
+            agent_id="a",
+            tool="t",
+            request_id="r1",
+            event=EVENT_BODY_COMPLETE,
+            terminal_outcome=TerminalOutcome.COMPLETED.value,
+        ),
+        OutcomeRow(
+            ts=3.0,
+            agent_id="a",
+            tool="t",
+            request_id="r1",
+            event=EVENT_RESOLUTION,
+            gate=GATE_RETURN,
+            terminal_outcome=TerminalOutcome.COMPLETED.value,
+        ),
+    ]
+    report = compute_dttr(rows)
+    assert report.silent_duplicates == 0
+    assert report.long_running_or_redispatched == 1
+    assert report.dttr == 0.0
+    assert report.transitions == 1
+
+
+def test_dttr_long_running_duration_rule() -> None:
+    rows = [
+        _resolution("r1", ts=0.0),
+        _body_start("r1", ts=5.0),
+        _body_start("r2", ts=5.0),
+    ]
+    assert compute_dttr(rows, long_running_after=None).long_running_or_redispatched == 0
+    assert compute_dttr(rows, long_running_after=2.0).long_running_or_redispatched == 1
+
+
+def test_dttr_empty_rows() -> None:
+    report = compute_dttr([])
+    assert report.dttr == 0.0
+    assert report.transitions == 0
+    assert report.silent_duplicates == 0
+
+
+def test_dttr_accepts_dicts() -> None:
+    rows = [_resolution("r1").to_dict(), _body_start("r1").to_dict()]
+    assert compute_dttr(rows).dttr == 0.0
+
+
+# ---------------------------------------------------------------------------
+# @ledger_sync / @ledger integration
+# ---------------------------------------------------------------------------
+
+
+def _sync_ledgered() -> tuple[Any, OutcomeEmitter]:
+    emitter = OutcomeEmitter(agent_id="test", storage=InMemoryOutcomeStorage())
+
+    @ledger_sync(
+        storage=InMemoryLedgerStorage(),
+        transition_binding=_BINDING,
+        outcome_emitter=emitter,
+    )
+    def charge(amount: int) -> str:
+        return f"charged-{amount}"
+
+    return charge, emitter
+
+
+def test_ledger_sync_emits_resolution_and_body_rows() -> None:
+    charge, emitter = _sync_ledgered()
+    with execution_scope(_SCOPE):
+        assert charge(5) == "charged-5"
+    events = [row.event for row in emitter.storage.list_all()]
+    assert events == [EVENT_RESOLUTION, EVENT_BODY_START, EVENT_BODY_COMPLETE]
+    report = compute_dttr(emitter.storage.list_all())
+    assert report.silent_duplicates == 0
+    assert report.dttr == 0.0
+
+
+def test_ledger_sync_redispatch_returns_cached_without_body() -> None:
+    charge, emitter = _sync_ledgered()
+    with execution_scope(_SCOPE):
+        assert charge(5) == "charged-5"
+        assert charge(5) == "charged-5"
+    events = [row.event for row in emitter.storage.list_all()]
+    body_rows = [row for row in emitter.storage.list_all() if row.tool_body_executed]
+    assert len(body_rows) == 1  # body ran exactly once across both dispatches
+    assert events.count(EVENT_RESOLUTION) == 2  # two dispatches, both resolved
+    assert events[3] == EVENT_RESOLUTION
+    report = compute_dttr(emitter.storage.list_all())
+    assert report.silent_duplicates == 0
+    assert report.long_running_or_redispatched == 1
+    assert report.dttr == 0.0
+
+
+def test_ledger_sync_body_failure_emits_fail_row() -> None:
+    emitter = OutcomeEmitter(agent_id="test", storage=InMemoryOutcomeStorage())
+
+    @ledger_sync(
+        storage=InMemoryLedgerStorage(),
+        transition_binding=_BINDING,
+        outcome_emitter=emitter,
+    )
+    def explode() -> str:
+        raise ValueError("boom")
+
+    with execution_scope(_SCOPE):
+        with pytest.raises(ValueError):
+            explode()
+    events = [row.event for row in emitter.storage.list_all()]
+    assert events == [EVENT_RESOLUTION, EVENT_BODY_START, EVENT_BODY_FAIL]
+    fail_row = emitter.storage.list_all()[-1]
+    assert fail_row.error_class == "ValueError"
+    assert fail_row.terminal_outcome == TerminalOutcome.FAILED_BEFORE_EFFECT.value
+
+
+def test_ledger_async_emits_rows() -> None:
+    emitter = OutcomeEmitter(agent_id="test", storage=InMemoryOutcomeStorage())
+
+    @ledger(
+        storage=InMemoryLedgerStorage(),
+        transition_binding=_BINDING,
+        outcome_emitter=emitter,
+    )
+    async def send(tag: str) -> str:
+        return f"sent-{tag}"
+
+    async def run() -> None:
+        with execution_scope(_SCOPE):
+            assert await send("x") == "sent-x"
+
+    asyncio_run(run())
+    events = [row.event for row in emitter.storage.list_all()]
+    assert events == [EVENT_RESOLUTION, EVENT_BODY_START, EVENT_BODY_COMPLETE]
+
+
+def test_ledger_sync_hard_block_emits_resolution_row() -> None:
+    from mycelium import side_effect
+
+    emitter = OutcomeEmitter(agent_id="test", storage=InMemoryOutcomeStorage())
+    fail_first = {"v": True}
+
+    @ledger_sync(
+        storage=InMemoryLedgerStorage(),
+        transition_binding=_BINDING,
+        outcome_emitter=emitter,
+    )
+    def dangerous(key: int) -> str:
+        with side_effect():
+            if fail_first["v"]:
+                fail_first["v"] = False
+                raise ValueError("boom")
+        return f"done-{key}"
+
+    with execution_scope(_SCOPE):
+        with pytest.raises(ValueError):
+            dangerous(key=1)
+        # FAILED_AFTER_EFFECT + no reconciler/ref → HARD_BLOCK.
+        with pytest.raises(LedgerHardBlockError):
+            dangerous(key=1)
+
+    gates = [
+        row.gate for row in emitter.storage.list_all() if row.event == EVENT_RESOLUTION
+    ]
+    assert GATE_HARD_BLOCK in gates
+    assert gates.count(GATE_HARD_BLOCK) == 1
+
+
+# ---------------------------------------------------------------------------
+# Operator release + reconciler NOT_EXECUTED authorization
+# ---------------------------------------------------------------------------
+
+
+def test_operator_release_not_executed_authorizes_reexec() -> None:
+    from mycelium import record_external_operation, side_effect
+
+    emitter = OutcomeEmitter(agent_id="test", storage=InMemoryOutcomeStorage())
+    fail_first = {"v": True}
+
+    @ledger_sync(
+        storage=InMemoryLedgerStorage(),
+        transition_binding=_BINDING,
+        outcome_emitter=emitter,
+    )
+    def charge(amount: int) -> str:
+        with side_effect():
+            record_external_operation("pi_7")
+            if fail_first["v"]:
+                fail_first["v"] = False
+                raise ValueError("provider timeout")
+        return f"charged-{amount}"
+
+    with execution_scope(_SCOPE):
+        with pytest.raises(ValueError):
+            charge(amount=5)
+        # Operator verifies the effect never happened → one authorized re-run.
+        ledger_instance = get_ledger_for(charge)
+        request_id = next(
+            row.request_id
+            for row in emitter.storage.list_all()
+            if row.event == EVENT_BODY_FAIL
+        )
+        ledger_instance.release(
+            request_id,
+            verified="not_executed",
+            by="ops",
+            reason="provider showed no charge",
+        )
+        assert charge(amount=5) == "charged-5"
+
+    rows = emitter.storage.list_all()
+    body_rows = [row for row in rows if row.tool_body_executed]
+    assert len(body_rows) == 2
+    assert body_rows[0].authorized_reexec is False
+    assert body_rows[1].authorized_reexec is True
+    release_rows = [row for row in rows if row.event == EVENT_RELEASE]
+    assert len(release_rows) == 1
+    assert release_rows[0].authorized_reexec is True
+    report = compute_dttr(rows)
+    assert report.silent_duplicates == 0
+    assert report.dttr == 0.0
+
+
+class _Reconciler:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def reconcile(self, entry: Any) -> ReconcileResult:
+        self.calls += 1
+        return ReconcileResult.not_executed()
+
+
+def test_reconciler_not_executed_authorizes_reexec() -> None:
+    from mycelium import record_external_operation, side_effect
+
+    emitter = OutcomeEmitter(agent_id="test", storage=InMemoryOutcomeStorage())
+    reconciler = _Reconciler()
+    fail_first = {"v": True}
+
+    @ledger_sync(
+        storage=InMemoryLedgerStorage(),
+        transition_binding=_BINDING,
+        outcome_emitter=emitter,
+        reconciler=reconciler,
+    )
+    def charge(amount: int) -> str:
+        with side_effect():
+            record_external_operation("pi_9")
+            if fail_first["v"]:
+                fail_first["v"] = False
+                raise ValueError("provider timeout")
+        return f"charged-{amount}"
+
+    with execution_scope(_SCOPE):
+        with pytest.raises(ValueError):
+            charge(amount=5)
+        # Redispatch: FAILED_AFTER_EFFECT + external_operation_ref → HARD_BLOCK
+        # → reconciler proves NOT_EXECUTED → exactly one authorized re-run.
+        assert charge(amount=5) == "charged-5"
+
+    rows = emitter.storage.list_all()
+    body_rows = [row for row in rows if row.tool_body_executed]
+    assert len(body_rows) == 2
+    assert body_rows[0].authorized_reexec is False
+    assert body_rows[1].authorized_reexec is True
+    assert compute_dttr(rows).silent_duplicates == 0
+
+
+# ---------------------------------------------------------------------------
+# Config wiring
+# ---------------------------------------------------------------------------
+
+
+def test_config_builds_outcome_emitter_from_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "mycelium.yaml"
+    path.write_text(
+        """
+transition:
+  agent_id: "acme"
+  policy_version: "1"
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+""",
+        encoding="utf-8",
+    )
+    config = load_config(path)
+    emitter = config.build_outcome_emitter()
+    assert emitter is not None
+    assert emitter.agent_id == "acme"
+    assert isinstance(emitter.storage, FileOutcomeStorage)
+
+
+def test_config_apply_tool_wires_outcome_emitter(tmp_path: Path) -> None:
+    path = tmp_path / "mycelium.yaml"
+    path.write_text(
+        """
+transition:
+  agent_id: "acme"
+  policy_version: "1"
+  scope_from:
+    run_id: run_id
+action_ledger:
+  storage: memory
+  tools: [charge]
+outcome_emit:
+  storage: memory
+tools:
+  charge:
+    callable: tests.test_outcome_emit:charge
+    side_effect_class: non_idempotent_mutate
+""",
+        encoding="utf-8",
+    )
+    config = load_config(path)
+
+    def charge(amount: int) -> str:
+        return f"charged-{amount}"
+
+    wrapped = config.apply_tool("charge", charge)
+    emitter = config.build_outcome_emitter()
+    assert emitter is not None
+    with execution_scope(_SCOPE):
+        assert wrapped(5) == "charged-5"
+    rows = emitter.storage.list_all()
+    assert len(rows) >= 3
+    assert any(row.event == EVENT_BODY_COMPLETE for row in rows)
+
+
+def test_config_outcome_emit_must_be_mapping() -> None:
+    with pytest.raises(Exception):
+        load_config_from_string("outcome_emit: 42\n")
+
+
+def test_config_outcome_emit_agent_id_not_supported() -> None:
+    with pytest.raises(Exception):
+        load_config_from_string(
+            "transition:\n  agent_id: a\n  policy_version: '1'\noutcome_emit:\n"
+            "  agent_id: x\n  storage: memory\n"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_outcomes_dttr_on_file(tmp_path: Path) -> None:
+    path = tmp_path / "outcomes.jsonl"
+    emitter = OutcomeEmitter(agent_id="a", storage=FileOutcomeStorage(path))
+    emitter.emit_event(tool="t", request_id="r1", event=EVENT_RESOLUTION, gate=GATE_ALLOW)
+    emitter.emit_event(
+        tool="t", request_id="r1", event=EVENT_BODY_START, tool_body_executed=True
+    )
+    emitter.emit_event(
+        tool="t",
+        request_id="r1",
+        event=EVENT_RESOLUTION,
+        gate=GATE_RETURN,
+        terminal_outcome=TerminalOutcome.COMPLETED.value,
+    )
+    assert main(["outcomes", "dttr", "--file", str(path)]) == 0
+
+
+def test_cli_outcomes_dttr_json(tmp_path: Path) -> None:
+    path = tmp_path / "outcomes.jsonl"
+    storage = FileOutcomeStorage(path)
+    storage.append(_body_start("r1"))
+    assert main(["outcomes", "dttr", "--file", str(path), "--json"]) == 0
+
+
+def test_cli_outcomes_dttr_missing_config(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["outcomes", "dttr", "-c", str(tmp_path / "nope.yaml")]) == 2
+    assert "no outcome log specified" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def get_ledger_for(func: Any) -> Any:
+    from mycelium import get_ledger
+
+    ledger_instance = get_ledger(func)
+    assert ledger_instance is not None
+    return ledger_instance
+
+
+def asyncio_run(coro: Any) -> None:
+    import asyncio
+
+    asyncio.run(coro)


### PR DESCRIPTION
## What

Opt-in resolution telemetry (`OutcomeEmitter`) plus a pinned **Duplicate Tool Transition Rate (DTTR)** metric — a single number that makes the no-double-execute guarantee observable in production. Target: 0.0.

- **`sdk/mycelium/outcome_emit.py`**: flat, warehouse-friendly `OutcomeRow` (one JSON object per NDJSON line), memory + file storage, fault-tolerant `OutcomeEmitter` (a storage failure is logged and swallowed — never breaks the tool path), and `compute_dttr()` / `compute_dttr_from_storage()`.
- **Wiring**: new `outcome_emitter=` kwarg on `@ledger` / `@ledger_sync` and `ActionLedger(...)`; rows emitted only on resolution events (gate decision, body start/complete/fail, operator release) — never per poll tick. A body run following a consumed `NOT_EXECUTED` verdict (reconciler or operator release) is tagged `authorized_reexec=True`.
- **Config**: YAML `outcome_emit:` section (off by default; `storage: memory|file`, `path:`, `long_running_after:`), commented stub in the full init template.
- **CLI**: `mycelium outcomes dttr [--config|--file] [--long-running-after N] [--json]`.
- **Version**: 1.19.2 → 1.20.0 (minor).

## DTTR definition

- Silent duplicate = tool-body execution not authorized by a consumed `NOT_EXECUTED` verdict (the guarantee is `executions <= 1 + not_executed_verdicts`).
- Long-running/redispatched = ≥2 resolution events OR a span > `long_running_after` (default `lease_ttl`).
- `DTTR = silent_duplicates / max(long_running_or_redispatched, 1)`; target 0.

## Verification

- `tests/test_outcome_emit.py`: 25 tests (rows, NDJSON storage incl. malformed-line tolerance, fault-tolerant emission, DTTR definitions, `@ledger`/`@ledger_sync` hook points incl. cached-redispatch and hard-block rows, operator release + reconciler `NOT_EXECUTED` authorization, config wiring, CLI).
- Full suite: **572 passed, 3 skipped**; `ruff check mycelium tests` clean.
- End-to-end smoke: config-driven emission → `mycelium outcomes dttr` reports `DTTR: 0.0000`; simulated double-execution rows report `DTTR: 1.0000`.

Semantics note: claim/CAS/reconcile behavior is untouched — telemetry only observes. Verified no new thread-local/ContextVar leaks into later tests (the `_outcome_reexec_authorized` ContextVar is reset at dispatch start).