### PR TITLE
test: sibling coverage for task_ledger, ToolCache, two-worker envelope

### DIFF
--- a/sdk/tests/test_cache.py
+++ b/sdk/tests/test_cache.py
@@ -1,0 +1,59 @@
+"""TTL cache used by @protect and Session (ToolCache)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mycelium.cache import ToolCache, default_cache
+
+
+def test_get_miss_returns_none() -> None:
+    cache = ToolCache()
+    assert cache.get("read_balance", None) is None
+
+
+def test_set_get_roundtrip() -> None:
+    cache = ToolCache()
+    cache.set("read_balance", None, {"balance": 100}, ttl=60)
+    assert cache.get("read_balance", None) == {"balance": 100}
+
+
+def test_entity_id_scopes_keys() -> None:
+    cache = ToolCache()
+    cache.set("read_balance", "acct_1", {"balance": 100}, ttl=60)
+    assert cache.get("read_balance", "acct_1") == {"balance": 100}
+    assert cache.get("read_balance", "acct_2") is None
+    assert cache.get("read_balance", None) is None
+
+
+def test_same_tool_different_entity_are_isolated() -> None:
+    cache = ToolCache()
+    cache.set("read_balance", "acct_1", {"balance": 100}, ttl=60)
+    cache.set("read_balance", "acct_2", {"balance": 200}, ttl=60)
+    assert cache.get("read_balance", "acct_1") == {"balance": 100}
+    assert cache.get("read_balance", "acct_2") == {"balance": 200}
+
+
+def test_expired_entry_evicted_on_get() -> None:
+    import time
+
+    cache = ToolCache()
+    now = time.monotonic()
+    cache.set("read_balance", None, {"balance": 100}, ttl=60)
+    with patch("mycelium.cache.time.monotonic", return_value=now + 1):
+        assert cache.get("read_balance", None) == {"balance": 100}
+    with patch("mycelium.cache.time.monotonic", return_value=now + 1000):
+        assert cache.get("read_balance", None) is None
+        assert cache.get("read_balance", None) is None
+
+
+def test_clear_removes_entry() -> None:
+    cache = ToolCache()
+    cache.set("read_balance", "acct_1", {"balance": 100}, ttl=60)
+    cache.clear("read_balance", "acct_1")
+    assert cache.get("read_balance", "acct_1") is None
+    cache.clear("read_balance", "acct_1")
+
+
+def test_default_cache_is_shared_singleton() -> None:
+    assert default_cache is default_cache

--- a/sdk/tests/test_task_ledger.py
+++ b/sdk/tests/test_task_ledger.py
@@ -1,0 +1,391 @@
+"""TaskLedger: task-level durable records and idempotency guard.
+
+Sibling test for ``mycelium/task_ledger.py`` — covers the public storage
+classes, claim/complete/fail lifecycle, request-id derivation priority, the
+sync + async ``@task_ledger`` decorators, and receipt emission.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from mycelium import (
+    AuditReceiptEmitter,
+    TaskFileLedgerStorage,
+    TaskInMemoryLedgerStorage,
+    TaskLedger,
+    TaskLedgerEntry,
+    TaskLedgerError,
+    TaskLedgerPendingError,
+    get_task_ledger,
+    task_ledger,
+    task_ledger_sync,
+)
+
+# ---------------------------------------------------------------------------
+# Entry + storage primitives
+# ---------------------------------------------------------------------------
+
+
+def test_task_entry_to_dict_from_dict_roundtrip() -> None:
+    entry = TaskLedgerEntry(
+        request_id="r1",
+        task="process_invoice",
+        args=[1, "x"],
+        kwargs={"amount": 5.0},
+        status="completed",
+        result={"ok": True},
+        error=None,
+        started_at=1.0,
+        finished_at=2.0,
+    )
+    restored = TaskLedgerEntry.from_dict(entry.to_dict())
+    assert restored == entry
+
+
+def test_task_in_memory_storage_get_set_list_all() -> None:
+    storage = TaskInMemoryLedgerStorage()
+    assert storage.get("missing") is None
+    entry = TaskLedgerEntry(request_id="r1", task="t", args=[], kwargs={}, status="in-flight")
+    storage.set(entry)
+    assert storage.get("r1") == entry
+    assert storage.list_all() == [entry]
+
+
+def test_task_file_storage_persists(tmp_path: Path) -> None:
+    path = tmp_path / "tasks.json"
+    storage = TaskFileLedgerStorage(path)
+    entry = TaskLedgerEntry(request_id="r1", task="t", args=[], kwargs={}, status="in-flight")
+    storage.set(entry)
+    assert storage.get("r1") == entry
+    assert [e.request_id for e in storage.list_all()] == ["r1"]
+
+    reloaded = TaskFileLedgerStorage(path)
+    assert reloaded.get("r1") == entry
+
+
+def test_task_file_storage_claim_completed_and_in_flight(tmp_path: Path) -> None:
+    path = tmp_path / "tasks.json"
+    storage = TaskFileLedgerStorage(path)
+
+    completed = TaskLedgerEntry(
+        request_id="done", task="t", args=[], kwargs={}, status="completed", result=42
+    )
+    storage.set(completed)
+    outcome, existing = storage.try_claim_inflight(completed)
+    assert outcome == "completed"
+    assert existing == completed
+
+    in_flight = TaskLedgerEntry(
+        request_id="busy", task="t", args=[], kwargs={}, status="in-flight"
+    )
+    storage.set(in_flight)
+    outcome, existing = storage.try_claim_inflight(in_flight)
+    assert outcome == "in_flight"
+    assert existing == in_flight
+
+
+def test_task_file_storage_claim_overwrites_failed(tmp_path: Path) -> None:
+    path = tmp_path / "tasks.json"
+    storage = TaskFileLedgerStorage(path)
+    failed = TaskLedgerEntry(
+        request_id="f1", task="t", args=[], kwargs={}, status="failed", error="boom"
+    )
+    storage.set(failed)
+    fresh = TaskLedgerEntry(request_id="f1", task="t", args=[], kwargs={}, status="in-flight")
+    outcome, existing = storage.try_claim_inflight(fresh)
+    assert outcome == "claimed"
+    assert existing is None
+    assert storage.get("f1").status == "in-flight"
+
+
+# ---------------------------------------------------------------------------
+# TaskLedger claim / complete / fail lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_claim_new_task_returns_in_flight_entry() -> None:
+    ledger = TaskLedger()
+    entry = ledger.claim("r1", "process_invoice", (1,), {"amount": 5.0})
+    assert entry.request_id == "r1"
+    assert entry.task == "process_invoice"
+    assert entry.status == "in-flight"
+    assert entry.args == [1]
+    assert entry.kwargs == {"amount": 5.0}
+
+
+def test_claim_completed_task_returns_cached_entry() -> None:
+    ledger = TaskLedger()
+    ledger.claim("r1", "process_invoice", (1,), {"amount": 5.0})
+    ledger.complete("r1", {"ok": True})
+
+    replayed = ledger.claim("r1", "process_invoice", (1,), {"amount": 5.0})
+    assert replayed.status == "completed"
+    assert replayed.result == {"ok": True}
+
+
+def test_claim_in_flight_task_raises_pending() -> None:
+    ledger = TaskLedger()
+    ledger.claim("r1", "process_invoice", (1,), {"amount": 5.0})
+    with pytest.raises(TaskLedgerPendingError, match="already in-flight"):
+        ledger.claim("r1", "process_invoice", (1,), {"amount": 5.0})
+
+
+def test_complete_unknown_request_raises() -> None:
+    ledger = TaskLedger()
+    with pytest.raises(TaskLedgerError, match="unknown request"):
+        ledger.complete("missing", {"ok": True})
+
+
+def test_fail_unknown_request_raises() -> None:
+    ledger = TaskLedger()
+    with pytest.raises(TaskLedgerError, match="unknown request"):
+        ledger.fail("missing", RuntimeError("boom"))
+
+
+def test_complete_records_result_and_finished_at() -> None:
+    ledger = TaskLedger()
+    ledger.claim("r1", "process_invoice", (1,), {})
+    completed = ledger.complete("r1", {"ok": True})
+    assert completed.status == "completed"
+    assert completed.result == {"ok": True}
+    assert completed.finished_at is not None
+    stored = ledger.get("r1")
+    assert stored.status == "completed"
+    assert stored.result == {"ok": True}
+
+
+def test_fail_records_error_and_keeps_failed_status() -> None:
+    ledger = TaskLedger()
+    ledger.claim("r1", "process_invoice", (1,), {})
+    failed = ledger.fail("r1", RuntimeError("gateway down"))
+    assert failed.status == "failed"
+    assert "RuntimeError" in (failed.error or "")
+    stored = ledger.get("r1")
+    assert stored.status == "failed"
+
+
+def test_get_returns_none_for_unknown() -> None:
+    assert TaskLedger().get("missing") is None
+
+
+# ---------------------------------------------------------------------------
+# Request-id derivation priority
+# ---------------------------------------------------------------------------
+
+
+def test_derive_request_id_prefers_task_id() -> None:
+    ledger = TaskLedger()
+    rid = ledger.derive_request_id(
+        "process_invoice", (), {"task_id": "t-1", "amount": 5.0}
+    )
+    assert rid == "t-1"
+
+
+def test_derive_request_id_uses_run_id_second() -> None:
+    ledger = TaskLedger()
+    rid = ledger.derive_request_id(
+        "process_invoice", (), {"run_id": "run-9", "amount": 5.0}
+    )
+    assert rid == "process_invoice:run-9"
+
+
+def test_derive_request_id_uses_id_from_fields() -> None:
+    ledger = TaskLedger(id_from=["account_id", "region"])
+    rid = ledger.derive_request_id(
+        "process_invoice", (), {"account_id": "acct_1", "region": "eu", "amount": 5.0}
+    )
+    assert rid == "process_invoice:account_id=acct_1:region=eu"
+
+
+def test_derive_request_id_stable_hash_of_args_and_kwargs() -> None:
+    ledger = TaskLedger()
+    a = ledger.derive_request_id("process_invoice", (1, 2), {"amount": 5.0})
+    b = ledger.derive_request_id("process_invoice", (1, 2), {"amount": 5.0})
+    c = ledger.derive_request_id("process_invoice", (1, 2), {"amount": 6.0})
+    assert a == b
+    assert a != c
+
+
+def test_derive_request_id_task_id_beats_run_id() -> None:
+    ledger = TaskLedger()
+    rid = ledger.derive_request_id(
+        "process_invoice", (), {"task_id": "t-1", "run_id": "run-9"}
+    )
+    assert rid == "t-1"
+
+
+# ---------------------------------------------------------------------------
+# Sync + async decorators
+# ---------------------------------------------------------------------------
+
+
+def test_task_ledger_sync_records_completion() -> None:
+    calls: list[int] = []
+
+    @task_ledger_sync()
+    def process_invoice(invoice_id: int) -> dict:
+        calls.append(invoice_id)
+        return {"processed": invoice_id}
+
+    result = process_invoice(invoice_id=10)
+    assert result == {"processed": 10}
+    assert calls == [10]
+
+
+def test_task_ledger_sync_dedupes_by_task_id() -> None:
+    calls: list[int] = []
+
+    @task_ledger_sync()
+    def process_invoice(invoice_id: int) -> dict:
+        calls.append(invoice_id)
+        return {"processed": invoice_id}
+
+    first = process_invoice(invoice_id=10, task_id="dup-1")
+    second = process_invoice(invoice_id=10, task_id="dup-1")
+    assert first == second == {"processed": 10}
+    assert calls == [10]
+
+
+def test_task_ledger_sync_records_failure() -> None:
+    @task_ledger_sync()
+    def process_invoice(invoice_id: int) -> dict:
+        raise RuntimeError("gateway down")
+
+    with pytest.raises(RuntimeError, match="gateway down"):
+        process_invoice(invoice_id=10)
+
+
+def test_task_ledger_sync_attaches_ledger() -> None:
+    @task_ledger_sync()
+    def process_invoice(invoice_id: int) -> dict:
+        return {"processed": invoice_id}
+
+    assert isinstance(get_task_ledger(process_invoice), TaskLedger)
+
+
+def test_task_ledger_sync_strips_bookkeeping_kwargs_from_body() -> None:
+    seen: dict = {}
+
+    @task_ledger_sync()
+    def process_invoice(invoice_id: int, **kwargs) -> dict:
+        seen.update(kwargs)
+        return {"processed": invoice_id}
+
+    process_invoice(invoice_id=10, task_id="t-1", run_id="r-1", amount=5.0)
+    assert seen == {"amount": 5.0}
+
+
+def test_task_ledger_sync_reruns_failed_task_on_retry() -> None:
+    calls: list[int] = []
+
+    @task_ledger_sync()
+    def flaky(invoice_id: int) -> dict:
+        calls.append(invoice_id)
+        if len(calls) == 1:
+            raise RuntimeError("gateway down")
+        return {"processed": invoice_id}
+
+    with pytest.raises(RuntimeError):
+        flaky(invoice_id=1, task_id="flaky-1")
+    result = flaky(invoice_id=1, task_id="flaky-1")
+    assert result == {"processed": 1}
+    assert calls == [1, 1]
+
+
+async def test_task_ledger_async_records_completion() -> None:
+    calls: list[int] = []
+
+    @task_ledger()
+    async def process_invoice(invoice_id: int) -> dict:
+        await asyncio.sleep(0)
+        calls.append(invoice_id)
+        return {"processed": invoice_id}
+
+    result = await process_invoice(invoice_id=10)
+    assert result == {"processed": 10}
+    assert calls == [10]
+
+
+async def test_task_ledger_async_dedupes_by_task_id() -> None:
+    calls: list[int] = []
+
+    @task_ledger()
+    async def process_invoice(invoice_id: int) -> dict:
+        calls.append(invoice_id)
+        return {"processed": invoice_id}
+
+    first = await process_invoice(invoice_id=10, task_id="dup-1")
+    second = await process_invoice(invoice_id=10, task_id="dup-1")
+    assert first == second == {"processed": 10}
+    assert calls == [10]
+
+
+async def test_task_ledger_async_records_failure() -> None:
+    @task_ledger()
+    async def process_invoice(invoice_id: int) -> dict:
+        raise RuntimeError("gateway down")
+
+    with pytest.raises(RuntimeError, match="gateway down"):
+        await process_invoice(invoice_id=10)
+
+
+async def test_task_ledger_async_attaches_ledger() -> None:
+    @task_ledger()
+    async def process_invoice(invoice_id: int) -> dict:
+        return {"processed": invoice_id}
+
+    assert isinstance(get_task_ledger(process_invoice), TaskLedger)
+
+
+def test_file_storage_dedupe_across_two_ledgers(tmp_path: Path) -> None:
+    path = tmp_path / "tasks.json"
+
+    @task_ledger_sync(storage=TaskFileLedgerStorage(path))
+    def first(invoice_id: int) -> dict:
+        return {"processed": invoice_id}
+
+    first(invoice_id=10, task_id="shared-1")
+
+    @task_ledger_sync(storage=TaskFileLedgerStorage(path))
+    def second(invoice_id: int) -> dict:
+        raise AssertionError("must not re-run")
+
+    result = second(invoice_id=10, task_id="shared-1")
+    assert result == {"processed": 10}
+
+
+# ---------------------------------------------------------------------------
+# Receipt emission
+# ---------------------------------------------------------------------------
+
+
+def test_task_ledger_sync_emits_receipt_on_success_and_failure() -> None:
+    emitter = AuditReceiptEmitter(agent_id="agent_a", signing_key="test-key")
+
+    @task_ledger_sync(audit_emitter=emitter)
+    def process_invoice(invoice_id: int) -> dict:
+        if invoice_id < 0:
+            raise RuntimeError("bad invoice")
+        return {"processed": invoice_id}
+
+    process_invoice(invoice_id=10, task_id="rec-1")
+    with pytest.raises(RuntimeError):
+        process_invoice(invoice_id=-1, task_id="rec-2")
+
+    receipts = emitter.storage.list_all()
+    assert [r.request_id for r in receipts] == ["rec-1", "rec-2"]
+    assert receipts[0].status == "completed"
+    assert receipts[1].status == "failed"
+    assert receipts[0].action_kind == "task"
+
+
+def test_task_ledger_sync_without_emitter_no_receipt() -> None:
+    @task_ledger_sync()
+    def process_invoice(invoice_id: int) -> dict:
+        return {"processed": invoice_id}
+
+    process_invoice(invoice_id=10)

