### PR TITLE
docs: sync published surfaces to v1.20.4 lineage (v1.20.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.20.5 (2026-08-01)
+
+Patch: docs-only sync of published surfaces to the v1.20.4 lineage. No code change.
+
+### Docs
+
+- Version sync: PyPI badges (`release=`) and "API-stable (v…)" lines moved
+  from v1.20.1 → v1.20.4 in root `README.md`, `sdk/README.md`, and handbook
+  `docs/index.html`; `sdk/README.md` "Current package" banner → v1.20.4
+  (adds the webhook event-dedupe recipe); `sdk/docs/FAILURE_AND_THREAT_MODEL.md`
+  version note → v1.20.4.
+- Handbook (`docs/index.html`): webhook event-dedupe pointer to
+  `sdk/examples/webhooks/` beside Manual integration; lede "Latest:" now includes
+  the webhook recipe (v1.20.3); boundaries link to the SDK README's
+  "What Mycelium does not do".
+
+## Unreleased
+
 ## 1.20.4 (2026-08-01)
 
 Patch: positioning-only docs — "What Mycelium does not do" boundaries. No code change.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.1)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.4)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -8,7 +8,7 @@
 
 Stops duplicate side effects on retry/redispatch, blocks bad tool args and out-of-scope calls, and keeps tool data fresh. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.20.1**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.20.4**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -383,7 +383,7 @@
 
     <h1>Mycelium: runtime guards for AI agents</h1>
     <p class="badges">
-      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.20.1" alt="PyPI version"></a>
+      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.20.4" alt="PyPI version"></a>
       <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/pyversions/mycelium-runtime.svg" alt="Python versions"></a>
       <a href="https://pepy.tech/project/mycelium-runtime"><img src="https://static.pepy.tech/badge/mycelium-runtime" alt="PyPI downloads"></a>
       <a href="https://github.com/mycelium-labs/mycelium"><img src="https://img.shields.io/github/license/mycelium-labs/mycelium.svg" alt="MIT license"></a>
@@ -399,9 +399,10 @@
       editing each function. Framework-agnostic. Not an approvals inbox, not hosted
       observability, not on-chain trails, not a recovery tool — a tool-boundary
       guard that composes under an approval layer and beside a tracer.
-      Latest: fail-closed Gmail sent-log reconciler (v1.19.0) and opt-in
-      resolution telemetry with a pinned Duplicate Tool Transition Rate (v1.20.0).
-      Early but API-stable (v1.20.1): breaking changes only at major versions.
+      Latest: fail-closed Gmail sent-log reconciler (v1.19.0), opt-in
+      resolution telemetry with a pinned Duplicate Tool Transition Rate (v1.20.0),
+      and a webhook event-dedupe recipe (v1.20.3).
+      Early but API-stable (v1.20.4): breaking changes only at major versions.
     </p>
 
     <section id="architecture">
@@ -415,6 +416,7 @@
         <strong>Do not redispatch unless the previous transition is proven terminal or
         safely recoverable.</strong>
         Not a framework. Not observability.
+        <a href="https://github.com/mycelium-labs/mycelium/blob/main/sdk/README.md#what-mycelium-does-not-do">Not an approvals inbox, not hosted observability, not on-chain trails, not a webhook hub, not a recovery tool — the full boundaries &amp; compose line.</a>
       </p>
       <div class="arch-flow">
         <div class="arch-box">Your agent loop<br><span style="font-weight:400;color:var(--ink-muted)">LangGraph · CrewAI · Python</span></div>
@@ -644,6 +646,13 @@ process_invoice(invoice_id="inv-42", amount=200.0)  # returns first result</pre>
         <code>complete(...)</code> / <code>fail(...)</code> — same ledger, same gates,
         same hard-block rules. There is no YAML switch; see the SDK README's
         <em>Manual integration (claim → execute → complete)</em> section.
+      </p>
+      <p>
+        <strong>Webhook event dedupe (v1.20.3):</strong> the same ledger can claim inbound
+        provider events on the provider event id (Stripe <code>event.id</code> /
+        GitHub <code>X-GitHub-Delivery</code> / Twilio SID) for at-most-once handler side
+        effects. Recipe + runnable examples:
+        <a href="https://github.com/mycelium-labs/mycelium/blob/main/sdk/examples/webhooks/stripe.md">sdk/examples/webhooks/</a>.
       </p>
     </section>
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.1)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.4)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.20.1** (outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
+Current package: **mycelium-runtime v1.20.4** (outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + webhook event-dedupe recipe + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
 
 ## One painful bug → a few lines of config
 

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -12,7 +12,7 @@ README is the source of truth for how the pieces are used; this file is the
 honest accounting of what can go wrong and which guarantee is pinned to which
 test.
 
-> Version note: this document tracks package **v1.20.1**. It is documentation
+> Version note: this document tracks package **v1.20.4**. It is documentation
 > only — no API or behavior change.
 
 ---

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.20.4"
+version = "1.20.5"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",


### PR DESCRIPTION
Docs/chore only — aligns all public surfaces with current sdk/pyproject.toml (1.20.4).

- **Version sync 1.20.1 → 1.20.4**: PyPI badges (`release=`) + "API-stable" lines in root `README.md`, `sdk/README.md` ("Current package" banner now also lists the webhook recipe), `docs/index.html`; `FAILURE_AND_THREAT_MODEL.md` version note.
- **Handbook content audit**: webhook event-dedupe pointer to `sdk/examples/webhooks/` beside Manual integration; lede "Latest:" now lists the webhook recipe (v1.20.3); boundaries link to the SDK README's *What Mycelium does not do*. DTTR / Gmail / Manual integration sections confirmed present.
- CHANGELOG `1.20.5`; pyproject `1.20.5`.

Acceptance: no stale "current version" claims remain (only the `Manual integration (v1.20.1)` intro footnote); badges match pyproject; lede matches current positioning. Full suite: 572 passed, 3 skipped; ruff clean.