### PR TITLE
docs: webhook event-dedupe recipe + runnable examples (v1.20.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.20.3 (2026-08-01)
+
+Patch: webhook event-dedupe recipe — docs + runnable examples only (no core
+ledger change).
+
+### Docs
+
+- `sdk/README.md`: new **Webhook event dedupe (optional)** section beside the
+  manual-claim path — claim inbound provider events on the provider event id
+  (Stripe `event.id` / GitHub `X-GitHub-Delivery` / Twilio SID) through the
+  same `ActionLedger`; at-least-once delivery + durable claim = at-most-once
+  handler side effects. Explicitly an adjacent recipe, not a webhook platform.
+- `sdk/examples/webhooks/`: runnable one-pagers (fakes, no credentials) —
+  `stripe.md`/`stripe_handler.py`, `github.md`/`github_handler.py`,
+  `twilio.md`/`twilio_handler.py`. Each: verify signature → claim on event id →
+  SKIP / PROCEED-once / HARD_BLOCK fail-closed.
+- Root `README.md`: one-line pointer ("Inbound webhook event ids").
+- `sdk/README.md` Manual integration example: dropped the `side_effect()`
+  helper (no-op + warning outside `@ledger` bodies); documented that the manual
+  path is still fail-closed via the durable claim.
+
+## Unreleased
+
 ## 1.20.2 (2026-08-01)
 
 Patch: sync root README and handbook with the latest implementation.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ These aren't reasoning failures. They're runtime failures. Mycelium sits between
 - **Bad tool calls:** block invalid inputs and out-of-scope tools before they run (`@bounded` / registry)
 - **Resolution telemetry + DTTR (v1.20.0):** opt-in `OutcomeEmitter` writes flat, append-only rows on resolution events; the **Duplicate Tool Transition Rate** makes the no-double-execute guarantee observable in production. Off by default; memory/file storage only (no analytics dependency); emission failures are logged and swallowed so telemetry never breaks the tool path.
 
-Not Langfuse. Use both if you want traces and guards. Full resolution rules: [sdk/README.md](sdk/README.md#resolution-gates). Envelope field stack: [sdk/README.md](sdk/README.md#transition-envelope-fields). Payment-class identity guidance: [sdk/README.md](sdk/README.md#payment-class-identity-server-authoritative). Failure & threat model: [sdk/docs/FAILURE_AND_THREAT_MODEL.md](sdk/docs/FAILURE_AND_THREAT_MODEL.md).
+Not Langfuse. Use both if you want traces and guards. Full resolution rules: [sdk/README.md](sdk/README.md#resolution-gates). Envelope field stack: [sdk/README.md](sdk/README.md#transition-envelope-fields). Payment-class identity guidance: [sdk/README.md](sdk/README.md#payment-class-identity-server-authoritative). Failure & threat model: [sdk/docs/FAILURE_AND_THREAT_MODEL.md](sdk/docs/FAILURE_AND_THREAT_MODEL.md). Inbound webhook event ids: [sdk/README.md](sdk/README.md#webhook-event-dedupe-optional).
 
 ## Use it
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -318,7 +318,6 @@ from mycelium import (
     LedgerHardBlockError,
     TerminalOutcome,
     execution_scope,
-    side_effect,
 )
 from mycelium.transition import SideEffectClass, ToolTransitionBinding, TransitionScope
 
@@ -350,13 +349,12 @@ def send_payment(amount: float, recipient: str, *, tool_call_id: str) -> dict:
 
         # PROCEED: we hold IN_FLIGHT — run the side effect once, then settle.
         try:
-            with side_effect():
-                result = gateway.charge(amount, recipient)
-            ledger.complete(request_id, result)
-            return result
+            result = gateway.charge(amount, recipient)
         except Exception as exc:
             ledger.fail(request_id, exc, failed_after_effect=False)
             raise
+        ledger.complete(request_id, result)
+        return result
 ```
 
 | Step | Meaning |
@@ -366,7 +364,79 @@ def send_payment(amount: float, recipient: str, *, tool_call_id: str) -> dict:
 | Else run body + `complete(...)` | Partner-facing **PROCEED** then settle. |
 | `fail(...)` | Settle a failure; use `failed_after_effect=True` if the provider may have accepted. |
 
+The `side_effect()` / `record_external_operation()` boundary helpers only take effect inside `@ledger` / `@ledger_sync` tool bodies; in this manual path they are ignored. Durability still holds from the claim itself: if the process dies after claiming, the entry expires and a redispatch hard-blocks rather than re-running.
+
 `mycelium init` / `mycelium run` always use the wrapper path — there is no YAML switch for manual claim/complete. For long tools claimed outside the decorator, call `renew_lease(request_id)` (or pass `lease_renew_interval` when you build the ledger) so peers keep polling instead of reclaiming mid-flight. See [Resolution gates](#resolution-gates).
+
+### Webhook event dedupe (optional)
+
+If you already use Mycelium to guard agent tools, you can also claim inbound
+provider events the same way. This is an **optional adjacent recipe** — agent
+tools stay the primary use case, and it is not a general webhook platform.
+
+Inbound providers deliver **at-least-once** (Stripe, GitHub, Twilio all retry
+on non-2xx). Claim the **provider event id** through the same `ActionLedger`
+and you get **at-most-once handler side effects for that event id**: the first
+delivery does the work and `complete`s; a redelivery hits the `RETURN`/SKIP
+path and returns `200` without re-running the side effect.
+
+Key the transition on the **provider event id** — Stripe `event.id`, GitHub
+`X-GitHub-Delivery`, Twilio message/event SID — not the whole payload, not the
+provider's *response* id, and not Stripe's `Idempotency-Key` *request* header
+(that header dedupes requests you send *to* Stripe; it is unrelated to inbound
+delivery). Because the event id is the only arg in the fingerprint, a
+redelivery with slightly different payload bytes still resolves to the same
+transition. Pin `agent_id` and `policy_version` across deploys so the key
+stays stable after a release.
+
+Verify the provider signature **before** claiming. Then claim, work once, and
+settle — the same manual API as above. On `HARD_BLOCK`, fail closed (reconcile
+or use the operator-release path), never re-run blindly:
+
+```python
+from mycelium import (
+    ActionLedger,
+    FileLedgerStorage,
+    LedgerHardBlockError,
+    TerminalOutcome,
+)
+from mycelium.transition import SideEffectClass, ToolTransitionBinding
+
+ledger = ActionLedger(storage=FileLedgerStorage("./webhook-events.json"))
+binding = ToolTransitionBinding.for_tool(
+    agent_id="webhook-worker",
+    policy_version="2026.08.1",
+    side_effect_class=SideEffectClass.KEYED_MUTATE,
+)
+
+def handle_event(tool: str, event_id: str, do_work) -> int:
+    args, kwargs = (event_id,), {}
+    request_id = ledger.derive_request_id(tool, args, kwargs, transition_binding=binding)
+    try:
+        entry = ledger.claim_side_effecting(request_id, tool, args, kwargs, binding)
+    except LedgerHardBlockError:
+        return 409                          # HARD_BLOCK: reconcile / operator release
+    if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+        return 200                          # SKIP: already handled this event id
+    try:
+        result = do_work()                  # the side effect, once
+    except Exception as exc:
+        ledger.fail(request_id, exc, failed_after_effect=False)
+        return 500
+    ledger.complete(request_id, result)
+    return 200                              # PROCEED
+```
+
+> **Note (manual mode):** the boundary/ref helpers (`side_effect()`,
+> `record_external_operation()`) only take effect inside `@ledger` /
+> `@ledger_sync` tool bodies. In manual claim mode they are ignored — durability
+> comes from the claim itself: if the process dies after claiming, the entry
+> expires and a redelivery hard-blocks instead of re-running.
+
+Runnable examples (fakes only, no provider credentials):
+[Stripe](examples/webhooks/stripe.md) (`event.id`) ·
+[GitHub](examples/webhooks/github.md) (`X-GitHub-Delivery`) ·
+[Twilio](examples/webhooks/twilio.md) (message/event SID).
 
 ## What `@ledger` / `ledger_sync` do
 

--- a/sdk/examples/webhooks/github.md
+++ b/sdk/examples/webhooks/github.md
@@ -1,0 +1,63 @@
+# GitHub webhook dedupe
+
+Key the Mycelium transition on the **`X-GitHub-Delivery`** header value (a
+per-delivery GUID, e.g. `d1a...`).
+
+GitHub delivers at-least-once; failed attempts retry with the **same**
+`X-GitHub-Delivery` GUID, so keying on it dedupes retries. Claim the delivery
+id through an `ActionLedger` and you get **at-most-once handler side effects
+for that delivery id**: the first attempt does the work and `complete`s; the
+retry hits the `RETURN`/SKIP path and returns `200` without re-running.
+
+Two nuances:
+- A manual **Redeliver** (UI or API) mints a *new* `X-GitHub-Delivery` — that
+  is a genuinely new webhook delivery, so a new transition is correct.
+- Deploy-style work is not naturally idempotent: use
+  `NON_IDEMPOTENT_MUTATE` so an ambiguous retry **hard-blocks** (fail closed)
+  instead of re-running a build. Key on the delivery id — not the payload,
+  not the GitHub `X-GitHub-Event` type or installation id.
+
+Verify the `X-Hub-Signature-256` header (HMAC-SHA256 with your webhook secret)
+before claiming. On `HARD_BLOCK`, reconcile or use the operator-release path;
+never re-run blindly.
+
+```python
+from mycelium import (
+    ActionLedger, FileLedgerStorage, LedgerHardBlockError, TerminalOutcome,
+)
+from mycelium.transition import SideEffectClass, ToolTransitionBinding
+
+ledger = ActionLedger(storage=FileLedgerStorage("./github-deliveries.json"))
+binding = ToolTransitionBinding.for_tool(
+    agent_id="webhook-worker", policy_version="2026.08.1",
+    side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+)
+
+def handle_github_delivery(delivery_id: str, event: dict) -> int:
+    args, kwargs = (delivery_id,), {}  # key on X-GitHub-Delivery
+    request_id = ledger.derive_request_id(
+        "handle_github_delivery", args, kwargs, transition_binding=binding,
+    )
+    try:
+        entry = ledger.claim_side_effecting(
+            request_id, "handle_github_delivery", args, kwargs, binding)
+    except LedgerHardBlockError:
+        return 409                      # HARD_BLOCK: reconcile / operator release
+    if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+        return 200                      # SKIP: already handled this delivery id
+    try:
+        result = run_build(event)       # the side effect, once
+    except Exception as exc:
+        ledger.fail(request_id, exc, failed_after_effect=False)
+        return 500
+    ledger.complete(request_id, result)
+    return 200                          # PROCEED
+```
+
+Runnable demo (fakes only, no credentials):
+
+```bash
+python sdk/examples/webhooks/github_handler.py
+# delivery 1: 200 — PROCEED   (work ran)
+# retry:       200 — SKIP      (same X-GitHub-Delivery, no second run)
+```

--- a/sdk/examples/webhooks/github_handler.py
+++ b/sdk/examples/webhooks/github_handler.py
@@ -1,0 +1,114 @@
+"""GitHub webhook dedupe with Mycelium — keyed on ``X-GitHub-Delivery``.
+
+Runnable demo with fakes; no GitHub credentials or HTTP server required.
+Requires Python 3.10+ and the SDK importable.
+
+Flow: verify signature -> claim on the delivery id ->
+  COMPLETED / SKIP  -> return 200, no side effect
+  PROCEED (IN_FLIGHT) -> do the work once -> complete
+  HARD_BLOCK        -> fail closed / operator path
+
+GitHub delivers at-least-once; failed attempts retry with the SAME
+``X-GitHub-Delivery`` GUID, so keying on it dedupes retries. A manual
+"Redeliver" from the UI/API mints a NEW delivery id — the same event content
+then resolves to a new transition, which is the correct (new) webhook delivery.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+# Make the SDK importable when run from a checkout (no install needed).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mycelium import (  # noqa: E402
+    ActionLedger,
+    FileLedgerStorage,
+    LedgerHardBlockError,
+    TerminalOutcome,
+)
+from mycelium.transition import (  # noqa: E402
+    SideEffectClass,
+    ToolTransitionBinding,
+)
+
+LEDGER_FILE = Path(tempfile.gettempdir()) / "mycelium-demo-webhooks-github.json"
+
+ledger = ActionLedger(storage=FileLedgerStorage(LEDGER_FILE))
+binding = ToolTransitionBinding.for_tool(
+    agent_id="webhook-worker",
+    policy_version="2026.08.1",
+    # Deploy-style work is not naturally idempotent: on an ambiguous retry we
+    # fail closed (HARD_BLOCK) instead of re-running the build.
+    side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+)
+
+TOOL = "handle_github_delivery"
+
+WORK_RUNS: list[str] = []  # demo bookkeeping: which deliveries did work run for?
+
+
+def verify_signature(payload: bytes, signature: str, secret: str) -> None:
+    """Verify the signature BEFORE claiming. Stub: compare to a known secret.
+
+    Real GitHub: HMAC-SHA256 over ``payload`` with the webhook secret, hex-digest
+    prefixed ``sha256=``, compared to the ``X-Hub-Signature-256`` header.
+    """
+    if signature != secret:
+        raise PermissionError("signature mismatch")
+
+
+def run_build(event: dict) -> dict:
+    """The side effect. Fake for the example — replace with real build/deploy."""
+    WORK_RUNS.append(event["delivery_id"])
+    return {"started": event["repository"]["full_name"]}
+
+
+def handle_github_delivery(delivery_id: str, event: dict) -> int:
+    # Key on the X-GitHub-Delivery header value (a per-delivery GUID), not the
+    # payload, and not the GitHub event / installation ids.
+    args = (delivery_id,)
+    kwargs: dict = {}
+
+    request_id = ledger.derive_request_id(
+        TOOL, args, kwargs, transition_binding=binding
+    )
+
+    try:
+        entry = ledger.claim_side_effecting(
+            request_id, TOOL, args, kwargs, binding
+        )
+    except LedgerHardBlockError:
+        return 409  # HARD_BLOCK: ambiguous; reconcile or operator-release.
+
+    if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+        return 200  # SKIP: this delivery id was already handled.
+
+    try:
+        result = run_build(event)
+    except Exception as exc:
+        ledger.fail(request_id, exc, failed_after_effect=False)
+        return 500
+
+    ledger.complete(request_id, result)
+    return 200  # PROCEED: the work ran exactly once for this delivery id.
+
+
+def _demo() -> None:
+    if LEDGER_FILE.exists():
+        LEDGER_FILE.unlink()  # deterministic demo: start with a clean ledger
+
+    payload = b'{"ref":"refs/heads/main"}'
+    verify_signature(payload, "sha256=ok", "sha256=ok")  # before the claim
+
+    evt = {"delivery_id": "deliv_1", "repository": {"full_name": "acme/app"}}
+    retry = {"delivery_id": "deliv_1", "repository": {"full_name": "acme/app"}}
+
+    print("delivery 1 (deliv_1):", handle_github_delivery("deliv_1", evt), "— PROCEED")
+    print("retry     (deliv_1):", handle_github_delivery("deliv_1", retry), "— SKIP")
+    print("work ran for:", WORK_RUNS)
+    assert WORK_RUNS == ["deliv_1"]
+
+
+if __name__ == "__main__":
+    _demo()

--- a/sdk/examples/webhooks/stripe.md
+++ b/sdk/examples/webhooks/stripe.md
@@ -1,0 +1,61 @@
+# Stripe webhook dedupe
+
+Key the Mycelium transition on the Stripe **`event.id`** (e.g. `evt_3...`).
+
+Stripe delivers events **at-least-once** and retries on non-2xx. Claim the
+`event.id` through an `ActionLedger` and you get **at-most-once handler side
+effects for that event id**: the first delivery does the work and `complete`s;
+a redelivery hits the `RETURN`/SKIP path and returns `200` without re-running.
+
+Key on `event.id` — not the payload bytes, not the provider *response* id, and
+not the `Idempotency-Key` request header (that header dedupes requests *you*
+send to Stripe; it is unrelated to inbound event delivery). Because only the
+`event.id` is in the args fingerprint, a redelivery with slightly different
+payload bytes still resolves to the same transition. Pin `agent_id` and
+`policy_version` across deploys so the key stays stable after a release.
+
+Verify the `Stripe-Signature` header before claiming. On `HARD_BLOCK`
+(ambiguous, e.g. crash after a prior attempt), fail closed — reconcile with
+the Stripe API or use the operator-release path; never re-run blindly.
+
+```python
+from mycelium import (
+    ActionLedger, FileLedgerStorage, LedgerHardBlockError, TerminalOutcome,
+)
+from mycelium.transition import SideEffectClass, ToolTransitionBinding
+
+ledger = ActionLedger(storage=FileLedgerStorage("./stripe-events.json"))
+binding = ToolTransitionBinding.for_tool(
+    agent_id="webhook-worker", policy_version="2026.08.1",
+    side_effect_class=SideEffectClass.KEYED_MUTATE,
+)
+
+def handle_stripe_event(event: dict) -> int:
+    event_id = event["id"]            # key on event.id (evt_...)
+    args, kwargs = (event_id,), {}    # not the payload / response id / Idempotency-Key
+    request_id = ledger.derive_request_id(
+        "handle_stripe_event", args, kwargs, transition_binding=binding,
+    )
+    try:
+        entry = ledger.claim_side_effecting(
+            request_id, "handle_stripe_event", args, kwargs, binding)
+    except LedgerHardBlockError:
+        return 409                     # HARD_BLOCK: reconcile / operator release
+    if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+        return 200                     # SKIP: already handled this event id
+    try:
+        result = fulfill_order(event)  # the side effect, once
+    except Exception as exc:
+        ledger.fail(request_id, exc, failed_after_effect=False)
+        return 500
+    ledger.complete(request_id, result)
+    return 200                         # PROCEED
+```
+
+Runnable demo (fakes only, no credentials):
+
+```bash
+python sdk/examples/webhooks/stripe_handler.py
+# delivery 1: 200 — PROCEED   (work ran)
+# delivery 2: 200 — SKIP      (redelivery, no second run)
+```

--- a/sdk/examples/webhooks/stripe_handler.py
+++ b/sdk/examples/webhooks/stripe_handler.py
@@ -1,0 +1,122 @@
+"""Stripe webhook dedupe with Mycelium — keyed on the Stripe ``event.id``.
+
+Runnable demo with fakes; no Stripe credentials or HTTP server required.
+Requires Python 3.10+ and the SDK importable (run with the SDK venv, or
+``pip install -e ./sdk`` then ``python sdk/examples/webhooks/stripe_handler.py``).
+
+Flow: verify signature -> claim on ``event.id`` ->
+  COMPLETED / SKIP  -> return 200, no side effect
+  PROCEED (IN_FLIGHT) -> do the work once -> complete
+  HARD_BLOCK        -> fail closed / operator path
+
+Stripe delivers events at-least-once and retries on non-2xx. The durable
+claim turns that into at-most-once handler side effects for each event id:
+a redelivery resolves the stored transition instead of re-running the work.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+# Make the SDK importable when run from a checkout (no install needed).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mycelium import (  # noqa: E402
+    ActionLedger,
+    FileLedgerStorage,
+    LedgerHardBlockError,
+    TerminalOutcome,
+)
+from mycelium.transition import (  # noqa: E402
+    SideEffectClass,
+    ToolTransitionBinding,
+)
+
+LEDGER_FILE = Path(tempfile.gettempdir()) / "mycelium-demo-webhooks-stripe.json"
+
+ledger = ActionLedger(storage=FileLedgerStorage(LEDGER_FILE))
+binding = ToolTransitionBinding.for_tool(
+    agent_id="webhook-worker",
+    policy_version="2026.08.1",
+    side_effect_class=SideEffectClass.KEYED_MUTATE,
+)
+
+TOOL = "handle_stripe_event"
+
+WORK_RUNS: list[str] = []  # demo bookkeeping: which event ids did the work run for?
+
+
+def verify_signature(payload: bytes, signature: str, secret: str) -> None:
+    """Verify the signature BEFORE claiming. Stub: compare to a known secret.
+
+    Real Stripe: construct ``t=<ts>,v1=<mac>`` from the ``Stripe-Signature``
+    header and HMAC-SHA256 over ``f"{ts}.{payload}"`` with the webhook signing
+    secret (or use ``stripe.Webhook.construct_event``).
+    """
+    if signature != secret:
+        raise PermissionError("signature mismatch")
+
+
+def fulfill_order(event: dict) -> dict:
+    """The side effect. Fake for the example — replace with real order logic."""
+    WORK_RUNS.append(event["id"])
+    return {"fulfilled": event["data"]["object"]["id"]}
+
+
+def handle_stripe_event(event: dict) -> int:
+    event_id = event["id"]  # key on the Stripe event id (evt_...), NOT the
+    args = (event_id,)      # payload bytes, NOT the provider response id, and
+    kwargs: dict = {}       # NOT the Idempotency-Key request header.
+
+    request_id = ledger.derive_request_id(
+        TOOL, args, kwargs, transition_binding=binding
+    )
+
+    try:
+        entry = ledger.claim_side_effecting(
+            request_id, TOOL, args, kwargs, binding
+        )
+    except LedgerHardBlockError:
+        return 409  # HARD_BLOCK: ambiguous (e.g. crash after a prior attempt);
+                    # reconcile or operator-release; never re-run blindly.
+
+    if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+        return 200  # SKIP: this event id was already handled; no side effect.
+
+    try:
+        result = fulfill_order(event)
+    except Exception as exc:
+        ledger.fail(request_id, exc, failed_after_effect=False)
+        return 500
+
+    ledger.complete(request_id, result)
+    return 200  # PROCEED: the work ran exactly once for this event id.
+
+
+def _demo() -> None:
+    if LEDGER_FILE.exists():
+        LEDGER_FILE.unlink()  # deterministic demo: start with a clean ledger
+
+    payload = b'{"id":"evt_1"}'
+    verify_signature(payload, "whsec_test", "whsec_test")  # before the claim
+
+    evt_1 = {
+        "id": "evt_1",
+        "type": "checkout.session.completed",
+        "data": {"object": {"id": "cs_1001"}},
+    }
+    evt_2 = {
+        "id": "evt_2",
+        "type": "checkout.session.completed",
+        "data": {"object": {"id": "cs_1002"}},
+    }
+
+    print("delivery 1 (evt_1):", handle_stripe_event(evt_1), "— PROCEED")
+    print("delivery 2 (evt_1):", handle_stripe_event(evt_1), "— SKIP")
+    print("delivery 3 (evt_2):", handle_stripe_event(evt_2), "— PROCEED")
+    print("work ran for:", WORK_RUNS)
+    assert WORK_RUNS == ["evt_1", "evt_2"]
+
+
+if __name__ == "__main__":
+    _demo()

--- a/sdk/examples/webhooks/twilio.md
+++ b/sdk/examples/webhooks/twilio.md
@@ -1,0 +1,61 @@
+# Twilio webhook dedupe
+
+Key the Mycelium transition on the Twilio **SID** — the `SM...` / `MM...`
+message SID (or an `EV...` status-event SID) that identifies the inbound
+message.
+
+Twilio delivers at-least-once and retries on non-2xx. Claim the SID through an
+`ActionLedger` and you get **at-most-once handler side effects for that SID**:
+the first delivery does the work and `complete`s; a retry hits the
+`RETURN`/SKIP path and returns `200` without re-running.
+
+Key on the SID — not the message body, not a provider *response* id you mint
+later. Because only the SID is in the args fingerprint, a retry with a
+slightly different body still resolves to the same transition. Pin `agent_id`
+and `policy_version` across deploys so the key stays stable after a release.
+
+Verify the `X-Twilio-Signature` header (HMAC-SHA1 over `url + params` with
+your `AUTH_TOKEN`) before claiming. On `HARD_BLOCK` (ambiguous), fail closed —
+reconcile or use the operator-release path; never re-run blindly.
+
+```python
+from mycelium import (
+    ActionLedger, FileLedgerStorage, LedgerHardBlockError, TerminalOutcome,
+)
+from mycelium.transition import SideEffectClass, ToolTransitionBinding
+
+ledger = ActionLedger(storage=FileLedgerStorage("./twilio-messages.json"))
+binding = ToolTransitionBinding.for_tool(
+    agent_id="webhook-worker", policy_version="2026.08.1",
+    side_effect_class=SideEffectClass.KEYED_MUTATE,
+)
+
+def handle_twilio_message(msg: dict) -> int:
+    sid = msg["sid"]                  # key on the SID (SM... / MM... / EV...)
+    args, kwargs = (sid,), {}         # not the body, not a response id
+    request_id = ledger.derive_request_id(
+        "handle_twilio_message", args, kwargs, transition_binding=binding,
+    )
+    try:
+        entry = ledger.claim_side_effecting(
+            request_id, "handle_twilio_message", args, kwargs, binding)
+    except LedgerHardBlockError:
+        return 409                     # HARD_BLOCK: reconcile / operator release
+    if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+        return 200                     # SKIP: already handled this SID
+    try:
+        result = process_incoming_sms(msg)  # the side effect, once
+    except Exception as exc:
+        ledger.fail(request_id, exc, failed_after_effect=False)
+        return 500
+    ledger.complete(request_id, result)
+    return 200                         # PROCEED
+```
+
+Runnable demo (fakes only, no credentials):
+
+```bash
+python sdk/examples/webhooks/twilio_handler.py
+# message 1: 200 — PROCEED   (work ran)
+# retry:     200 — SKIP      (same SID, no second run)
+```

--- a/sdk/examples/webhooks/twilio_handler.py
+++ b/sdk/examples/webhooks/twilio_handler.py
@@ -1,0 +1,112 @@
+"""Twilio webhook dedupe with Mycelium — keyed on the message / event SID.
+
+Runnable demo with fakes; no Twilio credentials or HTTP server required.
+Requires Python 3.10+ and the SDK importable.
+
+Flow: verify signature -> claim on the SID ->
+  COMPLETED / SKIP  -> return 200, no side effect
+  PROCEED (IN_FLIGHT) -> do the work once -> complete
+  HARD_BLOCK        -> fail closed / operator path
+
+Twilio delivers inbound messages/events at-least-once and retries on non-2xx.
+The durable claim turns that into at-most-once handler side effects for each
+SID (a ``SM...`` / ``MM...`` message SID, or an ``EV...`` status event SID).
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+# Make the SDK importable when run from a checkout (no install needed).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mycelium import (  # noqa: E402
+    ActionLedger,
+    FileLedgerStorage,
+    LedgerHardBlockError,
+    TerminalOutcome,
+)
+from mycelium.transition import (  # noqa: E402
+    SideEffectClass,
+    ToolTransitionBinding,
+)
+
+LEDGER_FILE = Path(tempfile.gettempdir()) / "mycelium-demo-webhooks-twilio.json"
+
+ledger = ActionLedger(storage=FileLedgerStorage(LEDGER_FILE))
+binding = ToolTransitionBinding.for_tool(
+    agent_id="webhook-worker",
+    policy_version="2026.08.1",
+    side_effect_class=SideEffectClass.KEYED_MUTATE,
+)
+
+TOOL = "handle_twilio_message"
+
+WORK_RUNS: list[str] = []  # demo bookkeeping: which SIDs did the work run for?
+
+
+def verify_signature(url: str, params: dict, signature: str, auth_token: str) -> None:
+    """Verify the signature BEFORE claiming. Stub: compare to a known token.
+
+    Real Twilio: HMAC-SHA1 over ``url + sorted form-encoded params`` with your
+    ``AUTH_TOKEN``, compared to the ``X-Twilio-Signature`` header.
+    """
+    if signature != auth_token:
+        raise PermissionError("signature mismatch")
+
+
+def process_incoming_sms(msg: dict) -> dict:
+    """The side effect. Fake for the example — replace with real handling."""
+    WORK_RUNS.append(msg["sid"])
+    return {"acknowledged": msg["sid"]}
+
+
+def handle_twilio_message(msg: dict) -> int:
+    sid = msg["sid"]        # key on the Twilio message SID (SM... / MM...),
+    args = (sid,)           # not the payload body and not a provider
+    kwargs: dict = {}       # response id you mint later.
+
+    request_id = ledger.derive_request_id(
+        TOOL, args, kwargs, transition_binding=binding
+    )
+
+    try:
+        entry = ledger.claim_side_effecting(
+            request_id, TOOL, args, kwargs, binding
+        )
+    except LedgerHardBlockError:
+        return 409  # HARD_BLOCK: ambiguous; reconcile or operator-release.
+
+    if entry.terminal_outcome == TerminalOutcome.COMPLETED.value:
+        return 200  # SKIP: this SID was already handled.
+
+    try:
+        result = process_incoming_sms(msg)
+    except Exception as exc:
+        ledger.fail(request_id, exc, failed_after_effect=False)
+        return 500
+
+    ledger.complete(request_id, result)
+    return 200  # PROCEED: the work ran exactly once for this SID.
+
+
+def _demo() -> None:
+    if LEDGER_FILE.exists():
+        LEDGER_FILE.unlink()  # deterministic demo: start with a clean ledger
+
+    url = "https://example.com/webhooks/twilio"
+    params = {"From": "+15551234567", "Body": "hello"}
+    verify_signature(url, params, "auth_token_test", "auth_token_test")
+
+    msg_1 = {"sid": "SM1001", "From": "+15551234567", "Body": "hello"}
+    msg_2 = {"sid": "SM1002", "From": "+15557654321", "Body": "hi"}
+
+    print("message 1 (SM1001):", handle_twilio_message(msg_1), "— PROCEED")
+    print("retry    (SM1001):", handle_twilio_message(msg_1), "— SKIP")
+    print("message 2 (SM1002):", handle_twilio_message(msg_2), "— PROCEED")
+    print("work ran for:", WORK_RUNS)
+    assert WORK_RUNS == ["SM1001", "SM1002"]
+
+
+if __name__ == "__main__":
+    _demo()

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.20.2"
+version = "1.20.3"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",


### PR DESCRIPTION
Optional adjacent recipe — agent tools stay the primary wedge; not a webhook platform. No core ledger change (patch, docs-only).

- `sdk/README.md`: **Webhook event dedupe (optional)** beside the manual-claim path. Claim inbound provider events on the provider event id (Stripe `event.id` / GitHub `X-GitHub-Delivery` / Twilio SID); at-least-once delivery + durable claim = at-most-once handler side effects. Key on event id, not payload / response id / Idempotency-Key header.
- `sdk/examples/webhooks/`: stripe / github / twilio one-pagers + runnable handlers (fakes, no credentials): verify signature → claim → SKIP / PROCEED-once / HARD_BLOCK fail-closed.
- Manual integration example: dropped `side_effect()` (no-op + warning outside `@ledger` bodies); documented manual path stays fail-closed via the durable claim.
- Root `README.md` one-line pointer; CHANGELOG `1.20.3`; pyproject `1.20.3`.

Full sdk test suite: 572 passed, 3 skipped; ruff clean.