### PR TITLE
docs: sync root README + handbook with latest implementation (v1.20.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.20.2 (2026-08-01)
+
+Patch: sync root README and handbook with the latest implementation.
+
+### Docs
+
+- Root `README.md`: "What it does (v1.20.x)" heading; added **Gmail sent-log reconciler (v1.19.0)** (Core) and **Resolution telemetry + DTTR (v1.20.0)** (Opt-in) bullets.
+- Handbook (`docs/index.html`): Gmail sent-log reconciler in Resolution (match matrix), Manual integration note in Actions, new **Outcome telemetry & DTTR** section (+ sidebar nav link), latest-features lede.
+
+## Unreleased
+
 ## 1.20.1 (2026-08-01)
 
 Patch: document explicit claim → execute → complete (manual integration) beside

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Developers running **agents with side-effect tools** in production (payments, em
 
 Python 3.10+. Framework-agnostic.
 
-## What it does (v1.19.x)
+## What it does (v1.20.x)
 
 These aren't reasoning failures. They're runtime failures. Mycelium sits between your agent loop and your tools (after the LLM returns `tool_calls`):
 
@@ -29,6 +29,7 @@ These aren't reasoning failures. They're runtime failures. Mycelium sits between
   - **Worker-death signal (v1.16.0, opt-in):** when `reclaim_requires_death_signal: true`, EXPIRED entries cannot be reclaimed or released without affirmative death evidence (`mark_worker_dead()` / `mycelium transitions mark-dead`, or heartbeat older than the grace window). Prevents reclaiming from a worker that is merely paused.
   - **Provider idempotency-key validity (v1.17.0):** when `provider_idempotency_key_ttl` is set, a same-key retry that exceeds the window hard-blocks instead of retrying — the provider may have purged its deduplication state.
   - **Atomicity contract (v1.18.0):** every terminal-outcome write uses CAS (`try_transition`) — already-resolved transitions refuse overwrites. Owner fencing in `@ledger`/`@ledger_sync` prevents stale workers from overwriting another worker's outcome.
+  - **Gmail sent-log reconciler (v1.19.0):** email send tools fail after the provider accepts a message but before the 250 OK arrives — the ambiguous transition hard-blocks. `GmailReconciler` resolves it automatically by checking the Gmail sent-log (`in:sent rfc822msgid:<Message-ID>`); zero matches stays `UNKNOWN` (indexing lag), never a blind retry.
   - **Unclassified tools:** tools without a `transition_binding` have unknown side-effect semantics. `unclassified_policy: strict` routes retries through a conservative binding so failed retries hard-block instead of re-executing (default `warn` emits a one-time `UserWarning`). Side-effecting tools using memory storage get a one-time warning — the duplicate-side-effect guard only holds within the process.
   - **Stale lease (`EXPIRED`):** strict classes reclaim only when reconcile proves `NOT_EXECUTED` (fail-closed without a ref)
   - **Lease auto-renew (v1.14.0):** while a `@ledger` / `@ledger_sync` tool runs, Mycelium extends `lease_until` automatically (default every `lease_ttl / 3`) so long work does not look dead to a redispatched peer. Set `lease_renew_interval: 0` to disable; call `renew_lease()` for a manual bump or when claiming outside the decorator.
@@ -39,6 +40,7 @@ These aren't reasoning failures. They're runtime failures. Mycelium sits between
 
 - **Stale or broken context:** TTL-fresh tool data (`@protect`); optional message/history validation before the next LLM turn
 - **Bad tool calls:** block invalid inputs and out-of-scope tools before they run (`@bounded` / registry)
+- **Resolution telemetry + DTTR (v1.20.0):** opt-in `OutcomeEmitter` writes flat, append-only rows on resolution events; the **Duplicate Tool Transition Rate** makes the no-double-execute guarantee observable in production. Off by default; memory/file storage only (no analytics dependency); emission failures are logged and swallowed so telemetry never breaks the tool path.
 
 Not Langfuse. Use both if you want traces and guards. Full resolution rules: [sdk/README.md](sdk/README.md#resolution-gates). Envelope field stack: [sdk/README.md](sdk/README.md#transition-envelope-fields). Payment-class identity guidance: [sdk/README.md](sdk/README.md#payment-class-identity-server-authoritative). Failure & threat model: [sdk/docs/FAILURE_AND_THREAT_MODEL.md](sdk/docs/FAILURE_AND_THREAT_MODEL.md).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -372,6 +372,7 @@
       <li><a href="#tools">Tool boundaries (opt-in)</a></li>
       <li><a href="#actions">Actions (core)</a></li>
       <li><a href="#resolution">Resolution</a></li>
+      <li><a href="#telemetry">Telemetry &amp; DTTR</a></li>
       <li><a href="#envelope">Envelope (core)</a></li>
       <li><a href="#yaml">YAML</a></li>
       <li><a href="#common-searches">FAQ</a></li>
@@ -396,6 +397,8 @@
       <strong>Opt-in:</strong> stale-context helpers and tool-boundary checks.
       YAML callable paths and <code>mycelium run</code> add the core path without
       editing each function. Framework-agnostic.
+      Latest: fail-closed Gmail sent-log reconciler (v1.19.0) and opt-in
+      resolution telemetry with a pinned Duplicate Tool Transition Rate (v1.20.0).
       Early but API-stable (v1.20.1): breaking changes only at major versions.
     </p>
 
@@ -632,6 +635,14 @@ def process_invoice(invoice_id: str, amount: float) -> dict:
 
 process_invoice(invoice_id="inv-42", amount=100.0)
 process_invoice(invoice_id="inv-42", amount=200.0)  # returns first result</pre>
+      <p>
+        <strong>Manual integration (v1.20.1):</strong> if you own the tool runner and
+        can't take a decorator or YAML wrap (custom loop, PROCEED/SKIP-style host), call
+        the two phases yourself — <code>claim_side_effecting(...)</code> then
+        <code>complete(...)</code> / <code>fail(...)</code> — same ledger, same gates,
+        same hard-block rules. There is no YAML switch; see the SDK README's
+        <em>Manual integration (claim → execute → complete)</em> section.
+      </p>
     </section>
 
     <section id="resolution">
@@ -743,6 +754,16 @@ def send_payment(...): ...</pre>
         <code>NOT_EXECUTED</code> → run exactly once more;
         <code>UNKNOWN</code> / no ref / no reconciler → <code>LedgerHardBlockError</code>.
       </p>
+      <p>
+        <strong>Gmail sent-log reconciler (v1.19.0):</strong> email sends fail after the
+        provider accepts the message but before the 250 OK reaches the agent. A
+        <code>GmailReconciler</code> checks the sent-log
+        (<code>users.messages.list(q='in:sent rfc822msgid:&lt;Message-ID&gt;')</code>):
+        one match → <code>COMPLETED</code>; zero matches → <code>UNKNOWN</code> (indexing
+        lag — never a blind retry); two or more → <code>UNKNOWN</code> (duplicate may
+        already have occurred). The transition stays hard-blocked until reconcile or
+        operator release.
+      </p>
       <pre>Boundary at failure     Terminal outcome        Redispatch
 not_crossed             FAILED_BEFORE_EFFECT    retry if policy allows
 maybe_crossed           UNKNOWN                 hard-block → reconcile
@@ -768,6 +789,27 @@ EXPIRED + maybe_crossed / crossed            → hard-block</pre>
 mycelium transitions show &lt;request_id&gt;
 mycelium transitions release &lt;request_id&gt; --verified not-executed \
   --by ops@example.com --reason "provider shows no charge"</pre>
+    </section>
+
+    <section id="telemetry">
+      <h2>Outcome telemetry &amp; DTTR (v1.20+)</h2>
+      <p>
+        Opt-in <code>OutcomeEmitter</code> writes flat, append-only rows (one JSON object
+        per line) only on resolution events — a dispatch resolving to a gate
+        (<code>ALLOW</code> / <code>RETURN</code> / <code>HARD_BLOCK</code> /
+        <code>SOFT_BLOCK</code>), tool-body start/complete/fail, and operator release.
+        Poll ticks never emit. Off by default; memory or file storage only in v1 (no
+        analytics dependency); a storage failure is logged and swallowed so telemetry can
+        never break the tool path or alter claim / CAS / reconcile semantics.
+      </p>
+      <p>
+        From those rows you compute the <strong>Duplicate Tool Transition Rate (DTTR)</strong>
+        — a single number that makes the no-double-execute guarantee observable in production
+        and regresses loudly the day it doesn't. Enable via <code>outcome_emit:</code> in YAML
+        or the <code>outcome_emitter=</code> kwarg on <code>@ledger</code> /
+        <code>@ledger_sync</code>; compute the metric with the CLI or the library. See the
+        SDK README's <em>Outcome telemetry &amp; DTTR</em> section.
+      </p>
     </section>
 
     <section id="envelope">

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.20.1"
+version = "1.20.2"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",


### PR DESCRIPTION
Docs-only sync + release prep.

**What:**
- Root `README.md`: `What it does (v1.20.x)` heading; added missing **Gmail sent-log reconciler (v1.19.0)** (Core) and **Resolution telemetry + DTTR (v1.20.0)** (Opt-in) bullets.
- Handbook `docs/index.html`: Gmail sent-log reconciler in Resolution (match matrix), Manual integration note in Actions, new **Outcome telemetry & DTTR** section + sidebar nav link, lede mentions latest features.
- `CHANGELOG.md` + `sdk/pyproject.toml` bumped to **v1.20.2** (patch — docs only; no API change).

Merge to release: automation tags v1.20.2 + GitHub Release; I'll then publish to PyPI (manual dispatch, known PAT trigger gap) and verify.