### PR TITLE
fix: BudgetGuard warn_at must not refuse under ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ### Fixed
 
+- **BudgetGuard `warn_at` no longer refuses the step** (Honey): soft warn
+  emits `warnings.warn` once per dimension and allows the step. Declared
+  ceilings stay honest — `warn_at=0.8` is not an 80% hard cap.
+  `max_steps=N` pinned to allow exactly N bodies before hard-block.
 - **CI runs the at-most-once concurrency proofs** (#69): Redis + Postgres
   services in `.github/workflows/ci.yml`; install `redis`/`psycopg` extras;
   `MYCELIUM_CI_REQUIRE_REDIS` / `MYCELIUM_CI_REQUIRE_POSTGRES` fail hard if

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1042,10 +1042,11 @@ def charge(*, tool_call_id: str) -> None:
 ```
 
 Manual `guard.check("llm")` still works if you own the turn loop yourself.
-Soft warn → `ToolBoundaryError` (`budget_warning`); hard → `LedgerHardBlockError`
-on the **next** step (never kill mid-flight). Operator:
-`mycelium budget status|release` (`clear` / `allow-once` / `abort-run`).
-Status exposes deterministic `remaining_budget` (pitch word: runway).
+Soft warn (`warn_at`) → `warnings.warn` once per dimension; the step **still
+runs**. Hard → `LedgerHardBlockError` only at the declared ceiling (never kill
+mid-flight). Operator: `mycelium budget status|release` (`clear` /
+`allow-once` / `abort-run`). Status exposes deterministic `remaining_budget`
+(pitch word: runway).
 
 ```bash
 mycelium loops status --stuck --config mycelium.yaml

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -45,7 +45,8 @@ This document is **explicitly out of scope** for:
 - **Spend / time budget enforcement** *unless* optional `budget:` is
   configured — the ledger does not meter tokens or USD. With `budget:`,
   host-declared `max_duration` / `max_steps` / `max_tokens` / `max_usd`
-  ceilings soft-warn then hard-block the **next** LLM/tool step (never
+  ceilings soft-warn (`warnings.warn`, step still allowed) then hard-block
+  only at the declared ceiling on the **next** LLM/tool step (never
   mid-flight kill). Tokens/USD are host-reported via `record_usage`;
   `on_missing_meter: hard` fail-closes if those ceilings are declared but
   never metered. Optional `loop_guard:` (AF-003) only halts consecutive

--- a/sdk/mycelium/budget_guard.py
+++ b/sdk/mycelium/budget_guard.py
@@ -34,7 +34,6 @@ from mycelium.loop_guard import (
     resolve_loop_scope_key,
 )
 from mycelium.storage.json_file import LockedJsonDictFile
-from mycelium.tool_boundary import ToolBoundaryError
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -697,8 +696,9 @@ class BudgetGuard:
         """Gate the next consequential step; optionally reserve one step.
 
         Call before an LLM turn (``kind="llm"``) or tool body (``kind="tool"``).
-        Hard-blocks raise ``LedgerHardBlockError``; soft warns raise
-        ``ToolBoundaryError`` without incrementing.
+        Hard-blocks raise ``LedgerHardBlockError``. Soft warns
+        (``warn_at``) emit ``warnings.warn`` once per dimension and **allow**
+        the step — they must not shrink the declared ceiling.
         """
         global _SCOPE_MISSING_WARNED
 
@@ -721,7 +721,7 @@ class BudgetGuard:
                 _SCOPE_MISSING_WARNED = True
             return BudgetRunState(scope_key="unscoped")
 
-        outcome: dict[str, Any] = {"exc": None, "state": None}
+        outcome: dict[str, Any] = {"exc": None, "state": None, "soft": None}
 
         def apply(state: BudgetRunState) -> BudgetRunState:
             now = time.time()
@@ -748,7 +748,8 @@ class BudgetGuard:
                 outcome["state"] = state
                 return state
 
-            hard = self._hard_dimension(state, now=now, pending_steps=1 if increment_steps else 0)
+            pending = 1 if increment_steps else 0
+            hard = self._hard_dimension(state, now=now, pending_steps=pending)
             if hard is not None:
                 if state.allow_once:
                     state.allow_once = False
@@ -767,29 +768,15 @@ class BudgetGuard:
                     outcome["state"] = state
                     return state
 
-            soft = self._soft_dimension(state, now=now, pending_steps=1 if increment_steps else 0)
+            soft = self._soft_dimension(state, now=now, pending_steps=pending)
             if soft is not None and not state.soft_issued.get(soft):
                 state.soft_issued[soft] = True
                 remaining = state.remaining(self._ceilings, now=now)
-                outcome["exc"] = ToolBoundaryError(
-                    f"budget soft-warn: {soft}",
-                    violation=VIOLATION_BUDGET_WARN,
-                    tool_name=tool or kind,
-                    llm_message=(
-                        f"Budget warning: approaching {soft} ceiling "
-                        f"(warn_at={self._warn_at}). Remaining: "
-                        f"{remaining.to_dict()}. Change strategy or stop; "
-                        "the step was not executed."
-                    ),
-                    expected=f"under warn_at for {soft}",
-                    actual=soft,
-                    recovery_hint=(
-                        "Reduce work, finish the run, or ask an operator to "
-                        "raise/release the budget."
-                    ),
+                outcome["soft"] = (
+                    f"BudgetGuard: approaching {soft} ceiling "
+                    f"(warn_at={self._warn_at}). Remaining: {remaining.to_dict()}. "
+                    "Step allowed; hard-block only at the declared ceiling."
                 )
-                outcome["state"] = state
-                return state
 
             if increment_steps:
                 state.steps += 1
@@ -800,6 +787,9 @@ class BudgetGuard:
         exc = outcome["exc"]
         if exc is not None:
             raise exc
+        soft_msg = outcome["soft"]
+        if soft_msg is not None:
+            warnings.warn(soft_msg, stacklevel=2)
         assert outcome["state"] is not None
         return outcome["state"]
 
@@ -992,6 +982,11 @@ class BudgetGuard:
         now: float,
         pending_steps: int,
     ) -> str | None:
+        """Return the ceiling that the next unit would exceed.
+
+        ``max_steps=N`` allows exactly N successful step reservations
+        (``pending_steps=1``): block only when ``steps + pending > N``.
+        """
         c = self._ceilings
         if c.max_duration is not None and (now - state.started_at) >= c.max_duration:
             return "max_duration"
@@ -1010,7 +1005,13 @@ class BudgetGuard:
         now: float,
         pending_steps: int,
     ) -> str | None:
-        """Warn when approaching a ceiling, but never on the final allowed unit."""
+        """Warn when meters reach ``warn_at`` of a ceiling (permissive).
+
+        Uses committed meters only (not the pending step), so a warn never
+        steals the final allowed unit. ``pending_steps`` is accepted for API
+        symmetry with ``_hard_dimension`` and ignored.
+        """
+        _ = pending_steps  # warn on committed usage; do not project the next step
         c = self._ceilings
         if c.max_duration is not None:
             elapsed = now - state.started_at
@@ -1019,11 +1020,10 @@ class BudgetGuard:
                 and _ratio(elapsed, c.max_duration) >= self._warn_at
             ):
                 return "max_duration"
