### PR TITLE
fix: CI runs at-most-once concurrency proofs (#69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
@@ -57,20 +58,20 @@ jobs:
 
       - name: SDK unit tests
         working-directory: sdk
+        # Full suite already exercises Redis/Postgres under REQUIRE_*=1.
         run: pytest tests/ -v
 
       - name: Concurrency proofs must not skip
         working-directory: sdk
         # Explicit gate for the flagship at-most-once story (#69).
-        # MYCELIUM_CI_REQUIRE_*=1 turns missing Redis/Postgres into fail.
+        # Focused re-run of concurrency proofs only (not Postgres identity
+        # tests — those already ran above and share durable state).
         run: >
           pytest
           tests/test_proof_two_worker_redis.py
           tests/test_multiprocess_concurrency.py
           tests/test_process_kill_crash_window.py
           tests/test_example_langgraph_redis_crash.py
-          tests/test_storage_backends.py::test_postgres_storage_atomic_claim
-          tests/test_operator_release.py::test_postgres_release_not_executed_round_trip
           -v --tb=short
 
       - name: Ruff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,36 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: mycelium
+          POSTGRES_PASSWORD: mycelium
+          POSTGRES_DB: mycelium_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U mycelium -d mycelium_test"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      MYCELIUM_TEST_REDIS_URL: redis://127.0.0.1:6379/15
+      MYCELIUM_TEST_POSTGRES_DSN: postgresql://mycelium:mycelium@127.0.0.1:5432/mycelium_test
+      MYCELIUM_CI_REQUIRE_REDIS: "1"
+      MYCELIUM_CI_REQUIRE_POSTGRES: "1"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -22,11 +52,26 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install SDK
-        run: pip install -e "./sdk[dev]"
+        # redis + postgres extras so real-backend proofs import the drivers.
+        run: pip install -e "./sdk[dev,redis,postgres]"
 
       - name: SDK unit tests
         working-directory: sdk
         run: pytest tests/ -v
+
+      - name: Concurrency proofs must not skip
+        working-directory: sdk
+        # Explicit gate for the flagship at-most-once story (#69).
+        # MYCELIUM_CI_REQUIRE_*=1 turns missing Redis/Postgres into fail.
+        run: >
+          pytest
+          tests/test_proof_two_worker_redis.py
+          tests/test_multiprocess_concurrency.py
+          tests/test_process_kill_crash_window.py
+          tests/test_example_langgraph_redis_crash.py
+          tests/test_storage_backends.py::test_postgres_storage_atomic_claim
+          tests/test_operator_release.py::test_postgres_release_not_executed_round_trip
+          -v --tb=short
 
       - name: Ruff
         working-directory: sdk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+### Fixed
+
+- **CI runs the at-most-once concurrency proofs** (#69): Redis + Postgres
+  services in `.github/workflows/ci.yml`; install `redis`/`psycopg` extras;
+  `MYCELIUM_CI_REQUIRE_REDIS` / `MYCELIUM_CI_REQUIRE_POSTGRES` fail hard if
+  backends are missing (no silent skip). File-ledger multiprocess tests no
+  longer module-gated behind Redis reachability.
+
 ### Added
 
 - **Thin handoff identity (audit causation):** `handoff_scope(parent_request_id, handoff_id=…)`

--- a/sdk/tests/backend_gates.py
+++ b/sdk/tests/backend_gates.py
@@ -1,0 +1,49 @@
+"""Shared helpers for Redis/Postgres integration gates."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from mycelium.proofs.langgraph_7417_redis import (
+    ENV_REDIS_URL,
+    redis_reachable,
+    resolve_redis_url,
+)
+
+ENV_REQUIRE_REDIS = "MYCELIUM_CI_REQUIRE_REDIS"
+ENV_REQUIRE_POSTGRES = "MYCELIUM_CI_REQUIRE_POSTGRES"
+ENV_POSTGRES_DSN = "MYCELIUM_TEST_POSTGRES_DSN"
+
+
+def require_redis_or_skip() -> str:
+    """Return a reachable Redis URL, or skip/fail depending on CI policy.
+
+    Locally: skip when Redis is missing (dev machines without docker).
+    In CI (``MYCELIUM_CI_REQUIRE_REDIS=1``): fail hard so a silent skip
+    cannot greenwash the concurrency proofs.
+    """
+    pytest.importorskip("redis")
+    url = resolve_redis_url()
+    if redis_reachable(url):
+        return url
+    msg = (
+        f"real Redis required at {url!r} "
+        f"(set {ENV_REDIS_URL} or start redis-server)"
+    )
+    if os.environ.get(ENV_REQUIRE_REDIS) == "1":
+        pytest.fail(msg)
+    pytest.skip(msg)
+
+
+def require_postgres_dsn_or_skip() -> str:
+    """Return Postgres DSN from env, or skip/fail depending on CI policy."""
+    pytest.importorskip("psycopg")
+    dsn = os.environ.get(ENV_POSTGRES_DSN)
+    if dsn:
+        return dsn
+    msg = f"set {ENV_POSTGRES_DSN} to run Postgres integration tests"
+    if os.environ.get(ENV_REQUIRE_POSTGRES) == "1":
+        pytest.fail(msg)
+    pytest.skip(msg)

--- a/sdk/tests/test_example_langgraph_redis_crash.py
+++ b/sdk/tests/test_example_langgraph_redis_crash.py
@@ -9,10 +9,9 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("redis")
 pytest.importorskip("langgraph")
 
-from mycelium.proofs.langgraph_7417_redis import redis_reachable, resolve_redis_url
+from backend_gates import require_redis_or_skip
 
 EXAMPLE = (
     Path(__file__).resolve().parents[1]
@@ -22,17 +21,12 @@ EXAMPLE = (
 )
 SDK_ROOT = Path(__file__).resolve().parents[1]
 
-_REDIS_URL = os.environ.get("MYCELIUM_REDIS_URL") or resolve_redis_url()
-pytestmark = pytest.mark.skipif(
-    not redis_reachable(_REDIS_URL),
-    reason=f"real Redis required at {_REDIS_URL!r}",
-)
-
 
 def test_example_run_py_main_exits_zero() -> None:
+    url = require_redis_or_skip()
     env = {
         **os.environ,
-        "MYCELIUM_REDIS_URL": _REDIS_URL,
+        "MYCELIUM_REDIS_URL": url,
         "MYCELIUM_SIGNING_KEY": "demo-signing-key",
         "PYTHONPATH": os.pathsep.join(
             [str(SDK_ROOT), os.environ.get("PYTHONPATH", "")]

--- a/sdk/tests/test_multiprocess_concurrency.py
+++ b/sdk/tests/test_multiprocess_concurrency.py
@@ -29,8 +29,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from mycelium import (
     ActionLedger,
     FileLedgerStorage,
@@ -42,11 +40,6 @@ from mycelium import (
     TransitionScope,
     execution_scope,
     ledger_sync,
-)
-from mycelium.proofs.langgraph_7417_redis import (
-    ENV_REDIS_URL,
-    redis_reachable,
-    resolve_redis_url,
 )
 
 _MP_CTX = mp.get_context("spawn")
@@ -361,24 +354,13 @@ def _redis_contested_worker(payload: dict[str, Any]) -> None:
         client.close()
 
 
-_REDIS_URL = resolve_redis_url()
-
-pytest.importorskip("redis")
-pytestmark = pytest.mark.skipif(
-    not redis_reachable(_REDIS_URL),
-    reason=(
-        f"real Redis required at {_REDIS_URL!r} "
-        f"(set {ENV_REDIS_URL} or start redis-server)"
-    ),
-)
-
-
 def test_two_processes_redis_contested_claim(tmp_path: Path) -> None:
     """Both processes start together and contend for the same payment claim on
     real Redis; exactly one tool-body execution, identical returned results."""
     import redis
+    from backend_gates import require_redis_or_skip
 
-    url = _REDIS_URL
+    url = require_redis_or_skip()
     run_id = f"mp_contested_{os.getpid()}_{int(time.time())}"
     prefix = f"mycelium:proof:mp:{run_id}:ledger:"
     keys = {

--- a/sdk/tests/test_operator_release.py
+++ b/sdk/tests/test_operator_release.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import time
+import uuid
 from pathlib import Path
 
 import pytest
@@ -572,7 +573,7 @@ def test_postgres_release_not_executed_round_trip() -> None:
 
     dsn = require_postgres_dsn_or_skip()
     storage = PostgresLedgerStorage(dsn, table="mycelium_test_action_ledger")
-    request_id = "pg-release-round-trip"
+    request_id = f"pg-release-round-trip-{uuid.uuid4().hex}"
     storage.set(
         LedgerEntry(
             request_id=request_id,

--- a/sdk/tests/test_operator_release.py
+++ b/sdk/tests/test_operator_release.py
@@ -15,7 +15,6 @@ Release is one-shot, fail-closed, and never deletes ledger entries.
 from __future__ import annotations
 
 import json
-import os
 import time
 from pathlib import Path
 
@@ -566,14 +565,12 @@ def test_release_emits_audit_receipt_when_emitter_configured() -> None:
     assert entry.receipt_ref == receipt.receipt_id
 
 
-@pytest.mark.skipif(
-    not os.environ.get("MYCELIUM_TEST_POSTGRES_DSN"),
-    reason="set MYCELIUM_TEST_POSTGRES_DSN to run Postgres integration tests",
-)
 def test_postgres_release_not_executed_round_trip() -> None:
+    from backend_gates import require_postgres_dsn_or_skip
+
     from mycelium import PostgresLedgerStorage
 
-    dsn = os.environ["MYCELIUM_TEST_POSTGRES_DSN"]
+    dsn = require_postgres_dsn_or_skip()
     storage = PostgresLedgerStorage(dsn, table="mycelium_test_action_ledger")
     request_id = "pg-release-round-trip"
     storage.set(

--- a/sdk/tests/test_proof_two_worker_redis.py
+++ b/sdk/tests/test_proof_two_worker_redis.py
@@ -2,29 +2,14 @@
 
 from __future__ import annotations
 
-import pytest
+from backend_gates import require_redis_or_skip
 
-from mycelium.proofs.langgraph_7417_redis import (
-    ENV_REDIS_URL,
-    prove_two_worker_redis_redispatch,
-    redis_reachable,
-    resolve_redis_url,
-)
-
-pytest.importorskip("redis")
-
-_REDIS_URL = resolve_redis_url()
-pytestmark = pytest.mark.skipif(
-    not redis_reachable(_REDIS_URL),
-    reason=(
-        f"real Redis required at {_REDIS_URL!r} "
-        f"(set {ENV_REDIS_URL} or start redis-server)"
-    ),
-)
+from mycelium.proofs.langgraph_7417_redis import prove_two_worker_redis_redispatch
 
 
 def test_two_worker_redis_cloud_style_redispatch() -> None:
-    result = prove_two_worker_redis_redispatch()
+    url = require_redis_or_skip()
+    result = prove_two_worker_redis_redispatch(url=url)
     assert result["workers"] == 2
     assert result["storage"] == "redis"
     assert result["executions"] == 1

--- a/sdk/tests/test_storage_backends.py
+++ b/sdk/tests/test_storage_backends.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import threading
 import time
 from pathlib import Path
@@ -273,14 +272,12 @@ def test_redis_storage_read_only_returns_completed(
     assert replay.result == {"query": "billing", "hits": 1}
 
 
-@pytest.mark.skipif(
-    not os.environ.get("MYCELIUM_TEST_POSTGRES_DSN"),
-    reason="set MYCELIUM_TEST_POSTGRES_DSN to run Postgres integration tests",
-)
 def test_postgres_storage_atomic_claim() -> None:
+    from backend_gates import require_postgres_dsn_or_skip
+
     from mycelium import PostgresLedgerStorage
 
-    dsn = os.environ["MYCELIUM_TEST_POSTGRES_DSN"]
+    dsn = require_postgres_dsn_or_skip()
     storage = PostgresLedgerStorage(dsn, table="mycelium_test_action_ledger")
     ledger = ActionLedger(storage=storage)
 

--- a/sdk/tests/test_storage_backends.py
+++ b/sdk/tests/test_storage_backends.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
+import uuid
 from pathlib import Path
 
 import pytest
@@ -281,10 +282,9 @@ def test_postgres_storage_atomic_claim() -> None:
     storage = PostgresLedgerStorage(dsn, table="mycelium_test_action_ledger")
     ledger = ActionLedger(storage=storage)
 
-    request_id = "req-pg-integration"
-    entry = ledger.get(request_id)
-    if entry is not None and entry.status == "in-flight":
-        ledger.fail(request_id, RuntimeError("cleanup stale in-flight row"))
+    # Unique per invocation so re-running the suite (or CI's focused concurrency
+    # step after the full suite) does not collide with a prior COMPLETED row.
+    request_id = f"req-pg-integration-{uuid.uuid4().hex}"
 
     first = ledger.claim(request_id, "send_payment", (), {"amount": 99})
     assert first.status == "in-flight"


### PR DESCRIPTION
## Summary
- Provision Redis 7 + Postgres 16 as CI services and install `./sdk[dev,redis,postgres]`
- `MYCELIUM_CI_REQUIRE_REDIS` / `MYCELIUM_CI_REQUIRE_POSTGRES` turn missing backends into hard fails (no silent skip)
- Un-gate file-ledger multiprocess tests (they were module-skipped whenever Redis was unreachable)
- Explicit concurrency proof pytest step for the flagship at-most-once suite

Fixes #69

## Test plan
- [x] Local: `pytest tests/test_multiprocess_concurrency.py tests/test_proof_two_worker_redis.py tests/test_process_kill_crash_window.py tests/test_example_langgraph_redis_crash.py` (9 passed with Redis)
- [x] `ruff check` on touched tests
- [ ] CI matrix green on this PR (Redis/Postgres services healthy; concurrency step not skipped)
- [ ] Confirm Actions log shows `test_two_worker_redis_cloud_style_redispatch` **PASSED**, not SKIPPED