--- a/sdk/tests/test_two_worker_envelope.py
+++ b/sdk/tests/test_two_worker_envelope.py
@@ -1,0 +1,211 @@
+"""In-process two-worker transition-envelope proof (no Redis required).
+
+The ``test_proof_two_worker_redis.py`` and ``test_multiprocess_concurrency.py``
+proofs spawn OS processes and (optionally) Redis. These tests run the same
+envelope deterministically inside one process with two threads sharing a
+durable backend, so the claim → POLL → stored-result-return contract is
+always exercised in CI, even with no Redis reachable.
+
+Scenarios covered:
+
+- Worker A claims and runs a slow side effect; Worker B redispatches the same
+  transition key while A is ``IN_FLIGHT``. B must POLL, not re-execute, and
+  return A's stored result — the side effect runs exactly once.
+- Worker A crashes (lease lapses to ``EXPIRED``) mid-flight; Worker B's
+  redispatch resolves the envelope fail-closed (reclaim / hard-block by class)
+  without a second side effect.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+from mycelium import (
+    ActionLedger,
+    FileLedgerStorage,
+    InMemoryLedgerStorage,
+    LedgerHardBlockError,
+    SideEffectBoundary,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+    ledger_sync,
+)
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="proof",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def test_two_workers_thread_redispatch_single_execution() -> None:
+    """B redispatches while A is in-flight → POLL → both return A's result."""
+    storage = InMemoryLedgerStorage()
+    started = threading.Event()
+    release = threading.Event()
+    exec_count = 0
+    results: list[tuple[str, dict]] = []
+    errors: list[BaseException] = []
+
+    @ledger_sync(
+        storage=storage,
+        transition_binding=_binding(),
+        lease_ttl=30.0,
+        poll_interval=0.01,
+        poll_timeout=5.0,
+    )
+    def analyze_market(task: str) -> dict:
+        nonlocal exec_count
+        exec_count += 1
+        started.set()
+        assert release.wait(timeout=5.0), "owner never released"
+        return {"task": task, "result": "done"}
+
+    def worker_a() -> None:
+        try:
+            with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+                results.append(("A", analyze_market(task="analyze_market", tool_call_id="call_1")))
+        except BaseException as exc:  # noqa: BLE001 — surface in parent thread
+            errors.append(exc)
+        finally:
+            release.set()
+
+    def worker_b() -> None:
+        try:
+            assert started.wait(timeout=5.0), "A never claimed"
+            with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+                results.append(("B", analyze_market(task="analyze_market", tool_call_id="call_1")))
+        except BaseException as exc:  # noqa: BLE001 — surface in parent thread
+            errors.append(exc)
+
+    thread_a = threading.Thread(target=worker_a, name="worker-a")
+    thread_b = threading.Thread(target=worker_b, name="worker-b")
+    thread_a.start()
+    assert started.wait(timeout=5.0), "A never started"
+    thread_b.start()
+    # Let B enter its POLL loop before A completes; otherwise B just sees a
+    # COMPLETED entry and this becomes the trivial RETURN path.
+    time.sleep(0.1)
+    release.set()
+    thread_b.join(timeout=10.0)
+    thread_a.join(timeout=10.0)
+
+    assert errors == [], errors
+    assert exec_count == 1, "side effect must run exactly once"
+    by_worker = dict(results)
+    assert set(by_worker) == {"A", "B"}
+    assert by_worker["A"] == by_worker["B"] == {"task": "analyze_market", "result": "done"}
+
+    entries = storage.list_all()
+    assert len(entries) == 1, "one envelope must survive"
+    assert entries[0].resolved_terminal_outcome() == TerminalOutcome.COMPLETED
+
+
+def test_two_workers_file_ledger_redispatch_single_execution(tmp_path: Path) -> None:
+    """Same envelope on the durable file backend: one execution, two results."""
+    storage = FileLedgerStorage(tmp_path / "ledger.json")
+    started = threading.Event()
+    release = threading.Event()
+    exec_count = 0
+    results: list[tuple[str, dict]] = []
+    errors: list[BaseException] = []
+
+    @ledger_sync(
+        storage=storage,
+        transition_binding=_binding(),
+        lease_ttl=30.0,
+        poll_interval=0.01,
+        poll_timeout=5.0,
+    )
+    def analyze_market(task: str) -> dict:
+        nonlocal exec_count
+        exec_count += 1
+        started.set()
+        assert release.wait(timeout=5.0), "owner never released"
+        return {"task": task, "result": "done"}
+
+    def worker_a() -> None:
+        try:
+            with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+                results.append(("A", analyze_market(task="analyze_market", tool_call_id="call_2")))
+        except BaseException as exc:  # noqa: BLE001 — surface in parent thread
+            errors.append(exc)
+        finally:
+            release.set()
+
+    def worker_b() -> None:
+        try:
+            assert started.wait(timeout=5.0), "A never claimed"
+            with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+                results.append(("B", analyze_market(task="analyze_market", tool_call_id="call_2")))
+        except BaseException as exc:  # noqa: BLE001 — surface in parent thread
+            errors.append(exc)
+
+    thread_a = threading.Thread(target=worker_a, name="worker-a-file")
+    thread_b = threading.Thread(target=worker_b, name="worker-b-file")
+    thread_a.start()
+    assert started.wait(timeout=5.0), "A never started"
+    thread_b.start()
+    time.sleep(0.1)
+    release.set()
+    thread_b.join(timeout=10.0)
+    thread_a.join(timeout=10.0)
+
+    assert errors == [], errors
+    assert exec_count == 1, "side effect must run exactly once"
+    by_worker = dict(results)
+    assert set(by_worker) == {"A", "B"}
+    assert by_worker["A"] == by_worker["B"] == {"task": "analyze_market", "result": "done"}
+
+
+def test_owner_crash_expired_envelope_does_not_reexecute_crossed() -> None:
+    """A died mid-effect (CROSSED + expired lease) → B hard-blocks, no re-run."""
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(
+        storage=storage,
+        lease_ttl=0.05,
+        poll_interval=0.01,
+        poll_timeout=0.5,
+    )
+    request_id = "call_crash"
+    binding = _binding()
+
+    claimed = ledger.claim_side_effecting(
+        request_id,
+        "analyze_market",
+        (),
+        {"task": "analyze_market"},
+        binding,
+        lease_ttl=0.05,
+    )
+    ledger.advance_boundary(request_id, SideEffectBoundary.CROSSED)
+    time.sleep(0.1)  # lease lapses → EXPIRED
+
+    assert claimed.resolved_terminal_outcome() in (
+        TerminalOutcome.IN_FLIGHT,
+        TerminalOutcome.EXPIRED,
+    )
+    stored = storage.get(request_id)
+    assert stored is not None
+    assert stored.resolved_terminal_outcome() == TerminalOutcome.EXPIRED
+
+    try:
+        ledger.claim_side_effecting(
+            request_id,
+            "analyze_market",
+            (),
+            {"task": "analyze_market"},
+            binding,
+            poll_timeout=0.2,
+        )
+    except LedgerHardBlockError:
+        pass  # expected: CROSSED + EXPIRED → manual reconciliation
+    else:
+        raise AssertionError("crash-window redispatch must hard-block, not re-execute")


### PR DESCRIPTION
Closes #70 — closes the no-test-file gap for three modules:

- `tests/test_task_ledger.py`: entry + storage primitives, claim/complete/fail lifecycle, request-id priority, `@task_ledger` / `@task_ledger_sync` decorators, receipt emission, retry-after-failure semantics.
- `tests/test_cache.py`: ToolCache set/get/evict with patched monotonic clock.
- `tests/test_two_worker_envelope.py`: in-process two-worker proof that a redispatch of an in-flight envelope returns the owner's result (thread + file backends), plus the crash-window guarantee (CROSSED + EXPIRED lease hard-blocks instead of re-executing) — a cheaper, hermetic sibling of the Redis two-worker proof.

Full suite: 824 passed, 3 skipped. `ruff check mycelium tests` clean.