-        if c.max_steps is not None:
-            projected = state.steps + pending_steps
+        if c.max_steps is not None and c.max_steps > 0:
             if (
-                projected < c.max_steps
-                and _ratio(float(projected), float(c.max_steps)) >= self._warn_at
+                state.steps < c.max_steps
+                and _ratio(float(state.steps), float(c.max_steps)) >= self._warn_at
             ):
                 return "max_steps"
         if c.max_tokens is not None and c.max_tokens > 0:

--- a/sdk/tests/test_budget_guard.py
+++ b/sdk/tests/test_budget_guard.py
@@ -28,7 +28,6 @@ from mycelium.loop_guard import (
     VERIFIED_ALLOW_ONCE,
     VERIFIED_CLEAR,
 )
-from mycelium.tool_boundary import ToolBoundaryError
 from mycelium.transition import TransitionScope, execution_scope
 
 
@@ -44,7 +43,32 @@ def test_parse_duration_seconds() -> None:
         parse_duration_seconds("nope")
 
 
-def test_max_steps_soft_then_hard() -> None:
+def test_max_steps_ceiling_allows_n() -> None:
+    """Honey Mail 2: max_steps=N must run N bodies (warn_at must not steal one)."""
+    for warn_at in (1.0, 0.8):
+        guard = BudgetGuard(
+            InMemoryBudgetGuardStorage(), max_steps=3, warn_at=warn_at
+        )
+        calls = {"n": 0}
+
+        @budget_guard_sync(guard)
+        def search(q: str, *, tool_call_id: str) -> str:
+            calls["n"] += 1
+            return q
+
+        with execution_scope(_scope(f"steps-{warn_at}")):
+            for i in range(3):
+                assert search(q="foo", tool_call_id=f"c{i}") == "foo"
+            assert calls["n"] == 3
+            state = guard.get_state(f"steps-{warn_at}")
+            assert state is not None
+            assert state.steps == 3
+            with pytest.raises(LedgerHardBlockError):
+                search(q="foo", tool_call_id="c3")
+            assert calls["n"] == 3
+
+
+def test_max_steps_soft_warn_allows_then_hard() -> None:
     guard = BudgetGuard(InMemoryBudgetGuardStorage(), max_steps=5, warn_at=0.8)
     calls = {"n": 0}
 
