### PR TITLE
chore: release v1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+## 1.29.0 (2026-08-09)
+
+MINOR: partner-facing reliability batch — safer reclaim default, Redis
+tombstones, budget LLM wire, UNKNOWN key window, and `allowed_paths` harden.
+All landed on `main` after v1.28.0; cut once so design partners can `pip install`.
+
 ### Added
 
 - **Provider idempotency-key validity window on `UNKNOWN`:** declaring both

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.28.0)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.29.0)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -10,7 +10,7 @@ Wrong answers are recoverable. Wrong actions are expensive. Mycelium sits betwee
 
 Not recovery after. Not tracing or dashboards. Prevention at the tool boundary.
 
-*Early but API-stable (**v1.28.0**): breaking changes only at major versions. The catalog grows; the promise stays.*
+*Early but API-stable (**v1.29.0**): breaking changes only at major versions. The catalog grows; the promise stays.*
 
 ## The promise — failure-mode catalog (AF-00N)
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,9 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.28.0)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.29.0)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-**The reliability layer for AI agents** — installable as `mycelium-runtime` **v1.28.0**.
+**The reliability layer for AI agents** — installable as `mycelium-runtime` **v1.29.0**.
 
 The public story is the [failure-mode catalog](docs/FAILURE_MODE_CATALOG.md) (**AF-001…AF-009**): each ID is a real runtime failure class; each shipped surface is a deterministic guard. The taxonomy is the product promise; envelope fields and gates are how AF-002 is implemented underneath.
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.28.0"
+version = "1.29.0"
 description = "The reliability layer for AI agents — prove run-or-not and enforce at-most-once at the tool boundary"
 keywords = [
   "ai-agents",

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.28.0"
+version = "1.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Cut **v1.29.0** (MINOR) — batch everything that landed on `main` after v1.28.0 so design partners can `pip install`.
- Batched: YAML death-signal default (`reclaim_requires_death_signal: true`), Redis in-flight tombstones, budget LLM auto-wiring, UNKNOWN provider-key validity window, `@bounded` `allowed_paths` harden.
- Version artifacts moved in lockstep: `sdk/pyproject.toml`, `CHANGELOG.md`, root + SDK README, `uv.lock`.

## Release checklist ([sdk/docs/RELEASE.md](sdk/docs/RELEASE.md))

### Intent
- [x] Batched release (not per-feature thrash)
- [x] No other `mycelium-runtime` version published today
- [x] CHANGELOG tells a coherent partner-facing story
- [x] Positioning stays reliability-layer (no velocity-as-virtue)

### Correctness
- [x] `pytest tests/` — 769 passed, 3 skipped
- [x] `ruff check mycelium tests` clean
- [ ] CI green on this PR (3.10–3.13)
- [x] New guarantees covered by existing tests on `main`
- [x] N/A hotfix

### Surface area
- [x] Public symbols already exported (`budget_llm`, `instrument_*`, etc.)
- [x] YAML / `mycelium init` already updated on feature PRs
- [x] README version lines synced
- [x] N/A catalog/threat-model delta in this cut (behavior already documented with landings)
- [x] Handbook lives in sibling Pages repo — not blocked on this cut

### Versioning
- [x] `sdk/pyproject.toml` → `1.29.0`
- [x] `CHANGELOG.md` has `## 1.29.0 (2026-08-09)`
- [x] README `v1.29.0` lines match
- [x] No second bump planned today

## Test plan
- [x] Local ruff + full pytest from `sdk/`
- [ ] CI green
- [ ] After merge: `release.yml` tags `v1.29.0`, `publish.yml` uploads to PyPI
- [ ] `pip index versions mycelium-runtime` / PyPI JSON shows `1.29.0`