### PR TITLE
release: mycelium-runtime v1.23.1 — AF-002 failure-case pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.23.1 (2026-08-03)
+
+Patch: AF-002 failure-case pack — teachable in-process gate repros. Docs/examples
+only; no runtime API changes.
+
+### Added
+
+- **Failure-case pack (AF-002):** five runnable in-process repros for
+  `RETURN` / `POLL` / `HARD_BLOCK` (+ `REPAIR` / reconcile) under
+  `sdk/examples/failure_cases/` — no Redis/Postgres required. New
+  `prove_return_completed()` in `mycelium.proofs.feature_demo`; tests in
+  `tests/test_failure_cases.py`.
+
 ## 1.23.0 (2026-08-03)
 
 Minor: AF-007 completion contract — refuse terminal output while host-declared

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.23.0)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.23.1)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -8,7 +8,7 @@
 
 Stops duplicate side effects on retry/redispatch, blocks bad tool args and out-of-scope calls, and keeps tool data fresh. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.23.0**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.23.1**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -402,13 +402,13 @@
       editing each function. Framework-agnostic. Not an approvals inbox, not hosted
       observability, not on-chain trails, not a recovery tool — a tool-boundary
       guard that composes under an approval layer and beside a tracer.
-      Latest: <strong>v1.23.0</strong> AF-007 completion contract (refuse terminal
+      Latest: <strong>v1.23.1</strong> AF-002 failure-case pack + AF-007 completion contract (refuse terminal
       while required checklist items are pending) + state-authority gate + AF-003 loop guard
       (identical actions across new <code>tool_call_id</code>s → soft then hard →
       <code>mycelium loops release</code>), fail-closed Gmail sent-log reconciler (v1.19.0),
       opt-in resolution telemetry with DTTR (v1.20.0), and a webhook event-dedupe
       recipe (v1.20.3).
-      Early but API-stable (v1.23.0): breaking changes only at major versions.
+      Early but API-stable (v1.23.1): breaking changes only at major versions.
     </p>
 
     <section id="architecture">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.23.0)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.23.1)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.23.0** (AF-007 completion contract + state-authority execution gate + AF-003 loop guard + outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + webhook event-dedupe recipe + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
+Current package: **mycelium-runtime v1.23.1** (AF-002 failure-case pack + AF-007 completion contract + state-authority execution gate + AF-003 loop guard + outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + webhook event-dedupe recipe + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
 
 ## One painful bug → a few lines of config
 
@@ -455,6 +455,11 @@ Runnable examples (fakes only, no provider credentials):
 [GitHub](examples/webhooks/github.md) (`X-GitHub-Delivery`) ·
 [Twilio](examples/webhooks/twilio.md) (message/event SID).
 
+**Failure-case pack (AF-002 gates):** five in-process repros for
+`RETURN` / `POLL` / `HARD_BLOCK` (+ `REPAIR` / reconcile) — no Redis required.
+See [examples/failure_cases/](examples/failure_cases/)
+(`python examples/failure_cases/run_all.py` from `sdk/`).
+
 ## What `@ledger` / `ledger_sync` do
 
 - Record every tool invocation in a durable `ActionLedger`
@@ -522,6 +527,9 @@ Each duplicate dispatch is classified to a gate. Read-only and side-effecting to
 | `REPAIR` | incomplete durable key / boundary / terminal (healable) | fix record, re-resolve — **no** second side effect |
 | `SOFT_BLOCK` | read-only `UNKNOWN` / `BLOCKED` only | **retry by default** (safe — reads don't spend); opt into deferral with `defer_read_only_unknown=True` → `LedgerSoftBlockError` |
 | `HARD_BLOCK` | ambiguous mutating transition | stop; run `Reconciler` when `external_operation_ref` is present, else fail-closed |
+
+Teachable in-process repros for the partner-facing gates:
+[examples/failure_cases/](examples/failure_cases/) (`run_all.py`).
 
 **Public transition-sufficiency language:** #7417-style discussions often use four words — `ALLOW` / `REPAIR` / `SOFT_BLOCK` / `HARD_BLOCK` (sometimes `BLOCK`). Mycelium implements that set and adds finer internals:
 

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -12,7 +12,7 @@ README is the source of truth for how the pieces are used; this file is the
 honest accounting of what can go wrong and which guarantee is pinned to which
 test.
 
-> Version note: this document tracks package **v1.23.0**. The ledger-core
+> Version note: this document tracks package **v1.23.1**. The ledger-core
 > guarantees below are unchanged; optional `loop_guard:` (AF-003),
 > `completion:` (AF-007), and `state_authority:` are documented in the SDK
 > README and are outside this core guarantee set.

--- a/sdk/examples/failure_cases/01_return_completed.py
+++ b/sdk/examples/failure_cases/01_return_completed.py
@@ -1,0 +1,27 @@
+"""01 — RETURN: completed redispatch returns stored result (no second body run)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mycelium.proofs.feature_demo import prove_return_completed
+
+from _narrate import narrate
+
+
+def main() -> int:
+    return narrate(
+        case_id="01",
+        title="Completed redispatch",
+        gate="RETURN",
+        without="same tool_call_id runs the charge again",
+        with_guard="second call returns the stored COMPLETED result",
+        prove=prove_return_completed,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/examples/failure_cases/02_poll_in_flight.py
+++ b/sdk/examples/failure_cases/02_poll_in_flight.py
@@ -1,0 +1,27 @@
+"""02 — POLL: peer sees HELD lease while owner still running (no parallel fire)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mycelium.proofs.feature_demo import prove_lease_auto_renew
+
+from _narrate import narrate
+
+
+def main() -> int:
+    return narrate(
+        case_id="02",
+        title="Peer while owner lease held",
+        gate="POLL",
+        without="second worker charges while the first is still in flight",
+        with_guard="peer gate is POLL; lease validity stays HELD via auto-renew",
+        prove=prove_lease_auto_renew,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/examples/failure_cases/03_hard_block_unknown.py
+++ b/sdk/examples/failure_cases/03_hard_block_unknown.py
@@ -1,0 +1,27 @@
+"""03 — HARD_BLOCK: ambiguous mutate crash cannot blind-retry."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mycelium.proofs.feature_demo import prove_hard_block
+
+from _narrate import narrate
+
+
+def main() -> int:
+    return narrate(
+        case_id="03",
+        title="Ambiguous mutate after provider timeout",
+        gate="HARD_BLOCK",
+        without="retry may double-charge if the first attempt actually committed",
+        with_guard="redispatch raises LedgerHardBlockError; body runs once",
+        prove=prove_hard_block,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/examples/failure_cases/04_repair_incomplete.py
+++ b/sdk/examples/failure_cases/04_repair_incomplete.py
@@ -1,0 +1,27 @@
+"""04 — REPAIR: incomplete durable record is healed; no second side effect."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mycelium.proofs.feature_demo import prove_repair_gate
+
+from _narrate import narrate
+
+
+def main() -> int:
+    return narrate(
+        case_id="04",
+        title="Incomplete durable record on redispatch",
+        gate="REPAIR",
+        without="missing idempotency_key / terminal fields can fork identity",
+        with_guard="claim loop repairs fields then RETURN; body still once",
+        prove=prove_repair_gate,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/examples/failure_cases/05_reconcile_completed.py
+++ b/sdk/examples/failure_cases/05_reconcile_completed.py
@@ -1,0 +1,27 @@
+"""05 — Reconcile COMPLETED: provider proof turns ambiguity into RETURN."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mycelium.proofs.feature_demo import prove_reconcile_completed
+
+from _narrate import narrate
+
+
+def main() -> int:
+    return narrate(
+        case_id="05",
+        title="Ambiguous mutate + provider reconcile",
+        gate="RETURN (via Reconciler COMPLETED)",
+        without="stuck HARD_BLOCK or unsafe blind retry",
+        with_guard="reconciler proves COMPLETED; stored result returned, no re-exec",
+        prove=prove_reconcile_completed,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/examples/failure_cases/README.md
+++ b/sdk/examples/failure_cases/README.md
@@ -1,0 +1,40 @@
+# Failure-case pack (AF-002 gates)
+
+Teachable, **in-process** repros for Mycelium resolution gates. No Redis or
+Postgres required — memory ledger only.
+
+| # | Case | Gate | Failure without Mycelium | With Mycelium |
+|---|------|------|--------------------------|---------------|
+| 01 | Completed redispatch | **RETURN** | Charge / side effect runs twice | Second call returns stored result |
+| 02 | Peer while owner held | **POLL** | Second worker fires in parallel | Peer waits; lease stays HELD |
+| 03 | Ambiguous mutate crash | **HARD_BLOCK** | Blind retry may double-spend | Redispatch raises; no second body run |
+| 04 | Incomplete durable record | **REPAIR** | Redispatch forks / re-executes | Heal fields, then RETURN — body once |
+| 05 | Ambiguous + provider proof | reconcile → **RETURN** | Stuck or blind retry | Reconciler proves COMPLETED; no re-exec |
+
+Public vocabulary often collapses to `ALLOW` / `REPAIR` / `SOFT_BLOCK` /
+`HARD_BLOCK`. Mycelium also exposes `RETURN` and `POLL` as first-class
+“do not execute again” gates — this pack makes those three partner-facing
+outcomes (plus REPAIR / reconcile) runnable.
+
+## Run
+
+From the `sdk/` directory (package installed editable or on `PYTHONPATH`):
+
+```bash
+python examples/failure_cases/run_all.py
+# or one case:
+python examples/failure_cases/01_return_completed.py
+python examples/failure_cases/02_poll_in_flight.py
+python examples/failure_cases/03_hard_block_unknown.py
+python examples/failure_cases/04_repair_incomplete.py
+python examples/failure_cases/05_reconcile_completed.py
+```
+
+Each script exits `0` on proof success and prints the gate name.
+
+## Related
+
+- Feature tour: `mycelium demo` (same proofs + operator release + unguarded baseline)
+- Cloud-style two-worker Redis: `mycelium demo --redis`
+- Gate table: [sdk/README.md § Resolution gates](../../README.md#resolution-gates)
+- Threat model: [docs/FAILURE_AND_THREAT_MODEL.md](../../docs/FAILURE_AND_THREAT_MODEL.md)

--- a/sdk/examples/failure_cases/_narrate.py
+++ b/sdk/examples/failure_cases/_narrate.py
@@ -1,0 +1,27 @@
+"""Shared ASCII-safe narration for failure-case scripts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+def narrate(
+    *,
+    case_id: str,
+    title: str,
+    gate: str,
+    without: str,
+    with_guard: str,
+    prove: Callable[[], dict[str, Any]],
+) -> int:
+    print(f"=== {case_id}: {title} ===")
+    print(f"gate:     {gate}")
+    print(f"without:  {without}")
+    print(f"with:     {with_guard}")
+    result = prove()
+    print("proof:")
+    for key, value in result.items():
+        print(f"  {key}={value!r}")
+    print(f"OK — {gate}")
+    return 0

--- a/sdk/examples/failure_cases/run_all.py
+++ b/sdk/examples/failure_cases/run_all.py
@@ -1,0 +1,59 @@
+"""Run the full AF-002 failure-case pack (in-process, no Redis).
+
+From the sdk/ directory::
+
+    python examples/failure_cases/run_all.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+CASES = (
+    "01_return_completed.py",
+    "02_poll_in_flight.py",
+    "03_hard_block_unknown.py",
+    "04_repair_incomplete.py",
+    "05_reconcile_completed.py",
+)
+
+
+def _load_main(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    # Sibling imports (``_narrate``) resolve against this package dir.
+    sys.modules[path.stem] = module
+    spec.loader.exec_module(module)
+    return module.main
+
+
+def main() -> int:
+    here = Path(__file__).resolve().parent
+    # Ensure ``from _narrate import …`` works for case scripts.
+    if str(here) not in sys.path:
+        sys.path.insert(0, str(here))
+
+    print("Mycelium failure-case pack — RETURN / POLL / HARD_BLOCK (+ REPAIR / reconcile)")
+    print("In-memory ledger only; no Redis/Postgres required.\n")
+
+    for name in CASES:
+        path = here / name
+        print("-" * 60)
+        code = _load_main(path)()
+        if code != 0:
+            print(f"FAIL {name} exit={code}", file=sys.stderr)
+            return code
+        print()
+
+    print("=" * 60)
+    print(f"OK — {len(CASES)}/{len(CASES)} failure cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -161,7 +161,7 @@ from mycelium.transition_resolution import (
     transition_needs_repair,
 )
 
-__version__ = "1.23.0"
+__version__ = "1.23.1"
 
 __all__ = [
     "ActionLedger",

--- a/sdk/mycelium/proofs/feature_demo.py
+++ b/sdk/mycelium/proofs/feature_demo.py
@@ -61,6 +61,33 @@ class _StubReconciler:
         return self._result
 
 
+def prove_return_completed() -> dict[str, Any]:
+    """COMPLETED redispatch returns stored result — gate RETURN, body once."""
+    storage = InMemoryLedgerStorage()
+    binding = _mutate_binding(agent_id="return-demo")
+    calls: list[float] = []
+
+    @ledger_sync(storage=storage, transition_binding=binding)
+    def charge(amount: float) -> dict[str, float]:
+        calls.append(amount)
+        return {"charged": amount}
+
+    with execution_scope(_scope()):
+        first = charge(10.0, tool_call_id="return_call")
+        second = charge(10.0, tool_call_id="return_call")
+        entry = storage.list_all()[0]
+        gate = resolve_side_effect_gate(entry, binding)
+
+    assert first == second == {"charged": 10.0}
+    assert calls == [10.0], f"expected one body run, got {calls!r}"
+    assert gate == TransitionGate.RETURN, gate
+    return {
+        "executions": len(calls),
+        "gate": gate.value,
+        "result": second,
+    }
+
+
 def prove_lease_auto_renew() -> dict[str, Any]:
     """Long tool keeps lease HELD via auto-renew; peer gate stays POLL."""
     storage = InMemoryLedgerStorage()

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.23.0"
+version = "1.23.1"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",

--- a/sdk/tests/test_failure_cases.py
+++ b/sdk/tests/test_failure_cases.py
@@ -1,0 +1,69 @@
+"""AF-002 failure-case pack — gate repros for RETURN / POLL / HARD_BLOCK (+)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from mycelium.proofs.feature_demo import (
+    prove_hard_block,
+    prove_lease_auto_renew,
+    prove_reconcile_completed,
+    prove_repair_gate,
+    prove_return_completed,
+)
+
+_PACK = Path(__file__).resolve().parents[1] / "examples" / "failure_cases"
+
+
+def test_prove_return_completed() -> None:
+    result = prove_return_completed()
+    assert result["gate"] == "RETURN"
+    assert result["executions"] == 1
+    assert result["result"] == {"charged": 10.0}
+
+
+def test_case_01_return() -> None:
+    result = prove_return_completed()
+    assert result["gate"] == "RETURN"
+
+
+def test_case_02_poll() -> None:
+    result = prove_lease_auto_renew()
+    assert result["peer_gate"] == "POLL"
+    assert result["lease_validity"] == "HELD"
+
+
+def test_case_03_hard_block() -> None:
+    result = prove_hard_block()
+    assert result["gate"] == "HARD_BLOCK"
+    assert result["executions"] == 1
+
+
+def test_case_04_repair() -> None:
+    result = prove_repair_gate()
+    assert result["executions"] == 1
+    assert result["repaired_idempotency_key"]
+
+
+def test_case_05_reconcile() -> None:
+    result = prove_reconcile_completed()
+    assert result["executions"] == 1
+    assert result["result"] == {"charged": True}
+
+
+def test_run_all_pack_exits_zero() -> None:
+    script = _PACK / "run_all.py"
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(_PACK.parent.parent),
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "5/5 failure cases passed" in completed.stdout
+    assert "RETURN" in completed.stdout
+    assert "POLL" in completed.stdout
+    assert "HARD_BLOCK" in completed.stdout

--- a/sdk/tests/test_feature_demo.py
+++ b/sdk/tests/test_feature_demo.py
@@ -9,8 +9,16 @@ from mycelium.proofs.feature_demo import (
     prove_read_unknown_safe_retry,
     prove_reconcile_completed,
     prove_repair_gate,
+    prove_return_completed,
 )
 from mycelium.quickstart import run_demo
+
+
+def test_prove_return_completed() -> None:
+    result = prove_return_completed()
+    assert result["gate"] == "RETURN"
+    assert result["executions"] == 1
+    assert result["result"] == {"charged": 10.0}
 
 
 def test_prove_lease_auto_renew() -> None:


### PR DESCRIPTION
## Summary
- Patch **v1.23.1**: AF-002 failure-case pack (`sdk/examples/failure_cases/`)
- Five in-process repros: RETURN / POLL / HARD_BLOCK (+ REPAIR / reconcile)
- `prove_return_completed()` + tests; docs/version banners bumped

## Test plan
- [x] `pytest tests/test_failure_cases.py` (8 passed)
- [x] `python examples/failure_cases/run_all.py` (5/5)
- [ ] CI green; Release workflow tags `v1.23.1` + PyPI publish