### PR TITLE
docs: manual claim/complete path + release v1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.20.1 (2026-08-01)
+
+Patch: document explicit claim → execute → complete (manual integration) beside
+the decorator / YAML wrap path; sync public version badges to 1.20.x.
+
+### Docs
+
+- `sdk/README.md`: new **Manual integration (claim → execute → complete)**
+  section — same ledger gates as `@ledger_sync`, for partners who own the tool
+  runner (PROCEED/SKIP-style). Prefers wrappers; no YAML switch.
+- Root `README.md`: link to that section from the non-YAML adoption path.
+- `mycelium init -h` description + post-init tip: prefer wrappers; point at
+  the manual-integration docs.
+
+### Chore
+
+- Bump package / badge / handbook version refs to **v1.20.1**.
+
 ## 1.20.0 (2026-08-01)
 
 Minor: opt-in resolution telemetry (`OutcomeEmitter`) + a pinned **Duplicate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.19.2)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.1)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -8,7 +8,7 @@
 
 Stops duplicate side effects on retry/redispatch, blocks bad tool args and out-of-scope calls, and keeps tool data fresh. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.19.2**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.20.1**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 
@@ -108,10 +108,14 @@ def my_side_effect_tool(...) -> dict:
     ...
 ```
 
-Without YAML, use the ledger decorators directly (`@ledger` / `@ledger_sync` for tools;
+Without YAML, prefer the ledger decorators (`@ledger` / `@ledger_sync` for tools;
 `@task_ledger` / `@task_ledger_sync` for coarser task-level idempotency). Same transition
 envelope and gates — see [sdk/README.md](sdk/README.md#what-ledger--ledger_sync-do)
 and [task-level idempotency](sdk/README.md#quickstart-task-level-idempotency).
+If you own the tool runner and need explicit claim → execute → complete
+(PROCEED/SKIP-style), see
+[Manual integration](sdk/README.md#manual-integration-claim--execute--complete)
+— same ledger; no YAML switch.
 
 Do not combine standalone guard decorators with command mode on the same
 function. Fully configured `@config.apply` wrappers are detected and skipped.

--- a/docs/index.html
+++ b/docs/index.html
@@ -382,7 +382,7 @@
 
     <h1>Mycelium: runtime guards for AI agents</h1>
     <p class="badges">
-      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.19.2" alt="PyPI version"></a>
+      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.20.1" alt="PyPI version"></a>
       <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/pyversions/mycelium-runtime.svg" alt="Python versions"></a>
       <a href="https://pepy.tech/project/mycelium-runtime"><img src="https://static.pepy.tech/badge/mycelium-runtime" alt="PyPI downloads"></a>
       <a href="https://github.com/mycelium-labs/mycelium"><img src="https://img.shields.io/github/license/mycelium-labs/mycelium.svg" alt="MIT license"></a>
@@ -396,7 +396,7 @@
       <strong>Opt-in:</strong> stale-context helpers and tool-boundary checks.
       YAML callable paths and <code>mycelium run</code> add the core path without
       editing each function. Framework-agnostic.
-      Early but API-stable (v1.19.2): breaking changes only at major versions.
+      Early but API-stable (v1.20.1): breaking changes only at major versions.
     </p>
 
     <section id="architecture">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.19.2)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.1)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.19.2** (fail-closed Gmail sent-log reconciler + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
+Current package: **mycelium-runtime v1.20.1** (outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
 
 ## One painful bug → a few lines of config
 
@@ -304,6 +304,69 @@ from mycelium import ledger
 async def send_payment(amount: float, recipient: str) -> dict:
     return await gateway.charge(amount, recipient)
 ```
