### PR TITLE
feat: SQLite ledger backend (v1.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.24.0 (2026-08-03)
+
+Minor: SQLite ledger backend — zero-ops single-node durable storage (stdlib
+`sqlite3`). Opt-in alternative to Redis/Postgres for local/dev and
+single-process agents. Backward compatible.
+
+### Added
+
+- **`SqliteLedgerStorage` / `SqliteTaskLedgerStorage`:** `request_id` + JSON
+  payload table (Postgres-shaped), WAL, transactional claim + CAS
+  `try_transition`. No Redis-style TTL (leases stay in payload).
+- YAML: `storage: sqlite` + `path:` (+ optional `table`) for action and task
+  ledgers.
+- CLI: `mycelium transitions … --sqlite PATH` (env `MYCELIUM_SQLITE_PATH`).
+- Tests: storage unit/CAS/concurrent claim; atomicity + operator-release
+  fixtures include `sqlite`.
+
 ## 1.23.1 (2026-08-03)
 
 Patch: AF-002 failure-case pack — teachable in-process gate repros. Docs/examples

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.23.1)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.24.0)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -8,7 +8,7 @@
 
 Stops duplicate side effects on retry/redispatch, blocks bad tool args and out-of-scope calls, and keeps tool data fresh. Not recovery after. Not tracing or dashboards.
 
-*Early but API-stable (**v1.23.1**): breaking changes only at major versions. More guards planned.*
+*Early but API-stable (**v1.24.0**): breaking changes only at major versions. More guards planned.*
 
 ## Who it's for
 
@@ -137,8 +137,10 @@ resolves the existing transition: read tools poll/soft-block; mutating tools
 hard-block or reconcile against the provider when you record
 `external_operation_ref`.
 