@@ -54,22 +78,48 @@ def test_max_steps_soft_then_hard() -> None:
         return q
 
     with execution_scope(_scope()):
-        for i in range(3):
+        for i in range(4):
             assert search(q="foo", tool_call_id=f"c{i}") == "foo"
-        assert calls["n"] == 3
+        assert calls["n"] == 4
 
-        with pytest.raises(ToolBoundaryError) as soft:
-            search(q="foo", tool_call_id="c3")
-        assert soft.value.violation == "budget_warning"
-        assert calls["n"] == 3
-
-        assert search(q="foo", tool_call_id="c4") == "foo"
-        assert search(q="foo", tool_call_id="c5") == "foo"
+        with pytest.warns(UserWarning, match="approaching max_steps"):
+            assert search(q="foo", tool_call_id="c4") == "foo"
         assert calls["n"] == 5
+        state = guard.get_state("run-1")
+        assert state is not None
+        assert state.soft_issued.get("max_steps")
 
         with pytest.raises(LedgerHardBlockError):
-            search(q="foo", tool_call_id="c6")
+            search(q="foo", tool_call_id="c5")
         assert calls["n"] == 5
+
+
+def test_warn_at_does_not_refuse_under_ceiling_usd() -> None:
+    """Honey Mail 2: warn_at is permissive — $0.85 of $1.00 must not refuse."""
+    guard = BudgetGuard(
+        InMemoryBudgetGuardStorage(),
+        max_usd=1.0,
+        warn_at=0.8,
+        on_missing_meter="off",
+    )
+    with execution_scope(_scope("usd-warn")):
+        guard.record_usage(usd=0.80)
+        with pytest.warns(UserWarning, match="approaching max_usd"):
+            guard.check(KIND_LLM, increment_steps=False)
+        guard.record_usage(usd=0.05)
+        state = guard.get_state("usd-warn")
+        assert state is not None
+        assert state.usd == pytest.approx(0.85)
+        assert not state.hard_blocked
+        assert state.soft_issued.get("max_usd")
+
+        guard.record_usage(usd=0.20)  # crosses 1.00
+        state = guard.get_state("usd-warn")
+        assert state is not None
+        assert state.hard_blocked
+        assert state.blocked_dimension == "max_usd"
+        with pytest.raises(LedgerHardBlockError):
+            guard.check(KIND_LLM, increment_steps=False)
 
 
 def test_llm_check_and_record_usage_usd() -> None:


### PR DESCRIPTION
## Summary
- Soft `warn_at` now emits `warnings.warn` once per dimension and **allows** the step — it no longer raises `ToolBoundaryError` and shrinks the declared ceiling to ~80%.
- Pin `max_steps=N` to exactly N bodies before hard-block (warn path must not steal a step); soft warn uses committed meters, not a projected next step.
- Docs/CHANGELOG aligned; partner report from Honey Mail 2 on 1.29.0.

## Test plan
- [x] `pytest tests/test_budget_guard.py tests/test_budget_llm.py`
- [x] Full suite: 825 passed, 3 skipped
- [ ] Confirm `max_steps=3` runs 3 bodies at `warn_at` 0.8 and 1.0
- [ ] Confirm `$0.80` of `$1.00` + `$0.05` step warns but does not refuse; hard-block only at ceiling