### PR TITLE
docs: add 'What Mycelium does not do' boundaries (v1.20.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.20.4 (2026-08-01)
+
+Patch: positioning-only docs — "What Mycelium does not do" boundaries. No code change.
+
+### Docs
+
+- `sdk/README.md`: new **What Mycelium does not do** section beside "What it does" —
+  explicit boundaries (approvals/policy UI, hosted observability, on-chain audit
+  trails, generic webhook hub, rewind/recovery) + the compose line (use Mycelium
+  *under* an approval layer and *beside* a tracer — they don't replace each other).
+- Root `README.md`: boundary summary + link to the SDK section.
+- Handbook `docs/index.html`: one boundary sentence in the lede.
+
+## Unreleased
+
 ## 1.20.3 (2026-08-01)
 
 Patch: webhook event-dedupe recipe — docs + runnable examples only (no core

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ These aren't reasoning failures. They're runtime failures. Mycelium sits between
 
 Not Langfuse. Use both if you want traces and guards. Full resolution rules: [sdk/README.md](sdk/README.md#resolution-gates). Envelope field stack: [sdk/README.md](sdk/README.md#transition-envelope-fields). Payment-class identity guidance: [sdk/README.md](sdk/README.md#payment-class-identity-server-authoritative). Failure & threat model: [sdk/docs/FAILURE_AND_THREAT_MODEL.md](sdk/docs/FAILURE_AND_THREAT_MODEL.md). Inbound webhook event ids: [sdk/README.md](sdk/README.md#webhook-event-dedupe-optional).
 
+Not an approvals/policy inbox, not hosted observability, not on-chain audit trails, not a generic webhook hub, and not a rewind/agent-memory tool. It stops unsafe re-execution of side effects at the tool boundary — prevention, not post-hoc healing. Approvals, traces, and chain anchors are adjacent layers it composes with, not features it competes on: [What Mycelium does not do](sdk/README.md#what-mycelium-does-not-do).
+
 ## Use it
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -396,7 +396,9 @@
       <strong>Core:</strong> transition envelope (class + lease + terminal + gates / reconcile).
       <strong>Opt-in:</strong> stale-context helpers and tool-boundary checks.
       YAML callable paths and <code>mycelium run</code> add the core path without
-      editing each function. Framework-agnostic.
+      editing each function. Framework-agnostic. Not an approvals inbox, not hosted
+      observability, not on-chain trails, not a recovery tool — a tool-boundary
+      guard that composes under an approval layer and beside a tracer.
       Latest: fail-closed Gmail sent-log reconciler (v1.19.0) and opt-in
       resolution telemetry with a pinned Duplicate Tool Transition Rate (v1.20.0).
       Early but API-stable (v1.20.1): breaking changes only at major versions.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -59,6 +59,20 @@ Mycelium sits between your agent loop and your tools (after the LLM returns `too
 
 Framework-agnostic. Raw message lists and plain Python functions (LangGraph, CrewAI, OpenAI tool loops, etc.).
 
+## What Mycelium does not do
+
+Mycelium is an **embeddable transition envelope at the tool boundary** — classify → claim/lease → gate (`RETURN` / `POLL` / `REPAIR` / `HARD_BLOCK` / …) → optional reconcile — for LangGraph, CrewAI, or plain Python, via YAML + decorators or manual claim/complete. It is not a full agent platform and deliberately stays out of adjacent lanes:
+
+| Not this | That lane | What Mycelium does instead |
+|---|---|---|
+| Approvals inbox / policy-builder UI | Approval & governance products (DashClaw / ThumbGate) | Hard-block + operator `release` (CLI/API); wire your own approver upstream |
+| Hosted traces & dashboards | Observability (Langfuse / LangSmith) | Optional local `OutcomeEmitter` / DTTR — opt-in telemetry, not a hosted identity |
+| On-chain audit trails | Separate “trails” / Argentum-style products | Durable ledger + optional provider reconcile / signed receipts — runtime/ledger anchors, not chain anchors |
+| Generic webhook/SaaS hub | Event buses / claim APIs | The same ledger *can* key on provider event ids; the wedge stays agent-tool redispatch |
+| Fix bad reasoning / rewind runs | Evals, memory, recovery tools | Stops unsafe **re-execution** of side effects at the tool boundary |
+
+**Compose:** use Mycelium *under* an approval layer and *beside* a tracer if you want all three — they don't replace each other. Layers shouldn't trust each other.
+
 ## Install
 
 **Requires Python 3.10+** (3.11+ recommended).

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.20.3"
+version = "1.20.4"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",


### PR DESCRIPTION
Positioning-only patch (docs, no code change) — makes it impossible to confuse Mycelium with adjacent layers.

- `sdk/README.md`: **What Mycelium does not do** section beside "What it does" — table of boundaries (approvals/policy UI, hosted observability, on-chain audit trails, generic webhook hub, rewind/recovery) naming the lane, not the competitor, plus the compose line (use *under* an approval layer and *beside* a tracer).
- Root `README.md`: 3-line boundary summary linking to the SDK section.
- `docs/index.html`: one boundary sentence in the lede.
- CHANGELOG `1.20.4`; pyproject `1.20.4`.

Full sdk test suite: 572 passed, 3 skipped; ruff clean.