### PR TITLE
chore: release mycelium-runtime v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 1.21.0 (2026-08-01)
+
+Minor: AF-003 loop guard — halt repeated identical tool actions across new
+`tool_call_id`s. Backward compatible (opt-in YAML; on by default in
+`mycelium init --full` / `--minimal`).
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.6)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.21.0)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -8,7 +8,7 @@
 
 Stops duplicate side effects on retry/redispatch, blocks bad tool args and out-of-scope calls, and keeps tool data fresh. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.20.6**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.21.0**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 
@@ -16,7 +16,7 @@ Developers running **agents with side-effect tools** in production (payments, em
 
 Python 3.10+. Framework-agnostic.
 
-## What it does (v1.20.x)
+## What it does (v1.21.x)
 
 These aren't reasoning failures. They're runtime failures. Mycelium sits between your agent loop and your tools (after the LLM returns `tool_calls`):
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -384,7 +384,7 @@
 
     <h1>Mycelium: runtime guards for AI agents</h1>
     <p class="badges">
-      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.20.6" alt="PyPI version"></a>
+      <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&amp;release=1.21.0" alt="PyPI version"></a>
       <a href="https://pypi.org/project/mycelium-runtime/"><img src="https://img.shields.io/pypi/pyversions/mycelium-runtime.svg" alt="Python versions"></a>
       <a href="https://pepy.tech/project/mycelium-runtime"><img src="https://static.pepy.tech/badge/mycelium-runtime" alt="PyPI downloads"></a>
       <a href="https://github.com/mycelium-labs/mycelium"><img src="https://img.shields.io/github/license/mycelium-labs/mycelium.svg" alt="MIT license"></a>
@@ -400,11 +400,11 @@
       editing each function. Framework-agnostic. Not an approvals inbox, not hosted
       observability, not on-chain trails, not a recovery tool — a tool-boundary
       guard that composes under an approval layer and beside a tracer.
-      Latest: AF-003 loop guard (identical actions across new
+      Latest: <strong>v1.21.0</strong> AF-003 loop guard (identical actions across new
       <code>tool_call_id</code>s → soft then hard → <code>mycelium loops release</code>),
       fail-closed Gmail sent-log reconciler (v1.19.0), opt-in resolution telemetry
       with DTTR (v1.20.0), and a webhook event-dedupe recipe (v1.20.3).
-      Early but API-stable (v1.20.6): breaking changes only at major versions.
+      Early but API-stable (v1.21.0): breaking changes only at major versions.
     </p>
 
     <section id="architecture">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.20.6)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.21.0)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.20.6** (outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + webhook event-dedupe recipe + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
+Current package: **mycelium-runtime v1.21.0** (AF-003 loop guard + outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + webhook event-dedupe recipe + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
 
 ## One painful bug → a few lines of config
 

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -12,8 +12,9 @@ README is the source of truth for how the pieces are used; this file is the
 honest accounting of what can go wrong and which guarantee is pinned to which
 test.
 
-> Version note: this document tracks package **v1.20.6**. It is documentation
-> only — no API or behavior change.
+> Version note: this document tracks package **v1.21.0**. The ledger-core
+> guarantees below are unchanged; optional `loop_guard:` (AF-003) is documented
+> in the SDK README / catalog and is outside this core guarantee set.
 
 ---
 

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -130,7 +130,7 @@ from mycelium.transition_resolution import (
     transition_needs_repair,
 )
 
-__version__ = "1.20.0"
+__version__ = "1.21.0"
 
 __all__ = [
     "ActionLedger",

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.20.6"
+version = "1.21.0"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",


### PR DESCRIPTION
## Summary
- Bump `mycelium-runtime` to **v1.21.0** (minor: AF-003 loop guard)
- Align `__version__`, CHANGELOG, README badges, handbook, threat-model version note

## Test plan
- [x] `__version__` / `pyproject.toml` = 1.21.0
- [x] `pytest tests/test_loop_guard.py`
- [ ] After merge: tag `v1.21.0` → Publish workflow → PyPI