### PR TITLE
docs: version-line hygiene — stop docs churn bumping vX.Y.Z (#71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,56 @@ on:
     branches: [main]
 
 jobs:
+  version-hygiene:
+    # Docs churn must not move the version line (#71).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: No shields.io &release= pins in READMEs
+        run: |
+          set -euo pipefail
+          if grep -nE 'shields\.io/pypi/v/mycelium-runtime\.svg\?[^\)]*release=' README.md sdk/README.md; then
+            echo "::error::Do not pin PyPI badge cache with &release= — badges track PyPI (see sdk/docs/RELEASE.md § Version-line hygiene)."
+            exit 1
+          fi
+
+      - name: No hardcoded current-version banners in READMEs
+        run: |
+          set -euo pipefail
+          # Forbid "API-stable (**vX.Y.Z**)" / "`mycelium-runtime` **vX.Y.Z**" current banners.
+          # Historical "shipped in vX.Y.Z" elsewhere is fine.
+          if grep -nE 'API-stable \(\*\*v[0-9]|as `mycelium-runtime` \*\*v[0-9]' README.md sdk/README.md; then
+            echo "::error::Do not hardcode the current package version in README banners — link to PyPI instead (#71)."
+            exit 1
+          fi
+
+      - name: pyproject bump requires matching CHANGELOG header
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if ! git diff --name-only "$BASE"...HEAD | grep -qx 'sdk/pyproject.toml'; then
+            echo "sdk/pyproject.toml unchanged — ok"
+            exit 0
+          fi
+          if ! git diff "$BASE"...HEAD -- sdk/pyproject.toml | grep -qE '^\+version[[:space:]]*='; then
+            echo "pyproject.toml touched but version line unchanged — ok"
+            exit 0
+          fi
+          NEW="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' sdk/pyproject.toml | head -1)"
+          if [ -z "$NEW" ]; then
+            echo "::error::could not parse version from sdk/pyproject.toml"
+            exit 1
+          fi
+          echo "Detected version bump to ${NEW}"
+          if ! grep -nE "^## ${NEW}( |$)" CHANGELOG.md; then
+            echo "::error::sdk/pyproject.toml version is ${NEW} but CHANGELOG.md has no '## ${NEW}' header. Version bumps belong in a release PR with a matching CHANGELOG section."
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
   `MYCELIUM_CI_REQUIRE_REDIS` / `MYCELIUM_CI_REQUIRE_POSTGRES` fail hard if
   backends are missing (no silent skip). File-ledger multiprocess tests no
   longer module-gated behind Redis reachability.
+- **Version-line hygiene** (#71): READMEs no longer hardcode current
+  `vX.Y.Z` / shields `&release=` pins; release policy documents batching
+  docs into release PRs; CI `version-hygiene` job blocks drive-by
+  `pyproject.toml` bumps without a matching CHANGELOG header.
+
+### Changed
+
+- Release checklist skill + `AGENTS.md` / `sdk/docs/RELEASE.md` aligned:
+  only the release PR moves the version line; badges track PyPI.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mycelium
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.29.0)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Downloads](https://static.pepy.tech/badge/mycelium-runtime)](https://pepy.tech/project/mycelium-runtime)
 
@@ -10,7 +10,9 @@ Wrong answers are recoverable. Wrong actions are expensive. Mycelium sits betwee
 
 Not recovery after. Not tracing or dashboards. Prevention at the tool boundary.
 
-*Early but API-stable (**v1.29.0**): breaking changes only at major versions. The catalog grows; the promise stays.*
+*Early but API-stable: breaking changes only at major versions. The catalog
+grows; the promise stays. Current package version is on
+[PyPI](https://pypi.org/project/mycelium-runtime/) — do not hardcode it here.*
 
 Early design-partner use: **live outbound-email lane** (Week 1: 25 ledgered sends, 0 duplicates). Not a public logo; the interactive sandbox is separate.
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,10 @@
 # Mycelium runtime
 
-[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg?cacheSeconds=60&release=1.29.0)](https://pypi.org/project/mycelium-runtime/)
+[![PyPI version](https://img.shields.io/pypi/v/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 [![Python](https://img.shields.io/pypi/pyversions/mycelium-runtime.svg)](https://pypi.org/project/mycelium-runtime/)
 
-**The reliability layer for AI agents** — installable as `mycelium-runtime` **v1.29.0**.
+**The reliability layer for AI agents** — installable as `mycelium-runtime`
+(current version on [PyPI](https://pypi.org/project/mycelium-runtime/)).
 
 The public story is the [failure-mode catalog](docs/FAILURE_MODE_CATALOG.md) (**AF-001…AF-009**): each ID is a real runtime failure class; each shipped surface is a deterministic guard. The taxonomy is the product promise; envelope fields and gates are how AF-002 is implemented underneath.
 

--- a/sdk/docs/RELEASE.md
+++ b/sdk/docs/RELEASE.md
@@ -58,6 +58,31 @@ Cadence is orthogonal to semver — batch *what* goes into each bump.
 
 ---
 
+## Version-line hygiene (docs churn)
+
+**Only real SDK changes may move the version line.** Hand-editing README /
+handbook / badge URLs to name `vX.Y.Z` on every merge is the same failure mode
+as PyPI spam — it makes the product look unstable (#71).
+
+Rules:
+
+1. **`sdk/pyproject.toml` is the only version source of truth.** Do not bump it
+   on docs-only, CI, or positioning PRs.
+2. **Do not hardcode the current package version** in root/`sdk` README prose
+   or shields.io badge query params (`&release=`). Badges track PyPI; prose
+   links to PyPI. Historical "shipped in vX.Y.Z" mentions in CHANGELOG / docs
+   stay — those are history, not a "current version" banner.
+3. **Batch docs/site/handbook edits into the release PR** (or a docs PR that
+   does **not** touch `pyproject.toml`). Never open a version-bump PR just to
+   refresh copy.
+4. **CHANGELOG:** land notes under `## Unreleased` on feature PRs; promote to
+   `## X.Y.Z (date)` only in the release PR. Prefer summarizing the batch from
+   git history over a diary of micro-commits.
+5. **CI enforces** that a `pyproject.toml` version change requires a matching
+   `CHANGELOG.md` `## X.Y.Z` header (see `.github/workflows/ci.yml`).
+
+---
+
 ## Before you bump the version (checklist)
 
 Complete **every** applicable item. If something does not apply, write N/A in
@@ -95,9 +120,11 @@ the PR description — do not skip silently.
 ### Versioning artifacts (same PR)
 
 - [ ] `sdk/pyproject.toml` `version` bumped once for this cut.
-- [ ] `CHANGELOG.md` has `## X.Y.Z (YYYY-MM-DD)` matching that version.
-- [ ] Badge / “vX.Y.Z” lines in root + SDK README match (or intentionally
-      omit and let badges track PyPI — do not leave contradictory numbers).
+- [ ] `CHANGELOG.md` has `## X.Y.Z (YYYY-MM-DD)` matching that version
+      (promote from `## Unreleased`; summarize the batch).
+- [ ] Root + SDK README do **not** hardcode `vX.Y.Z` as "current" (badges /
+      PyPI links only). Handbook site updated in its own repo if the cut is
+      user-visible.
 - [ ] No second bump planned the same day.
 
 ### After merge (automation)
@@ -114,16 +141,18 @@ uploads to PyPI. Confirm:
 
 ## How to cut a release (mechanics)
 
-1. Land work on `main` via PRs **without** version bumps (preferred).
+1. Land work on `main` via PRs **without** version bumps (preferred). Docs and
+   site edits land the same way — no `pyproject.toml` touch.
 2. Open a **release PR** that only (or primarily):
    - bumps `sdk/pyproject.toml`
-   - adds the CHANGELOG section (summarize the batch)
-   - syncs README version lines / critical docs
+   - promotes `## Unreleased` → `## X.Y.Z (date)` in CHANGELOG (batch summary)
+   - optionally batches handbook / positioning that waited for the cut
 3. Pass the checklist above in the PR body (copy the checkboxes).
 4. Merge. Do not manually tag unless automation fails (see root README escape hatch).
 
 **Do not** open a version-bump PR for every merged feature. That is how
-8-releases-a-day happens.
+8-releases-a-day happens. **Do not** bump README "current version" strings on
+feature PRs — that is how 10 version lines show up in a week of docs churn.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove hardcoded current `vX.Y.Z` / shields `&release=` pins from root + SDK READMEs (badges track PyPI)
- Document version-line hygiene in `sdk/docs/RELEASE.md`: only real SDK cuts move the version; batch docs into release PRs; land notes under `## Unreleased`
- CI `version-hygiene` job: reject badge pins / current-version banners; require matching CHANGELOG header when `sdk/pyproject.toml` version changes

Fixes #71

## Test plan
- [x] Local hygiene greps pass (no `&release=`, no API-stable `**v…**` banners)
- [ ] CI `version-hygiene` green on this PR
- [ ] Confirm feature PRs can land docs without touching `pyproject.toml`