### PR TITLE
chore: release v1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,11 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
-### Fixed
+## 1.30.0 (2026-08-11)
 
-- **BudgetGuard `warn_at` no longer refuses the step** (Honey): soft warn
-  emits `warnings.warn` once per dimension and allows the step. Declared
-  ceilings stay honest — `warn_at=0.8` is not an 80% hard cap.
-  `max_steps=N` pinned to allow exactly N bodies before hard-block.
-- **CI runs the at-most-once concurrency proofs** (#69): Redis + Postgres
-  services in `.github/workflows/ci.yml`; install `redis`/`psycopg` extras;
-  `MYCELIUM_CI_REQUIRE_REDIS` / `MYCELIUM_CI_REQUIRE_POSTGRES` fail hard if
-  backends are missing (no silent skip). File-ledger multiprocess tests no
-  longer module-gated behind Redis reachability.
-- **Version-line hygiene** (#71): READMEs no longer hardcode current
-  `vX.Y.Z` / shields `&release=` pins; release policy documents batching
-  docs into release PRs; CI `version-hygiene` job blocks drive-by
-  `pyproject.toml` bumps without a matching CHANGELOG header.
-
-### Changed
-
-- Release checklist skill + `AGENTS.md` / `sdk/docs/RELEASE.md` aligned:
-  only the release PR moves the version line; badges track PyPI.
+MINOR: supervisor handoff audit glue + async peer-wait DX, LangGraph/Redis
+adoption recipe, BudgetGuard soft-warn honesty, and CI that actually runs the
+concurrency proofs. Batched so partners can `pip install` once.
 
 ### Added
 
@@ -43,6 +28,27 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
   (`examples/langgraph_redis_crash/`): adoption recipe — redispatch RETURN with
   signed receipt, then mid-flight kill → `HARD_BLOCK` (body once). No new
   capability; stitches existing LangGraph / Redis / receipt / crash paths.
+
+### Fixed
+
+- **BudgetGuard `warn_at` no longer refuses the step** (Honey): soft warn
+  emits `warnings.warn` once per dimension and allows the step. Declared
+  ceilings stay honest — `warn_at=0.8` is not an 80% hard cap.
+  `max_steps=N` pinned to allow exactly N bodies before hard-block.
+- **CI runs the at-most-once concurrency proofs** (#69): Redis + Postgres
+  services in `.github/workflows/ci.yml`; install `redis`/`psycopg` extras;
+  `MYCELIUM_CI_REQUIRE_REDIS` / `MYCELIUM_CI_REQUIRE_POSTGRES` fail hard if
+  backends are missing (no silent skip). File-ledger multiprocess tests no
+  longer module-gated behind Redis reachability.
+- **Version-line hygiene** (#71): READMEs no longer hardcode current
+  `vX.Y.Z` / Docs `&release=` pins; release policy documents batching
+  docs into release PRs; CI `version-hygiene` job blocks drive-by
+  `pyproject.toml` bumps without a matching CHANGELOG header.
+
+### Changed
+
+- Release checklist skill + `AGENTS.md` / `sdk/docs/RELEASE.md` aligned:
+  only the release PR moves the version line; badges track PyPI.
 
 ## 1.29.0 (2026-08-09)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Developers running **agents with side-effect tools** in production (payments, em
 
 Python 3.10+. Framework-agnostic. Drop in via YAML + `mycelium run`, or decorators.
 
-## How it works (v1.28.x)
+## How it works
 
 Mycelium wraps tool calls after the LLM returns `tool_calls` and returns a verdict: run, return a stored result, wait, ask the provider what happened, or hard-stop.
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -562,6 +562,10 @@ Each duplicate dispatch is classified to a gate. Read-only and side-effecting to
 | `ALLOW` | no prior transition, or policy permits retry (e.g. `FAILED_BEFORE_EFFECT` + same provider key) | tool runs |
 | `RETURN` | `COMPLETED` | return stored result — no re-execution |
 | `POLL` | `IN_FLIGHT` with valid lease (`LeaseValidity.HELD`) | wait for the other worker |
+| `RECLAIM` | read-only `EXPIRED` / `FAILED_*` | take over stale lease and run |
+| `REPAIR` | incomplete durable key / boundary / terminal (healable) | fix record, re-resolve — **no** second side effect |
+| `SOFT_BLOCK` | read-only `UNKNOWN` / `BLOCKED` only | **retry by default** (safe — reads don't spend); opt into deferral with `defer_read_only_unknown=True` → `LedgerSoftBlockError` |
+| `HARD_BLOCK` | ambiguous mutating transition | stop; run `Reconciler` when `external_operation_ref` is present, else fail-closed |
 
 Decorator claim paths already poll. For a custom async LangGraph node that
 already knows the peer `request_id` and only needs to wait (no re-claim):
@@ -573,10 +577,21 @@ entry = await ledger.wait_for_transition_async(request_id)
 
 `wait_for_transition` is the sync twin. Timeout raises `LedgerPollTimeoutError`
 and does **not** mark `UNKNOWN` (claim loops own that policy).
-| `RECLAIM` | read-only `EXPIRED` / `FAILED_*` | take over stale lease and run |
-| `REPAIR` | incomplete durable key / boundary / terminal (healable) | fix record, re-resolve — **no** second side effect |
-| `SOFT_BLOCK` | read-only `UNKNOWN` / `BLOCKED` only | **retry by default** (safe — reads don't spend); opt into deferral with `defer_read_only_unknown=True` → `LedgerSoftBlockError` |
-| `HARD_BLOCK` | ambiguous mutating transition | stop; run `Reconciler` when `external_operation_ref` is present, else fail-closed |
+
+**Thin handoff identity (audit causation):** after a supervisor/spawn claim,
+wrap subagent tool calls in `handoff_scope(parent_request_id, handoff_id=…)`
+so child ledger entries record `parent_request_id` / `handoff_id`. Audit glue
+only — does not grant capabilities or change at-most-once claim keys.
+`list_transitions(parent_request_id=…)` and
+`mycelium transitions list --parent` / `show` expose the link.
+
+```python
+from mycelium import handoff_scope
+
+# parent_id = the supervisor transition's request_id
+with handoff_scope(parent_id, handoff_id="spawn-pay"):
+    charge(amount=10, tool_call_id="child-1")  # stamped with parent link
+```
 
 Teachable in-process repros for the partner-facing gates:
 [examples/failure_cases/](examples/failure_cases/) (`run_all.py`).

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.29.0"
+version = "1.30.0"
 description = "The reliability layer for AI agents — prove run-or-not and enforce at-most-once at the tool boundary"
 keywords = [
   "ai-agents",

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.29.0"
+version = "1.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Release **v1.30.0** MINOR — handoff audit glue, async wait helper, LangGraph+Redis crash example, BudgetGuard `warn_at` honesty (#75), CI concurrency proofs, version-line hygiene.
- Docs: resolution-gates table repaired; `handoff_scope` documented; root README drops hardcoded `v1.28.x` heading.

## Checklist
- [x] Batched cut (not same-day thrash; last PyPI was 1.29.0 on 2026-08-09)
- [x] `sdk/pyproject.toml` → 1.30.0
- [x] `CHANGELOG.md` `## 1.30.0 (2026-08-11)`
- [x] READMEs do not hardcode current version as banner
- [x] `ruff check mycelium tests` clean
- [x] `pytest tests/` (reinstall editable for version test; Redis proof ignored locally)
- [ ] CI green on this PR
- [ ] After merge: PyPI shows 1.30.0