-Multi-worker / cloud ledgers: `pip install 'mycelium-runtime[redis]'` or
-`'mycelium-runtime[postgres]'`. See the [handbook](https://mycelium-labs.github.io/mycelium/).
+Zero-ops single-node durable ledger: YAML `storage: sqlite` + `path:` (stdlib;
+no extra install). Multi-worker / cloud: `pip install 'mycelium-runtime[redis]'`
+or `'mycelium-runtime[postgres]'`. See the
+[handbook](https://mycelium-labs.github.io/mycelium/).
 
 ## Docs
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -402,13 +402,13 @@
       editing each function. Framework-agnostic. Not an approvals inbox, not hosted
       observability, not on-chain trails, not a recovery tool — a tool-boundary
       guard that composes under an approval layer and beside a tracer.
-      Latest: <strong>v1.23.1</strong> AF-002 failure-case pack + AF-007 completion contract (refuse terminal
+      Latest: <strong>v1.24.0</strong> SQLite ledger + AF-002 failure-case pack + AF-007 completion contract (refuse terminal
       while required checklist items are pending) + state-authority gate + AF-003 loop guard
       (identical actions across new <code>tool_call_id</code>s → soft then hard →
       <code>mycelium loops release</code>), fail-closed Gmail sent-log reconciler (v1.19.0),
       opt-in resolution telemetry with DTTR (v1.20.0), and a webhook event-dedupe
       recipe (v1.20.3).
-      Early but API-stable (v1.23.1): breaking changes only at major versions.
+      Early but API-stable (v1.24.0): breaking changes only at major versions.
     </p>
 
     <section id="architecture">

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.23.1)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.24.0)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-Current package: **mycelium-runtime v1.23.1** (AF-002 failure-case pack + AF-007 completion contract + state-authority execution gate + AF-003 loop guard + outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + webhook event-dedupe recipe + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
+Current package: **mycelium-runtime v1.24.0** (SQLite ledger backend + AF-002 failure-case pack + AF-007 completion contract + state-authority execution gate + AF-003 loop guard + outcome telemetry / DTTR + fail-closed Gmail sent-log reconciler + webhook event-dedupe recipe + atomicity contract + CAS backends + owner fencing + worker-death signal + operator release + `REPAIR` gate + lease auto-renew + transition envelope).
 
 ## One painful bug → a few lines of config
 
@@ -801,6 +801,7 @@ When a side-effecting transition ends ambiguous (`BLOCKED` / `UNKNOWN` / `FAILED
 ```bash
 mycelium transitions list --stuck --config mycelium.yaml
 # or without the app's config, straight at the backend:
+mycelium transitions list --stuck --sqlite ./mycelium-ledger.db
 mycelium transitions list --stuck --redis-url redis://localhost:6379/0
 ```
 
@@ -834,7 +835,7 @@ mycelium transitions release <request_id> --verified not-executed \
 
 Release is **one-shot** (a recorded verification is never overwritten — a second release fails) and **fail-closed**: unknown request ids, already-`COMPLETED` transitions, and `IN_FLIGHT` transitions with a still-held lease (a worker may be alive) are all refused. Entries are never deleted — the resolution (`operator_resolution`, `resolved_by`, `resolution_reason`, `resolved_at`, `released_from_outcome`) is stamped onto the durable record, so `provider_idempotency_key` enforcement and audit history survive. When an `AuditReceiptEmitter` is configured on the ledger, releases also emit signed receipts.
 
-Storage resolution: `--config` reads each tool's `ledger:` section (deduplicated); `--file PATH` / `--redis-url` / `--postgres-dsn` (env: `MYCELIUM_LEDGER_FILE` / `MYCELIUM_REDIS_URL` / `MYCELIUM_POSTGRES_DSN`) point the CLI at a backend directly for operator machines without the app's config. `storage: memory` can't be reached from the CLI — it lives inside the agent process; use the Python API there.
+Storage resolution: `--config` reads each tool's `ledger:` section (deduplicated); `--file PATH` / `--sqlite PATH` / `--redis-url` / `--postgres-dsn` (env: `MYCELIUM_LEDGER_FILE` / `MYCELIUM_SQLITE_PATH` / `MYCELIUM_REDIS_URL` / `MYCELIUM_POSTGRES_DSN`) point the CLI at a backend directly for operator machines without the app's config. `storage: memory` can't be reached from the CLI — it lives inside the agent process; use the Python API there.
 
 The same workflow exists in Python (e.g. from a runbook script or an admin console):
 
@@ -1029,18 +1030,31 @@ Storage backends:
 |---------|----------|----------------|
 | `memory` | Single process, tests | `memory` (default) |
 | `file` | Local dev, single host (`fcntl` lock) | `file` + `path` |
+| `sqlite` | Zero-ops single-node durable (stdlib) | `sqlite` + `path` (+ optional `table`) |
 | `redis` | Multi-worker, in-flight TTL | `redis` + `url` or `url_env` |
 | `postgres` | Audit/compliance, durable SQL | `postgres` + `dsn` or `dsn_env` |
 
 ```python
 from mycelium import ActionLedger, FileLedgerStorage, InMemoryLedgerStorage
-from mycelium import RedisLedgerStorage, PostgresLedgerStorage
+from mycelium import RedisLedgerStorage, PostgresLedgerStorage, SqliteLedgerStorage
 
 ledger = ActionLedger(storage=InMemoryLedgerStorage())
 ledger = ActionLedger(storage=FileLedgerStorage("./mycelium-ledger.json"))
+ledger = ActionLedger(storage=SqliteLedgerStorage("./mycelium-ledger.db"))
 ledger = ActionLedger(storage=RedisLedgerStorage("redis://localhost:6379/0"))
 ledger = ActionLedger(storage=PostgresLedgerStorage("postgresql://localhost/mycelium"))
 ```
+
+```yaml
+action_ledger:
+  storage: sqlite
+  path: ./mycelium-ledger.db
+  # table: mycelium_action_ledger   # optional
+```
+
+CLI triage: `mycelium transitions list --stuck --sqlite ./mycelium-ledger.db`
+(or `MYCELIUM_SQLITE_PATH`). Prefer Redis/Postgres for multi-worker / cross-node
+retry; SQLite is the simple durable on-ramp (no extra deps).
 
 Optional extras: `pip install 'mycelium-runtime[redis]'` or `pip install 'mycelium-runtime[postgres]'`.
 

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -12,7 +12,7 @@ README is the source of truth for how the pieces are used; this file is the
 honest accounting of what can go wrong and which guarantee is pinned to which
 test.
 
-> Version note: this document tracks package **v1.23.1**. The ledger-core
+> Version note: this document tracks package **v1.24.0**. The ledger-core
 > guarantees below are unchanged; optional `loop_guard:` (AF-003),
 > `completion:` (AF-007), and `state_authority:` are documented in the SDK
 > README and are outside this core guarantee set.

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -117,6 +117,7 @@ from mycelium.state_flush import (
 )
 from mycelium.storage.postgres_ledger import PostgresLedgerStorage, PostgresTaskLedgerStorage
 from mycelium.storage.redis_ledger import RedisLedgerStorage, RedisTaskLedgerStorage
+from mycelium.storage.sqlite_ledger import SqliteLedgerStorage, SqliteTaskLedgerStorage
 from mycelium.task_ledger import (
     TaskFileLedgerStorage,
     TaskInMemoryLedgerStorage,
@@ -161,7 +162,7 @@ from mycelium.transition_resolution import (
     transition_needs_repair,
 )
 
-__version__ = "1.23.1"
+__version__ = "1.24.0"
 
 __all__ = [
     "ActionLedger",
@@ -221,6 +222,8 @@ __all__ = [
     "RedisTaskLedgerStorage",
     "PostgresLedgerStorage",
     "PostgresTaskLedgerStorage",
+    "SqliteLedgerStorage",
+    "SqliteTaskLedgerStorage",
     "get_task_ledger",
     "task_ledger",
     "task_ledger_sync",

--- a/sdk/mycelium/__main__.py
+++ b/sdk/mycelium/__main__.py
@@ -21,6 +21,7 @@ _TEMPLATE_MINIMAL = "mycelium.minimal.yaml"
 _ENV_LEDGER_FILE = "MYCELIUM_LEDGER_FILE"
 _ENV_REDIS_URL = "MYCELIUM_REDIS_URL"
 _ENV_POSTGRES_DSN = "MYCELIUM_POSTGRES_DSN"
+_ENV_SQLITE_PATH = "MYCELIUM_SQLITE_PATH"
 _ENV_OUTCOME_FILE = "MYCELIUM_OUTCOME_FILE"
 
 
@@ -152,13 +153,20 @@ def _add_operator_storage_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help=f"Postgres ledger DSN (or ${_ENV_POSTGRES_DSN}); overrides --config",
     )
+    parser.add_argument(
+        "--sqlite",
+        dest="sqlite_path",
+        type=Path,
+        default=None,
+        help=f"SQLite ledger DB path (or ${_ENV_SQLITE_PATH}); overrides --config",
+    )
 
 
 def _operator_storage_configs(args: argparse.Namespace) -> list[dict[str, Any]]:
     """Resolve normalized ledger-storage config dicts from flags/env or config.
 
-    Direct flags (--file/--redis-url/--postgres-dsn, with env fallback) win
-    over --config. Config mode reuses each tool's normalized ``ledger:``
+    Direct flags (--file/--redis-url/--postgres-dsn/--sqlite, with env fallback)
+    win over --config. Config mode reuses each tool's normalized ``ledger:``
     section, deduplicating tools that share one backend.
     """
     from mycelium.config import ConfigError, load_config
@@ -166,6 +174,7 @@ def _operator_storage_configs(args: argparse.Namespace) -> list[dict[str, Any]]:
     file_path = args.file_path or os.environ.get(_ENV_LEDGER_FILE)
     redis_url = args.redis_url or os.environ.get(_ENV_REDIS_URL)
     postgres_dsn = args.postgres_dsn or os.environ.get(_ENV_POSTGRES_DSN)
+    sqlite_path = args.sqlite_path or os.environ.get(_ENV_SQLITE_PATH)
     direct: list[dict[str, Any]] = []
     if file_path:
         direct.append({"storage": "file", "path": str(file_path)})
@@ -173,6 +182,8 @@ def _operator_storage_configs(args: argparse.Namespace) -> list[dict[str, Any]]:
         direct.append({"storage": "redis", "url": redis_url})
     if postgres_dsn:
         direct.append({"storage": "postgres", "dsn": postgres_dsn})
+    if sqlite_path:
+        direct.append({"storage": "sqlite", "path": str(sqlite_path)})
     if direct:
         return direct
 
@@ -180,7 +191,7 @@ def _operator_storage_configs(args: argparse.Namespace) -> list[dict[str, Any]]:
     if not config_path.is_file():
         raise ConfigError(
             f"no ledger storage specified and config not found: {config_path} "
-            "(pass --config, or --file/--redis-url/--postgres-dsn)"
+            "(pass --config, or --file/--redis-url/--postgres-dsn/--sqlite)"
         )
     config = load_config(config_path)
     raws: list[dict[str, Any]] = []
@@ -212,7 +223,7 @@ def _operator_ledgers(args: argparse.Namespace) -> list[Any]:
                 "process — the CLI cannot reach it. Use the Python API "
                 "(ActionLedger.list_transitions() / ActionLedger.release(...)) "
                 "from a process sharing that storage, or point the CLI at a "
-                "durable backend with --file/--redis-url/--postgres-dsn"
+                "durable backend with --file/--redis-url/--postgres-dsn/--sqlite"
             )
         ledgers.append(ActionLedger(storage=MyceliumConfig._build_ledger_storage(raw)))
     return ledgers

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -1019,7 +1019,7 @@ class ActionLedger:
             f"Tool {tool!r} is side-effecting ({binding.side_effect_class.value}) "
             "but its ActionLedger uses InMemoryLedgerStorage: claims are not "
             "durable across processes or restarts, so the duplicate-side-effect "
-            "guard only holds within this process. Use file/redis/postgres "
+            "guard only holds within this process. Use file/sqlite/redis/postgres "
             "storage beyond local dev/demo.",
             stacklevel=3,
         )

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -937,6 +937,16 @@ class MyceliumConfig:
                 dsn,
                 table=str(raw.get("table", "mycelium_action_ledger")),
             )
+        if storage_type == "sqlite":
+            from mycelium.storage.sqlite_ledger import SqliteLedgerStorage
+
+            path = raw.get("path")
+            if not path:
+                raise ConfigError("ledger storage 'sqlite' requires a 'path'")
+            return SqliteLedgerStorage(
+                path,
+                table=str(raw.get("table", "mycelium_action_ledger")),
+            )
         raise ConfigError(f"unknown ledger storage type: {storage_type!r}")
 
     @staticmethod
@@ -976,6 +986,16 @@ class MyceliumConfig:
                 raise ConfigError(str(exc)) from exc
             return PostgresTaskLedgerStorage(
                 dsn,
+                table=str(raw.get("table", "mycelium_task_ledger")),
+            )
+        if storage_type == "sqlite":
+            from mycelium.storage.sqlite_ledger import SqliteTaskLedgerStorage
+
+            path = raw.get("path")
+            if not path:
+                raise ConfigError("task ledger storage 'sqlite' requires a 'path'")
+            return SqliteTaskLedgerStorage(
+                path,
                 table=str(raw.get("table", "mycelium_task_ledger")),
             )
         raise ConfigError(f"unknown task ledger storage type: {storage_type!r}")
@@ -1539,7 +1559,7 @@ def _warn_memory_storage_for_side_effecting(
 
     Memory is fine for dev/demo, but the duplicate-side-effect guard only holds
     within the process. Emit a one-time warning at YAML load time so the
-    operator knows to switch to file/redis/postgres for production.
+    operator knows to switch to file/sqlite/redis/postgres for production.
     """
     if transition is None:
         return
@@ -1560,7 +1580,7 @@ def _warn_memory_storage_for_side_effecting(
         warnings.warn(
             f"tool {name!r} is side-effecting ({tool.side_effect_class.value}) "
             "but its ledger uses memory storage; the duplicate-side-effect "
-            "guard only holds within this process. Use file/redis/postgres "
+            "guard only holds within this process. Use file/sqlite/redis/postgres "
             "for production deployments.",
             stacklevel=1,
         )

--- a/sdk/mycelium/storage/__init__.py
+++ b/sdk/mycelium/storage/__init__.py
@@ -10,6 +10,10 @@ from mycelium.storage.redis_ledger import (
     RedisLedgerStorage,
     RedisTaskLedgerStorage,
 )
+from mycelium.storage.sqlite_ledger import (
+    SqliteLedgerStorage,
+    SqliteTaskLedgerStorage,
+)
 
 __all__ = [
     "LockedJsonDictFile",
@@ -18,4 +22,6 @@ __all__ = [
     "PostgresTaskLedgerStorage",
     "RedisLedgerStorage",
     "RedisTaskLedgerStorage",
+    "SqliteLedgerStorage",
+    "SqliteTaskLedgerStorage",
 ]

--- a/sdk/mycelium/storage/sqlite_ledger.py
+++ b/sdk/mycelium/storage/sqlite_ledger.py
@@ -1,0 +1,276 @@
+"""SQLite-backed ledger storage (stdlib sqlite3; zero-ops single-node)."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+from mycelium.storage._helpers import ClaimOutcome, claim_inflight_outcome, with_lease
+
+E = TypeVar("E")
+
+_TABLE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _validate_table_name(table: str) -> str:
+    if not _TABLE_RE.fullmatch(table):
+        raise ValueError(
+            f"invalid SQLite table name {table!r}; use lowercase letters, digits, underscores"
+        )
+    return table
+
+
+def _payload_dict(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return dict(raw)
+    return dict(json.loads(raw))
+
+
+class SqliteEntryStorage:
+    """Generic SQLite table store for ledger entries keyed by request_id.
+
+    Mirrors :class:`~mycelium.storage.postgres_ledger.PostgresEntryStorage`:
+    ``request_id`` + JSON ``payload``, transactional claim / CAS transition.
+    Uses stdlib ``sqlite3`` + WAL; no Redis TTL (leases live in payload).
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        table: str,
+        from_dict: Callable[[dict[str, Any]], E],
+    ) -> None:
+        self._path = Path(path)
+        self._table = _validate_table_name(table)
+        self._from_dict = from_dict
+        self._lock = threading.Lock()
+        self._schema_ready = False
+
+    def _connect(self) -> sqlite3.Connection:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(
+            str(self._path),
+            timeout=30.0,
+            check_same_thread=False,
+        )
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=30000")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self, conn: sqlite3.Connection) -> None:
+        if self._schema_ready:
+            return
+        conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {self._table} ("
+            "request_id TEXT PRIMARY KEY, payload TEXT NOT NULL)"
+        )
+        conn.commit()
+        self._schema_ready = True
+
+    def get(self, request_id: str) -> E | None:
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                row = conn.execute(
+                    f"SELECT payload FROM {self._table} WHERE request_id = ?",
+                    (request_id,),
+                ).fetchone()
+        if row is None:
+            return None
+        return self._from_dict(_payload_dict(row["payload"]))
+
+    def set(self, entry: E) -> None:
+        payload = json.dumps(entry.to_dict(), default=str)
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                conn.execute(
+                    f"INSERT INTO {self._table} (request_id, payload) VALUES (?, ?) "
+                    "ON CONFLICT(request_id) DO UPDATE SET payload = excluded.payload",
+                    (entry.request_id, payload),
+                )
+                conn.commit()
+
+    def try_claim_inflight(
+        self,
+        entry: E,
+        *,
+        lease_ttl: float = 3600.0,
+    ) -> tuple[ClaimOutcome, E | None]:
+        now = time.time()
+        leased = with_lease(entry, now=now, lease_ttl=lease_ttl)
+        payload = json.dumps(leased.to_dict(), default=str)
+
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    cur = conn.execute(
+                        f"INSERT OR IGNORE INTO {self._table} (request_id, payload) "
+                        "VALUES (?, ?)",
+                        (entry.request_id, payload),
+                    )
+                    if cur.rowcount == 1:
+                        conn.commit()
+                        return "claimed", None
+
+                    row = conn.execute(
+                        f"SELECT payload FROM {self._table} WHERE request_id = ?",
+                        (entry.request_id,),
+                    ).fetchone()
+                    if row is None:
+                        # Rare race: deleted between IGNORE miss and SELECT.
+                        conn.execute(
+                            f"INSERT INTO {self._table} (request_id, payload) "
+                            "VALUES (?, ?)",
+                            (entry.request_id, payload),
+                        )
+                        conn.commit()
+                        return "claimed", None
+
+                    existing = self._from_dict(_payload_dict(row["payload"]))
+                    outcome = claim_inflight_outcome(existing, now=now)
+                    if outcome == "completed":
+                        conn.commit()
+                        return "completed", existing
+                    if outcome == "in_flight":
+                        conn.commit()
+                        return "in_flight", existing
+
+                    conn.execute(
+                        f"UPDATE {self._table} SET payload = ? WHERE request_id = ?",
+                        (payload, entry.request_id),
+                    )
+                    conn.commit()
+                    return "claimed", None
+                except Exception:
+                    conn.rollback()
+                    raise
+
+    def try_transition(
+        self,
+        entry: E,
+        *,
+        expected_terminal_outcomes: frozenset[str],
+        expected_owner: str | None = None,
+    ) -> bool:
+        if not expected_terminal_outcomes:
+            return False
+        payload = json.dumps(entry.to_dict(), default=str)
+        outcomes = sorted(expected_terminal_outcomes)
+        placeholders = ", ".join("?" for _ in outcomes)
+        sql = (
+            f"UPDATE {self._table} SET payload = ? "
+            f"WHERE request_id = ? "
+            f"AND json_extract(payload, '$.terminal_outcome') IN ({placeholders})"
+        )
+        params: list[Any] = [payload, entry.request_id, *outcomes]
+        if expected_owner is not None:
+            sql += " AND json_extract(payload, '$.owner') = ?"
+            params.append(expected_owner)
+
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                cur = conn.execute(sql, params)
+                conn.commit()
+                return cur.rowcount == 1
+
+    def list_all(self) -> list[E]:
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                rows = conn.execute(f"SELECT payload FROM {self._table}").fetchall()
+        return [self._from_dict(_payload_dict(row["payload"])) for row in rows]
+
+
+class SqliteLedgerStorage:
+    """SQLite storage for :class:`~mycelium.action_ledger.LedgerEntry`."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        table: str = "mycelium_action_ledger",
+    ) -> None:
+        from mycelium.action_ledger import LedgerEntry
+
+        self._inner = SqliteEntryStorage(
+            path,
+            table=table,
+            from_dict=LedgerEntry.from_dict,
+        )
+
+    def get(self, request_id: str) -> Any:
+        return self._inner.get(request_id)
+
+    def set(self, entry: Any) -> None:
+        self._inner.set(entry)
+
+    def try_claim_inflight(
+        self,
+        entry: Any,
+        *,
+        lease_ttl: float = 3600.0,
+    ) -> tuple[ClaimOutcome, Any | None]:
+        return self._inner.try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+    def list_all(self) -> list[Any]:
+        return self._inner.list_all()
+
+    def try_transition(
+        self,
+        entry: Any,
+        *,
+        expected_terminal_outcomes: frozenset[str],
+        expected_owner: str | None = None,
+    ) -> bool:
+        return self._inner.try_transition(
+            entry,
+            expected_terminal_outcomes=expected_terminal_outcomes,
+            expected_owner=expected_owner,
+        )
+
+
+class SqliteTaskLedgerStorage:
+    """SQLite storage for :class:`~mycelium.task_ledger.TaskLedgerEntry`."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        table: str = "mycelium_task_ledger",
+    ) -> None:
+        from mycelium.task_ledger import TaskLedgerEntry
+
+        self._inner = SqliteEntryStorage(
+            path,
+            table=table,
+            from_dict=TaskLedgerEntry.from_dict,
+        )
+
+    def get(self, request_id: str) -> Any:
+        return self._inner.get(request_id)
+
+    def set(self, entry: Any) -> None:
+        self._inner.set(entry)
+
+    def try_claim_inflight(
+        self,
+        entry: Any,
+        *,
+        lease_ttl: float = 3600.0,
+    ) -> tuple[ClaimOutcome, Any | None]:
+        return self._inner.try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+    def list_all(self) -> list[Any]:
+        return self._inner.list_all()

--- a/sdk/mycelium/templates/mycelium.template.yaml
+++ b/sdk/mycelium/templates/mycelium.template.yaml
@@ -18,8 +18,9 @@
 #        mycelium run --config mycelium.yaml -- python -m your_package.app
 #      Or keep explicit @config.apply / @config.apply_task / config.instrument.
 #
-# storage (ledgers): memory | file | redis | postgres
+# storage (ledgers): memory | file | sqlite | redis | postgres
 #   memory — process-local  |  file — needs path:
+#   sqlite — path: (+ optional table); zero-ops single-node durable
 #   redis  — url: or url_env: (+ optional prefix, in_flight_ttl)
 #   postgres — dsn: or dsn_env: (+ optional table)
 # state_flush / audit_receipt: memory | file only
@@ -83,10 +84,14 @@ transition:
 # action_ledger  (tool-level claim/settle)
 # ---------------------------------------------------------------------------
 action_ledger:
-  storage: file            # <TODO: memory | file | redis | postgres>
+  storage: file            # <TODO: memory | file | sqlite | redis | postgres>
   path: ./mycelium-ledger.json
   # unclassified_policy: warn   # warn (default): one-time warning on failed retry
                                 # strict: hard-block unclassified failed retries
+  # sqlite (zero-ops single-node durable):
+  # storage: sqlite
+  # path: ./mycelium-ledger.db
+  # table: mycelium_action_ledger
   # url_env: MYCELIUM_REDIS_URL          # redis
   # dsn_env: MYCELIUM_POSTGRES_DSN       # postgres
   # <TODO step 1: copy ledgered tool names from tools: keys below>
@@ -96,7 +101,7 @@ action_ledger:
 # task_ledger  (whole-task claim/settle; omit if unused)
 # ---------------------------------------------------------------------------
 task_ledger:
-  storage: file            # <TODO: memory | file | redis | postgres>
+  storage: file            # <TODO: memory | file | sqlite | redis | postgres>
   path: ./mycelium-task-ledger.json
   # url_env: MYCELIUM_REDIS_URL
   # dsn_env: MYCELIUM_POSTGRES_DSN

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.23.1"
+version = "1.24.0"
 description = "Runtime guards and YAML auto-instrumentation for reliable AI agent tools"
 keywords = [
   "ai-agents",

--- a/sdk/tests/test_atomicity_contract.py
+++ b/sdk/tests/test_atomicity_contract.py
@@ -32,6 +32,7 @@ from mycelium import (
     RedisLedgerStorage,
     SideEffectBoundary,
     SideEffectClass,
+    SqliteLedgerStorage,
     TerminalOutcome,
     ToolTransitionBinding,
     TransitionScope,
@@ -106,6 +107,7 @@ def _fake_redis(monkeypatch: pytest.MonkeyPatch) -> None:
     params=[
         pytest.param("memory", id="memory"),
         pytest.param("file", id="file"),
+        pytest.param("sqlite", id="sqlite"),
         pytest.param("redis", id="redis"),
     ]
 )
@@ -114,6 +116,8 @@ def ledger(request, tmp_path, monkeypatch):
         storage = InMemoryLedgerStorage()
     elif request.param == "file":
         storage = FileLedgerStorage(tmp_path / "ledger.json")
+    elif request.param == "sqlite":
+        storage = SqliteLedgerStorage(tmp_path / "ledger.db")
     elif request.param == "redis":
         _fake_redis(monkeypatch)
         storage = RedisLedgerStorage("redis://test")
@@ -571,7 +575,7 @@ def test_concurrent_reclaim_race_redis(monkeypatch: pytest.MonkeyPatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("backend", ["memory", "file", "redis"])
+@pytest.mark.parametrize("backend", ["memory", "file", "sqlite", "redis"])
 def test_concurrent_reconcile_not_executed_race(
     backend: str,
     tmp_path: Path,
@@ -584,6 +588,8 @@ def test_concurrent_reconcile_not_executed_race(
         storage = InMemoryLedgerStorage()
     elif backend == "file":
         storage = FileLedgerStorage(tmp_path / "reconcile_race.json")
+    elif backend == "sqlite":
+        storage = SqliteLedgerStorage(tmp_path / "reconcile_race.db")
     elif backend == "redis":
         fakeredis = pytest.importorskip("fakeredis")
         fake = fakeredis.FakeRedis(decode_responses=True)
@@ -659,7 +665,7 @@ def test_concurrent_reconcile_not_executed_race(
     )
 
 
-@pytest.mark.parametrize("backend", ["memory", "file", "redis"])
+@pytest.mark.parametrize("backend", ["memory", "file", "sqlite", "redis"])
 def test_concurrent_reconcile_not_executed_race_expired_seed(
     backend: str,
     tmp_path: Path,
@@ -673,6 +679,8 @@ def test_concurrent_reconcile_not_executed_race_expired_seed(
         storage = InMemoryLedgerStorage()
     elif backend == "file":
         storage = FileLedgerStorage(tmp_path / "reconcile_race_expired.json")
+    elif backend == "sqlite":
+        storage = SqliteLedgerStorage(tmp_path / "reconcile_race_expired.db")
     elif backend == "redis":
         fakeredis = pytest.importorskip("fakeredis")
         fake = fakeredis.FakeRedis(decode_responses=True)

--- a/sdk/tests/test_operator_release.py
+++ b/sdk/tests/test_operator_release.py
@@ -32,6 +32,7 @@ from mycelium import (
     RedisLedgerStorage,
     SideEffectBoundary,
     SideEffectClass,
+    SqliteLedgerStorage,
     TerminalOutcome,
     ToolTransitionBinding,
     TransitionScope,
@@ -78,12 +79,14 @@ def _fake_redis(monkeypatch: pytest.MonkeyPatch):
     return fake
 
 
-@pytest.fixture(params=["memory", "file", "redis"])
+@pytest.fixture(params=["memory", "file", "sqlite", "redis"])
 def storage(request: pytest.FixtureRequest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     if request.param == "memory":
         return InMemoryLedgerStorage()
     if request.param == "file":
         return FileLedgerStorage(tmp_path / "ledger.json")
+    if request.param == "sqlite":
+        return SqliteLedgerStorage(tmp_path / "ledger.db")
     _fake_redis(monkeypatch)
     return RedisLedgerStorage("redis://test")
 
@@ -601,6 +604,31 @@ def _seed_file_ledger(path: Path) -> str:
     ledger_inst.attach_external_operation_ref("req-cli", "pi_cli_1")
     ledger_inst.mark_blocked("req-cli", error="stale lease; maybe crossed")
     return "req-cli"
+
+
+def _seed_sqlite_ledger(path: Path) -> str:
+    storage = SqliteLedgerStorage(path)
+    ledger_inst = ActionLedger(storage=storage)
+    ledger_inst.claim("req-cli-sqlite", "send_payment", (), {"amount": 10})
+    ledger_inst.attach_external_operation_ref("req-cli-sqlite", "pi_cli_sqlite")
+    ledger_inst.mark_blocked("req-cli-sqlite", error="stale lease; maybe crossed")
+    return "req-cli-sqlite"
+
+
+def test_cli_transitions_sqlite_backend_list_show(tmp_path: Path, capsys) -> None:
+    from mycelium.__main__ import main
+
+    db = tmp_path / "ledger.db"
+    request_id = _seed_sqlite_ledger(db)
+
+    assert main(["transitions", "list", "--sqlite", str(db), "--stuck"]) == 0
+    out = capsys.readouterr().out
+    assert request_id in out
+    assert "BLOCKED" in out
+
+    assert main(["transitions", "show", request_id, "--sqlite", str(db)]) == 0
+    out = capsys.readouterr().out
+    assert "external_operation_ref: pi_cli_sqlite" in out
 
 
 def test_cli_transitions_file_backend_round_trip(tmp_path: Path, capsys) -> None:

--- a/sdk/tests/test_storage_backends.py
+++ b/sdk/tests/test_storage_backends.py
@@ -17,6 +17,7 @@ from mycelium import (
     LedgerPendingError,
     RedisLedgerStorage,
     SideEffectClass,
+    SqliteLedgerStorage,
     TerminalOutcome,
     ToolTransitionBinding,
 )
@@ -328,3 +329,137 @@ def test_config_builds_postgres_storage() -> None:
         }
     )
     assert isinstance(storage, PostgresLedgerStorage)
+
+
+def test_sqlite_storage_atomic_claim(tmp_path: Path) -> None:
+    storage = SqliteLedgerStorage(tmp_path / "ledger.db")
+    ledger = ActionLedger(storage=storage)
+
+    first = ledger.claim("req-sqlite", "send_payment", (), {"amount": 1})
+    assert first.status == "in-flight"
+
+    with pytest.raises(LedgerPendingError):
+        ledger.claim("req-sqlite", "send_payment", (), {"amount": 1})
+
+    completed = ledger.complete("req-sqlite", {"ok": True})
+    assert completed.status == "completed"
+
+    replay = ledger.claim("req-sqlite", "send_payment", (), {"amount": 1})
+    assert replay.status == "completed"
+    assert replay.result == {"ok": True}
+
+
+def test_sqlite_storage_serializes_concurrent_claims(tmp_path: Path) -> None:
+    storage = SqliteLedgerStorage(tmp_path / "ledger.db")
+    ledger = ActionLedger(storage=storage)
+    barrier = threading.Barrier(2)
+    results: list[str] = []
+
+    def claim() -> None:
+        barrier.wait()
+        try:
+            ledger.claim("req-1", "send_payment", (), {"amount": 10})
+            results.append("claimed")
+        except LedgerPendingError:
+            results.append("pending")
+
+    threads = [threading.Thread(target=claim) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(results) == ["claimed", "pending"]
+    assert ledger.get("req-1") is not None
+    assert ledger.get("req-1").status == "in-flight"
+
+
+def test_sqlite_storage_payment_hard_blocks_expired_lease(tmp_path: Path) -> None:
+    storage = SqliteLedgerStorage(tmp_path / "ledger.db")
+    ledger = ActionLedger(storage=storage)
+    request_id = "sqlite-expired-payment"
+
+    storage.set(
+        LedgerEntry(
+            request_id=request_id,
+            tool="send_payment",
+            args=[],
+            kwargs={"amount": 10.0},
+            status="in-flight",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+            lease_until=time.time() - 1,
+            idempotency_key=request_id,
+        )
+    )
+
+    with pytest.raises(LedgerHardBlockError, match="manual reconciliation"):
+        ledger.claim_side_effecting(
+            request_id,
+            "send_payment",
+            (),
+            {"amount": 10.0},
+            _payment_binding(),
+        )
+
+    entry = storage.get(request_id)
+    assert entry is not None
+    assert entry.terminal_outcome == TerminalOutcome.BLOCKED.value
+
+
+def test_sqlite_cas_transition_owner_fence(tmp_path: Path) -> None:
+    storage = SqliteLedgerStorage(tmp_path / "ledger.db")
+    entry = LedgerEntry(
+        request_id="cas-1",
+        tool="send_payment",
+        args=[],
+        kwargs={},
+        status="in-flight",
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        owner="owner-a",
+        idempotency_key="cas-1",
+    )
+    storage.set(entry)
+    completed = LedgerEntry(
+        request_id="cas-1",
+        tool="send_payment",
+        args=[],
+        kwargs={},
+        status="completed",
+        terminal_outcome=TerminalOutcome.COMPLETED.value,
+        result={"ok": True},
+        owner="owner-a",
+        idempotency_key="cas-1",
+    )
+    assert storage.try_transition(
+        completed,
+        expected_terminal_outcomes=frozenset({TerminalOutcome.IN_FLIGHT.value}),
+        expected_owner="owner-a",
+    )
+    assert not storage.try_transition(
+        completed,
+        expected_terminal_outcomes=frozenset({TerminalOutcome.IN_FLIGHT.value}),
+        expected_owner="owner-b",
+    )
+    stored = storage.get("cas-1")
+    assert stored is not None
+    assert stored.status == "completed"
+
+
+def test_config_builds_sqlite_storage(tmp_path: Path) -> None:
+    from mycelium.config import MyceliumConfig
+
+    storage = MyceliumConfig._build_ledger_storage(
+        {
+            "storage": "sqlite",
+            "path": str(tmp_path / "ledger.db"),
+            "table": "mycelium_action_ledger",
+        }
+    )
+    assert isinstance(storage, SqliteLedgerStorage)
+
+
+def test_config_sqlite_requires_path() -> None:
+    from mycelium.config import ConfigError, MyceliumConfig
+
+    with pytest.raises(ConfigError, match="requires a 'path'"):
+        MyceliumConfig._build_ledger_storage({"storage": "sqlite"})


### PR DESCRIPTION
## Summary
- Add **`SqliteLedgerStorage` / `SqliteTaskLedgerStorage`** (WAL, transactional claim + CAS)
- YAML `storage: sqlite` + `path:` (+ optional `table`)
- CLI `--sqlite` / `MYCELIUM_SQLITE_PATH`
- Tests across storage / atomicity / operator-release fixtures
- Release **mycelium-runtime v1.24.0**

## Test plan
- [x] SQLite unit/CAS/concurrent claim tests
- [x] Atomicity + operator-release with `sqlite` backend
- [ ] CI green; Release tags `v1.24.0` + PyPI publish