### PR TITLE
docs: align version badges to v1.20.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.20.6 (2026-08-01)
+
+Patch: align public version strings with the package; clean changelog headers.
+No code change.
+
+### Docs
+
+- PyPI badges (`release=`), "API-stable", and "Current package" banners →
+  **v1.20.6** (were still on v1.20.4 after the 1.20.5 release).
+- `sdk/docs/FAILURE_AND_THREAT_MODEL.md` version note → v1.20.6.
+- Remove stray empty `## Unreleased` headers between version sections.
+
 ## 1.20.5 (2026-08-01)
 
 Patch: docs-only sync of published surfaces to the v1.20.4 lineage. No code change.
@@ -16,8 +28,6 @@ Patch: docs-only sync of published surfaces to the v1.20.4 lineage. No code chan
   the webhook recipe (v1.20.3); boundaries link to the SDK README's
   "What Mycelium does not do".
 
-## Unreleased
-
 ## 1.20.4 (2026-08-01)
 
 Patch: positioning-only docs — "What Mycelium does not do" boundaries. No code change.
@@ -30,8 +40,6 @@ Patch: positioning-only docs — "What Mycelium does not do" boundaries. No code
   *under* an approval layer and *beside* a tracer — they don't replace each other).
 - Root `README.md`: boundary summary + link to the SDK section.
 - Handbook `docs/index.html`: one boundary sentence in the lede.
-
-## Unreleased
 
 ## 1.20.3 (2026-08-01)
 
@@ -54,8 +62,6 @@ ledger change).
   helper (no-op + warning outside `@ledger` bodies); documented that the manual
   path is still fail-closed via the durable claim.
 
-## Unreleased
-
 ## 1.20.2 (2026-08-01)
 
 Patch: sync root README and handbook with the latest implementation.
@@ -64,8 +70,6 @@ Patch: sync root README and handbook with the latest implementation.
 
 - Root `README.md`: "What it does (v1.20.x)" heading; added **Gmail sent-log reconciler (v1.19.0)** (Core) and **Resolution telemetry + DTTR (v1.20.0)** (Opt-in) bullets.
 - Handbook (`docs/index.html`): Gmail sent-log reconciler in Resolution (match matrix), Manual integration note in Actions, new **Outcome telemetry & DTTR** section (+ sidebar nav link), latest-features lede.
-
-## Unreleased
 
 ## 1.20.1 (2026-08-01)
 
@@ -120,6 +124,10 @@ observable in production.
 
 ### Docs
 
+- New public failure & threat model in `sdk/docs/FAILURE_AND_THREAT_MODEL.md`
+  (linked near "What `@ledger` does" in `sdk/README.md` and the root README):
+  scope, threat actors, guarantees the transition/ledger core provides and
+  deliberately does not, guarantee → test map, residual risks. Docs only.
 - `sdk/README.md` "Outcome telemetry & DTTR" section (definition + examples).
 - `sdk/docs/FAILURE_AND_THREAT_MODEL.md` residual-risk item: silent duplicates
   are invisible without opt-in telemetry; DTTR is the observability measure.
@@ -189,12 +197,6 @@ external verifiers, request_id identity semantics).
   = new transition (intentional). Opt-in identity-conflict rejection mode
   discussed but not shipped. (Mengchheang probe 1 / `dp-identity-conflict`
   closed as decided + documented.)
-
-## Unreleased
-
-### Docs
-
-- New public failure & threat model in `sdk/docs/FAILURE_AND_THREAT_MODEL.md` (link added near "What `@ledger` does" in `sdk/README.md` and the root README): scope, threat actors, the guarantees the transition/ledger core actually provides, the guarantees it deliberately does not (release authorization, runaway loops, trusting the reconciler, in-memory ledgers across processes, identity-conflict rejection), a guarantee → test map pinning every documented promise to a concrete test, and residual risks. Docs only — no API or behavior change.
 
 ## 1.19.0 (2026-07-30)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.4)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.6)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -8,7 +8,7 @@
 
 Stops duplicate side effects on retry/redispatch, blocks bad tool args and out-of-scope calls, and keeps tool data fresh. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.20.4**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.20.6**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -383,7 +383,7 @@
 
     <h1>Mycelium: runtime guards for AI agents</h1>
     <p class="badges">
-      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.20.4" alt="PyPI version"></a>
+      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.20.6" alt="PyPI version"></a>
       <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/pyversions/mycelium-runtime.svg" alt="Python versions"></a>
       <a href="https://pepy.tech/project/mycelium-runtime"><img src="https://static.pepy.tech/badge/mycelium-runtime" alt="PyPI downloads"></a>
       <a href="https://github.com/mycelium-labs/mycelium"><img src="https://img.shields.io/github/license/mycelium-labs/mycelium.svg" alt="MIT license"></a>
@@ -402,7 +402,7 @@
       Latest: fail-closed Gmail sent-log reconciler (v1.19.0), opt-in
       resolution telemetry with a pinned Duplicate Tool Transition Rate (v1.20.0),
       and a webhook event-dedupe recipe (v1.20.3).
-      Early but API-stable (v1.20.4): breaking changes only at major versions.
+      Early but API-stable (v1.20.6): breaking changes only at major versions.
     </p>
 
     <section id="architecture">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.4)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.6)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.20.4** (outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + webhook event-dedupe recipe + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
+Current package: **mycelium-runtime v1.20.6** (outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + webhook event-dedupe recipe + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
 
 ## One painful bug → a few lines of config
 

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -12,7 +12,7 @@ README is the source of truth for how the pieces are used; this file is the
 honest accounting of what can go wrong and which guarantee is pinned to which
 test.
 
-> Version note: this document tracks package **v1.20.4**. It is documentation
+> Version note: this document tracks package **v1.20.6**. It is documentation
 > only — no API or behavior change.
 
 ---

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.20.5"
+version = "1.20.6"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",


### PR DESCRIPTION
## Summary
- Bump package + public badges / API-stable / Current package / threat-model version note to **v1.20.6** (were stuck on v1.20.4 after 1.20.5).
- Remove stray empty `## Unreleased` headers between changelog versions; fold the orphaned failure/threat-model docs bullet under 1.20.0.

## Test plan
- [ ] After merge, Release tags `v1.20.6` and Publish ships to PyPI
- [ ] Badges/`rg` show 1.20.6; no leftover `## Unreleased` between sections