+
+### Manual integration (claim → execute → complete)
+
+Prefer `@ledger_sync` / `@ledger`, YAML + `mycelium run`, or `@config.apply` — those wrap the tool and run the two phases for you. Use the explicit API only when you already own the tool runner (custom loop, PROCEED/SKIP-style host) and cannot take a decorator.
+
+Same ledger, same gates, same hard-block rules. You call claim and complete yourself:
+
+```python
+from mycelium import (
+    ActionLedger,
+    FileLedgerStorage,
+    LedgerHardBlockError,
+    TerminalOutcome,
+    execution_scope,
+    side_effect,
+)
+from mycelium.transition import SideEffectClass, ToolTransitionBinding, TransitionScope
+
+ledger = ActionLedger(storage=FileLedgerStorage("./mycelium-ledger.json"))
+binding = ToolTransitionBinding.for_tool(
+    agent_id="payment-agent",
+    policy_version="2026.07.1",
+    side_effect_class=SideEffectClass.KEYED_MUTATE,
+)
+
+def send_payment(amount: float, recipient: str, *, tool_call_id: str) -> dict:
+    args = (amount, recipient)
+    kwargs = {"tool_call_id": tool_call_id}
+    request_id = ledger.derive_request_id(
+        "send_payment", args, kwargs, transition_binding=binding
+    )
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1", node="tools")):
+        try:
+            entry = ledger.claim_side_effecting(
+                request_id, "send_payment", args, kwargs, binding
+            )
+        except LedgerHardBlockError:
+            # Ambiguous mutate — reconcile / operator release; do not re-run.
+            raise
+
+        # SKIP / RETURN: already completed — replay stored result, no second send.
+        if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+            return entry.result
+
+        # PROCEED: we hold IN_FLIGHT — run the side effect once, then settle.
+        try:
+            with side_effect():
+                result = gateway.charge(amount, recipient)
+            ledger.complete(request_id, result)
+            return result
+        except Exception as exc:
+            ledger.fail(request_id, exc, failed_after_effect=False)
+            raise
+```
+
+| Step | Meaning |
+|------|---------|
+| `claim_side_effecting(...)` | May I run? Resolves gates (`RETURN` / `POLL` / `HARD_BLOCK` / …). Raises on hard-block. |
+| `COMPLETED` → return `entry.result` | Partner-facing **SKIP** — already done. |
+| Else run body + `complete(...)` | Partner-facing **PROCEED** then settle. |
+| `fail(...)` | Settle a failure; use `failed_after_effect=True` if the provider may have accepted. |
+
+`mycelium init` / `mycelium run` always use the wrapper path — there is no YAML switch for manual claim/complete. For long tools claimed outside the decorator, call `renew_lease(request_id)` (or pass `lease_renew_interval` when you build the ledger) so peers keep polling instead of reclaiming mid-flight. See [Resolution gates](#resolution-gates).
 
 ## What `@ledger` / `ledger_sync` do
 

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -12,7 +12,7 @@ README is the source of truth for how the pieces are used; this file is the
 honest accounting of what can go wrong and which guarantee is pinned to which
 test.
 
-> Version note: this document tracks package **v1.19.2**. It is documentation
+> Version note: this document tracks package **v1.20.1**. It is documentation
 > only — no API or behavior change.
 
 ---

--- a/sdk/mycelium/__main__.py
+++ b/sdk/mycelium/__main__.py
@@ -53,6 +53,10 @@ def cmd_init(output: Path, *, full: bool, minimal: bool, force: bool) -> int:
         print("Try: mycelium demo")
     else:
         print("Next: edit tool/task names, then load_config(...) in your agent code.")
+    print(
+        "Prefer wrappers (mycelium run / @ledger_sync). For a custom tool loop, "
+        "see sdk/README.md — Manual integration (claim → execute → complete)."
+    )
     return 0
 
 
@@ -514,7 +518,18 @@ def main(argv: list[str] | None = None) -> int:
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
-    init_parser = sub.add_parser("init", help="Create mycelium.yaml in the current project")
+    init_parser = sub.add_parser(
+        "init",
+        help="Create mycelium.yaml in the current project",
+        description=(
+            "Scaffold mycelium.yaml for the wrapper path "
+            "(mycelium run / @config.apply / @ledger_sync). Prefer wrappers. "
+            "For a custom tool loop that needs explicit claim → execute → complete "
+            "(PROCEED/SKIP-style), see the SDK README section "
+            "'Manual integration (claim → execute → complete)' — there is no "
+            "YAML switch; that API is called from your code."
+        ),
+    )
     init_parser.add_argument(
         "-o",
         "--output",

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.20.0"
+version = "1.20.1"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",


### PR DESCRIPTION
## Summary
- Document **Manual integration (claim → execute → complete)** next to `@ledger_sync` (same ledger; prefer wrappers; no YAML switch).
- Mention it from `mycelium init -h` and the post-init tip.
- Patch release **v1.20.1** — bump pyproject + badges/handbook left on 1.19.2 after v1.20.0.

## Test plan
- [ ] `mycelium init -h` shows wrapper-prefer / manual-integration pointer
- [ ] After merge, Release workflow tags `v1.20.1` and publish.yml ships to PyPI
- [ ] Confirm https://pypi.org/project/mycelium-runtime/ shows 1.20.1