### PR TITLE
feat: add production-safe memory storage policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+### Added
+
+- **`action_ledger.memory_storage_policy`:** `warn` (default, backward
+  compatible) or `error`. Side-effecting tools (`idempotent_mutate`,
+  `keyed_mutate`, `non_idempotent_mutate`, `irreversible`) plus
+  `storage: memory` now raise `ConfigError` at YAML load when policy is
+  `error` — the error names the tool and recommends
+  `file/sqlite/redis/postgres`. Reads may keep using memory storage.
+  Shipped `mycelium init` templates default the action ledger to SQLite.
+
 ## 1.30.0 (2026-08-11)
 
 MINOR: supervisor handoff audit glue + async peer-wait DX, LangGraph/Redis

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1223,11 +1223,11 @@ Storage backends:
 
 | Backend | Use case | YAML `storage` |
 |---------|----------|----------------|
-| `memory` | Single process, tests | `memory` (default) |
-| `file` | Local dev, single host (`fcntl` lock) | `file` + `path` |
-| `sqlite` | Zero-ops single-node durable (stdlib) | `sqlite` + `path` (+ optional `table`) |
-| `redis` | Multi-worker, in-flight TTL | `redis` + `url` or `url_env` |
-| `postgres` | Audit/compliance, durable SQL | `postgres` + `dsn` or `dsn_env` |
+| `memory` | Tests / single-process disposable state | `memory` (default; not production) |
+| `file` | Local development / single host (`fcntl` lock) | `file` + `path` |
+| `sqlite` | Durable single-node default (stdlib, no extras) | `sqlite` + `path` (+ optional `table`) |
+| `redis` | Multi-worker coordination | `redis` + `url` or `url_env` |
+| `postgres` | Durable multi-worker / audit-oriented deployment | `postgres` + `dsn` or `dsn_env` |
 
 ```python
 from mycelium import ActionLedger, FileLedgerStorage, InMemoryLedgerStorage
@@ -1287,7 +1287,29 @@ action_ledger:
   on_args_drift: soft   # soft (default) | hard | off — identity-conflict gate
 ```
 
-When `transition:` is configured and a side-effecting tool uses memory storage, a one-time warning is emitted at YAML load time — the duplicate-side-effect guard only holds within the process.
+When `transition:` is configured and a side-effecting tool uses memory storage, a one-time warning is emitted at YAML load time — the duplicate-side-effect guard only holds within the process. Set `action_ledger.memory_storage_policy: error` to reject that combination at load time (`ConfigError` names the tool and recommends `file/sqlite/redis/postgres`). The default remains `warn` so existing test/dev configs keep loading. Reads may keep using memory storage under either policy.
+
+Durable storage keeps the ledger across a process restart. It cannot by itself tell you whether an external provider finished during the crash window (`maybe_crossed`). Production still needs the full fail-closed pattern:
+
+```yaml
+transition:
+  reclaim_requires_death_signal: true
+action_ledger:
+  storage: postgres          # or redis for multi-worker coordination
+  dsn_env: MYCELIUM_POSTGRES_DSN
+  unclassified_policy: strict
+  memory_storage_policy: error
+```
+
+```python
+@ledger_sync(transition_binding=binding, reconciler=StripeReconciler())
+def send_payment(amount, recipient, *, idempotency_key):
+    record_external_operation(idempotency_key)   # before the provider call
+    with side_effect():                          # maybe_crossed is durable first
+        return gateway.charge(amount, recipient, idempotency_key=idempotency_key)
+```
+
+Checklist: durable Redis/Postgres ledger, stable request/transition identity, provider idempotency key, `record_external_operation()` before the provider call when possible, `side_effect()` around the external call, a read-only `Reconciler`, `unclassified_policy: strict`, and `reclaim_requires_death_signal: true`. Unresolved ambiguity stays fail-closed — hard-block or reconcile; never re-execute blindly.
 
 ## Quickstart: task-level idempotency
 
@@ -1346,9 +1368,10 @@ transition:
   # presumed_dead_after: 7200             # default = 2 × lease_ttl; grace window for heartbeat
 
 action_ledger:
-  storage: file
-  path: ./mycelium-ledger.json
+  storage: sqlite
+  path: ./mycelium-ledger.db
   unclassified_policy: strict   # warn (default) or strict
+  memory_storage_policy: warn   # warn (default) | error
   tools: [send_payment, search_docs]
 
 task_ledger:

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -247,7 +247,11 @@ than the code makes.
 - **In-memory ledgers across processes.** `storage: memory` claims are not
   durable beyond the process. Mycelium emits a warning when a side-effecting
   tool is configured with memory storage; the guard only holds within the
-  process. (Out-of-scope alternative: use file/Redis/Postgres.)
+  process. Set `memory_storage_policy: error` to reject that combination at
+  load time. (Out-of-scope alternative: use file/SQLite/Redis/Postgres.)
+  Durable storage preserves `maybe_crossed` across restart but cannot alone
+  prove whether the provider completed; unresolved ambiguity stays
+  fail-closed.
 - **Unclassified tools under the default `warn` policy.** A tool without a
   transition binding that fails is re-executed on reclaim (legacy behavior,
   with a one-time warning). `unclassified_policy: strict` routes them through
@@ -280,7 +284,7 @@ are cited once. "Where documented" links the README section.
 | Hard-block on ambiguous mutation | README § [Resolution gates](../README.md#resolution-gates) | `test_side_effect_resolution.py::test_payment_hard_blocks_expired_lease` · `test_side_effect_resolution.py::test_crash_after_claim_before_complete_hard_blocks_redispatch` · `test_side_effect_resolution.py::test_payment_hard_blocks_failed_after_effect_retry` · `test_reconcile.py::test_hard_block_without_reconciler_still_blocks` · `test_process_kill_crash_window.py::test_kill_before_ref_recorded_hard_blocks_no_provider_lookup` · `test_payment_provider_mock.py::test_no_reconciler_hard_blocks_without_provider_evidence` |
 | Resolution gate matrix (POLL / RETURN / ALLOW / HARD_BLOCK / reconcile) | README § [Resolution gates](../README.md#resolution-gates) | `test_conformance_tsc007.py` (5 cases) · `test_side_effect_resolution.py::test_resolve_side_effect_gate_matrix` · `test_read_only_resolution.py::test_resolve_read_only_gate_matrix` |
 | Reconciliation fail-closed | README § [Reconciling automatically](../README.md#reconciling-automatically-reconciler) | `test_reconcile.py::test_reconcile_failure_is_fail_closed` · `test_reconcile.py::test_reconcile_skipped_without_external_ref` · `test_reconcile.py::test_reconcile_unknown_hard_blocks` · `test_outage_redis_postgres.py::test_mid_reconcile_storage_outage_fail_closed` |
-| Boundary classification + monotonic, durable `maybe_crossed` | README § [Marking the side-effect boundary](../README.md#marking-the-side-effect-boundary-side_effect) | `test_side_effect_boundary.py::test_advance_boundary_is_monotonic` · `test_side_effect_boundary.py::test_side_effect_marks_maybe_crossed_midflight` · `test_side_effect_boundary.py::test_exception_inside_side_effect_marks_unknown_and_hard_blocks` · `test_side_effect_boundary.py::test_exception_before_marker_is_failed_before_effect` · `test_side_effect_boundary.py::test_mark_crossed_then_exception_is_failed_after_effect` · `test_side_effect_boundary.py::test_async_side_effect_marks_unknown_on_error` |
+| Boundary classification + monotonic, durable `maybe_crossed` | README § [Marking the side-effect boundary](../README.md#marking-the-side-effect-boundary-side_effect) | `test_side_effect_boundary.py::test_advance_boundary_is_monotonic` · `test_side_effect_boundary.py::test_side_effect_marks_maybe_crossed_midflight` · `test_side_effect_boundary.py::test_exception_inside_side_effect_marks_unknown_and_hard_blocks` · `test_side_effect_boundary.py::test_exception_before_marker_is_failed_before_effect` · `test_side_effect_boundary.py::test_mark_crossed_then_exception_is_failed_after_effect` · `test_side_effect_boundary.py::test_async_side_effect_marks_unknown_on_error` · `test_storage_backends.py::test_sqlite_maybe_crossed_survives_restart_and_does_not_reexecute` |
 | Demo Gmail adapter matrix (0/1/2+/missing ref + Message-ID canonicalize) | README § [Demo adapter: Gmail sent-log](../README.md#demo-adapter-gmail-sent-log-gmailreconciler) | `test_gmail_reconciler.py::test_zero_matches_returns_unknown` · `test_gmail_reconciler.py::test_one_match_returns_completed_with_canonical_receipt` · `test_gmail_reconciler.py::test_two_matches_returns_unknown` · `test_gmail_reconciler.py::test_missing_external_operation_ref_returns_unknown` · `test_gmail_reconciler.py::test_empty_external_operation_ref_returns_unknown` · `test_gmail_reconciler.py::test_message_id_forms_share_query_and_receipt` |
 | Operator release one-shot + fail-closed | README § [Operator runbook](../README.md#operator-runbook-your-agent-hard-blocked) | `test_operator_release.py::test_release_is_one_shot` · `test_operator_release.py::test_release_not_executed_grants_exactly_one_reexecution` · `test_operator_release.py::test_release_completed_returns_result_without_reexecution` · `test_operator_release.py::test_release_refused_while_lease_held_allowed_once_expired` · `test_operator_release.py::test_release_refused_on_completed_and_unknown_request` · `test_operator_release.py::test_keyed_mutate_still_enforces_provider_key_after_release` |
 | Release stamps the record (never deleted) | README § [Operator runbook](../README.md#operator-runbook-your-agent-hard-blocked) | `test_operator_release.py::test_release_not_executed_grants_exactly_one_reexecution` (asserts `operator_resolution`/`resolved_by`) · `test_operator_release.py::test_postgres_release_not_executed_round_trip` |
@@ -304,8 +308,9 @@ otherwise.
 Still can go wrong — even with everything above configured correctly:
 
 - **`storage: memory` across processes.** The guard holds within one process
-  only. Mycelium warns at config time; don't ship memory storage for
-  multi-worker side-effecting tools.
+  only. Mycelium warns at config time (`memory_storage_policy: warn`, the
+  default); set `error` so production cannot load that combination. Don't
+  ship memory storage for multi-worker side-effecting tools.
 - **A reconciler that lies.** If your reconciler returns `NOT_EXECUTED` for an
   effect that actually happened, the runtime re-executes once. Reconcilers are
   read-only *by contract*; verify them with the same care as the tools

--- a/sdk/examples/langgraph_redis_crash/mycelium.example.yaml
+++ b/sdk/examples/langgraph_redis_crash/mycelium.example.yaml
@@ -1,4 +1,6 @@
 # Copy-paste starter: LangGraph tool + Redis ledger + signed receipts.
+# Intentionally Redis (not the sqlite init default): this demo coordinates
+# multi-worker crash/redispatch. Single-node apps should use storage: sqlite.
 #
 # Prereqs:
 #   docker run -d --name mycelium-redis -p 6379:6379 redis:7

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -96,6 +96,9 @@ from mycelium.completion_contract import (
     wrap_final_message,
 )
 from mycelium.config import (
+    MEMORY_STORAGE_POLICIES,
+    MEMORY_STORAGE_POLICY_ERROR,
+    MEMORY_STORAGE_POLICY_WARN,
     ConfigError,
     MyceliumConfig,
     TransitionConfig,
@@ -250,6 +253,9 @@ __all__ = [
     "OPERATOR_RESOLUTION_NOT_EXECUTED",
     "UNCLASSIFIED_POLICY_WARN",
     "UNCLASSIFIED_POLICY_STRICT",
+    "MEMORY_STORAGE_POLICY_WARN",
+    "MEMORY_STORAGE_POLICY_ERROR",
+    "MEMORY_STORAGE_POLICIES",
     "GmailReconciler",
     "canonicalize_message_id",
     "get_ledger",

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -133,6 +133,24 @@ class ConfigError(Exception):
     """Raised when a Mycelium config file is invalid or inconsistent."""
 
 
+MEMORY_STORAGE_POLICY_WARN = "warn"
+MEMORY_STORAGE_POLICY_ERROR = "error"
+MEMORY_STORAGE_POLICIES = frozenset(
+    {MEMORY_STORAGE_POLICY_WARN, MEMORY_STORAGE_POLICY_ERROR}
+)
+
+# Ledgered tools in these classes must not silently use process-local memory
+# storage in production: a restart drops the ledger and dedupe can re-execute.
+_SIDE_EFFECTING_MEMORY_CLASSES = frozenset(
+    {
+        SideEffectClass.IDEMPOTENT_MUTATE,
+        SideEffectClass.KEYED_MUTATE,
+        SideEffectClass.NON_IDEMPOTENT_MUTATE,
+        SideEffectClass.IRREVERSIBLE,
+    }
+)
+
+
 _CALLABLE_PATH_RE = re.compile(
     r"^(?:[A-Za-z_][A-Za-z0-9_]*\.)*[A-Za-z_][A-Za-z0-9_]*:"
     r"[A-Za-z_][A-Za-z0-9_]*$"
@@ -1425,7 +1443,7 @@ def _storage_settings(cfg: dict[str, Any] | None) -> dict[str, Any]:
     return {
         key: value
         for key, value in cfg.items()
-        if key not in ("tools", "tasks", "auto")
+        if key not in ("tools", "tasks", "auto", "memory_storage_policy")
     }
 
 
@@ -1912,34 +1930,73 @@ def _validate_transition_tools(
             )
 
 
-def _warn_memory_storage_for_side_effecting(
-    tools: dict[str, ToolConfig],
-    transition: TransitionConfig | None,
-) -> None:
-    """Warn once per tool when transition config + memory storage + side effects.
+def _memory_storage_policy(action_ledger: dict[str, Any] | None) -> str:
+    """Return the configured memory-storage policy, defaulting to ``warn``."""
+    if action_ledger is None:
+        return MEMORY_STORAGE_POLICY_WARN
+    raw = action_ledger.get("memory_storage_policy", MEMORY_STORAGE_POLICY_WARN)
+    if raw not in MEMORY_STORAGE_POLICIES:
+        raise ConfigError(
+            "'action_ledger.memory_storage_policy' must be "
+            f"{MEMORY_STORAGE_POLICY_WARN!r} or {MEMORY_STORAGE_POLICY_ERROR!r}, "
+            f"got {raw!r}"
+        )
+    return str(raw)
 
-    Memory is fine for dev/demo, but the duplicate-side-effect guard only holds
-    within the process. Emit a one-time warning at YAML load time so the
-    operator knows to switch to file/sqlite/redis/postgres for production.
-    """
-    if transition is None:
-        return
-    warned: set[str] = set()
+
+def _side_effecting_memory_tools(
+    tools: dict[str, ToolConfig],
+) -> list[tuple[str, SideEffectClass]]:
+    """Ledgered mutating tools whose storage is process-local memory."""
+    affected: list[tuple[str, SideEffectClass]] = []
     for name, tool in tools.items():
-        if name in warned:
+        if tool.ledger is None or tool.side_effect_class is None:
             continue
-        if tool.ledger is None:
-            continue
-        if tool.side_effect_class is None:
-            continue
-        if tool.side_effect_class == SideEffectClass.READ:
+        if tool.side_effect_class not in _SIDE_EFFECTING_MEMORY_CLASSES:
             continue
         storage_type = tool.ledger.get("storage", "memory")
         if storage_type != "memory":
             continue
-        warned.add(name)
+        affected.append((name, tool.side_effect_class))
+    return affected
+
+
+def _enforce_memory_storage_policy(
+    tools: dict[str, ToolConfig],
+    transition: TransitionConfig | None,
+    action_ledger: dict[str, Any] | None,
+) -> None:
+    """Apply ``action_ledger.memory_storage_policy`` at YAML load time.
+
+    ``storage: memory`` stays available for tests and local development.
+    ``warn`` (default) emits a one-time warning per side-effecting tool when
+    ``transition:`` is configured — the duplicate-side-effect guard only holds
+    within the process. ``error`` rejects those tools with :class:`ConfigError`
+    so production cannot silently lose ledger state across a restart. Reads
+    may keep using memory storage under either policy.
+    """
+    policy = _memory_storage_policy(action_ledger)
+    affected = _side_effecting_memory_tools(tools)
+    if not affected:
+        return
+
+    if policy == MEMORY_STORAGE_POLICY_ERROR:
+        names = ", ".join(repr(name) for name, _ in affected)
+        classes = ", ".join(sorted({cls.value for _, cls in affected}))
+        verb = "is" if len(affected) == 1 else "are"
+        noun = "tool" if len(affected) == 1 else "tools"
+        raise ConfigError(
+            f"{noun} {names} {verb} side-effecting ({classes}) but the "
+            "action ledger uses memory storage; memory_storage_policy is "
+            "'error'. Use file/sqlite/redis/postgres so ledger state "
+            "survives a process restart."
+        )
+
+    if transition is None:
+        return
+    for name, side_effect_class in affected:
         warnings.warn(
-            f"tool {name!r} is side-effecting ({tool.side_effect_class.value}) "
+            f"tool {name!r} is side-effecting ({side_effect_class.value}) "
             "but its ledger uses memory storage; the duplicate-side-effect "
             "guard only holds within this process. Use file/sqlite/redis/postgres "
             "for production deployments.",
@@ -2051,7 +2108,7 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
         _apply_action_ledger_tools(tools, action_ledger_raw, audit_auto=audit_auto)
 
     _validate_transition_tools(tools, transition)
-    _warn_memory_storage_for_side_effecting(tools, transition)
+    _enforce_memory_storage_policy(tools, transition, action_ledger_raw)
 
     tasks_raw = data.get("tasks", {})
     if not isinstance(tasks_raw, dict):
@@ -2278,6 +2335,9 @@ def load_config(path: str | Path) -> MyceliumConfig:
 
 __all__ = [
     "ConfigError",
+    "MEMORY_STORAGE_POLICIES",
+    "MEMORY_STORAGE_POLICY_ERROR",
+    "MEMORY_STORAGE_POLICY_WARN",
     "MyceliumConfig",
     "ToolConfig",
     "TransitionConfig",

--- a/sdk/mycelium/templates/mycelium.minimal.yaml
+++ b/sdk/mycelium/templates/mycelium.minimal.yaml
@@ -10,10 +10,12 @@
 transition:
   agent_id: "<TODO: fill with your agent id — used in transition keys and receipts>"
   policy_version: "<TODO: fill with your policy version string, e.g. 2026.07.1>"
+  reclaim_requires_death_signal: true
 
 action_ledger:
-  storage: file
-  path: ./mycelium-ledger.json
+  storage: sqlite
+  path: ./mycelium-ledger.db
+  unclassified_policy: strict
   tools:
     - delete_file
 

--- a/sdk/mycelium/templates/mycelium.quickstart.yaml
+++ b/sdk/mycelium/templates/mycelium.quickstart.yaml
@@ -19,10 +19,12 @@ integrations:
 transition:
   agent_id: "<TODO: fill with your agent id — used in transition keys and receipts>"
   policy_version: "<TODO: fill with your policy version string, e.g. 2026.07.1>"
+  reclaim_requires_death_signal: true
 
 action_ledger:
-  storage: file
-  path: ./mycelium-ledger.json
+  storage: sqlite
+  path: ./mycelium-ledger.db
+  unclassified_policy: strict
   tools:
     - subagent_task
 

--- a/sdk/mycelium/templates/mycelium.template.yaml
+++ b/sdk/mycelium/templates/mycelium.template.yaml
@@ -19,10 +19,13 @@
 #      Or keep explicit @config.apply / @config.apply_task / config.instrument.
 #
 # storage (ledgers): memory | file | sqlite | redis | postgres
-#   memory — process-local  |  file — needs path:
-#   sqlite — path: (+ optional table); zero-ops single-node durable
-#   redis  — url: or url_env: (+ optional prefix, in_flight_ttl)
-#   postgres — dsn: or dsn_env: (+ optional table)
+#   memory — tests / single-process disposable state (not production)
+#   file   — local development / single host (needs path:)
+#   sqlite — durable single-node default (path: + optional table)
+#   redis  — multi-worker coordination (url: or url_env:)
+#   postgres — durable multi-worker / audit-oriented (dsn: or dsn_env:)
+# Side-effecting tools + storage: memory: set memory_storage_policy: error
+#   to reject at load time (default warn keeps tests/dev working).
 # state_flush / audit_receipt: memory | file only
 #
 # side_effect_class (per ledgered tool): read | idempotent_mutate |
@@ -87,20 +90,18 @@ transition:
 # action_ledger  (tool-level claim/settle)
 # ---------------------------------------------------------------------------
 action_ledger:
-  storage: file            # <TODO: memory | file | sqlite | redis | postgres>
-  path: ./mycelium-ledger.json
-  # unclassified_policy: warn   # warn (default): one-time warning on failed retry
+  storage: sqlite          # <TODO: memory | file | sqlite | redis | postgres>
+  path: ./mycelium-ledger.db
+  unclassified_policy: strict   # warn (default): one-time warning on failed retry
                                 # strict: hard-block unclassified failed retries
+  # memory_storage_policy: warn # warn (default) | error — reject memory + mutate
   on_args_drift: soft           # soft (default) | hard | off — same dispatch
                                 # ticket + different args → ToolBoundaryError /
                                 # LedgerHardBlockError (identity-conflict gate);
                                 # off = escape hatch for "new args = new transition"
-  # sqlite (zero-ops single-node durable):
-  # storage: sqlite
-  # path: ./mycelium-ledger.db
   # table: mycelium_action_ledger
-  # url_env: MYCELIUM_REDIS_URL          # redis
-  # dsn_env: MYCELIUM_POSTGRES_DSN       # postgres
+  # url_env: MYCELIUM_REDIS_URL          # redis (multi-worker)
+  # dsn_env: MYCELIUM_POSTGRES_DSN       # postgres (multi-worker / audit)
   # <TODO step 1: copy ledgered tool names from tools: keys below>
   tools: []
 

--- a/sdk/tests/test_cli.py
+++ b/sdk/tests/test_cli.py
@@ -19,6 +19,10 @@ def test_init_writes_quickstart_template_by_default(tmp_path: Path) -> None:
     assert "langgraph:" in text
     assert "enabled: true" in text
     assert "action_ledger:" in text
+    assert "storage: sqlite" in text
+    assert "mycelium-ledger.db" in text
+    assert "unclassified_policy: strict" in text
+    assert "reclaim_requires_death_signal: true" in text
     assert "subagent_task" in text
     assert "side_effect_class: non_idempotent_mutate" in text
     assert "send_payment" not in text

--- a/sdk/tests/test_fail_closed_storage.py
+++ b/sdk/tests/test_fail_closed_storage.py
@@ -440,12 +440,132 @@ transition:
   scope_from: {}
 action_ledger:
   storage: memory
+  memory_storage_policy: warn
   tools: [my_tool]
 tools:
   my_tool:
     side_effect_class: non_idempotent_mutate
 """
-        with pytest.warns(UserWarning, match="my_tool.*non_idempotent_mutate"):
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", UserWarning)
+            load_config_from_string(yaml_text)
+        matching = [
+            w for w in caught
+            if issubclass(w.category, UserWarning)
+            and "my_tool" in str(w.message)
+            and "non_idempotent_mutate" in str(w.message)
+        ]
+        assert len(matching) == 1
+
+    def test_omitted_policy_defaults_to_warn(self) -> None:
+        yaml_text = """\
+transition:
+  agent_id: demo
+  policy_version: "1"
+  scope_from: {}
+action_ledger:
+  storage: memory
+  tools: [my_tool]
+tools:
+  my_tool:
+    side_effect_class: non_idempotent_mutate
+"""
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", UserWarning)
+            config = load_config_from_string(yaml_text)
+        assert config.action_ledger is not None
+        assert "memory_storage_policy" not in config.action_ledger
+        matching = [
+            w for w in caught
+            if issubclass(w.category, UserWarning) and "memory storage" in str(w.message)
+        ]
+        assert len(matching) == 1
+
+    def test_error_policy_raises_for_side_effecting_memory(self) -> None:
+        from mycelium import ConfigError
+
+        yaml_text = """\
+transition:
+  agent_id: demo
+  policy_version: "1"
+  scope_from: {}
+action_ledger:
+  storage: memory
+  memory_storage_policy: error
+  tools: [charge]
+tools:
+  charge:
+    side_effect_class: non_idempotent_mutate
+"""
+        with pytest.raises(ConfigError, match="charge.*file/sqlite/redis/postgres") as exc_info:
+            load_config_from_string(yaml_text)
+        assert "memory_storage_policy" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "side_effect_class",
+        [
+            "idempotent_mutate",
+            "keyed_mutate",
+            "non_idempotent_mutate",
+            "irreversible",
+        ],
+    )
+    def test_error_policy_covers_all_mutating_classes(self, side_effect_class: str) -> None:
+        from mycelium import ConfigError
+
+        yaml_text = f"""\
+transition:
+  agent_id: demo
+  policy_version: "1"
+  scope_from: {{}}
+action_ledger:
+  storage: memory
+  memory_storage_policy: error
+  tools: [my_tool]
+tools:
+  my_tool:
+    side_effect_class: {side_effect_class}
+"""
+        with pytest.raises(ConfigError, match="my_tool"):
+            load_config_from_string(yaml_text)
+
+    def test_error_policy_allows_read_tools(self) -> None:
+        yaml_text = """\
+transition:
+  agent_id: demo
+  policy_version: "1"
+  scope_from: {}
+action_ledger:
+  storage: memory
+  memory_storage_policy: error
+  tools: [my_tool]
+tools:
+  my_tool:
+    side_effect_class: read
+"""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            load_config_from_string(yaml_text)
+
+    def test_invalid_memory_storage_policy_raises(self) -> None:
+        from mycelium import ConfigError
+
+        yaml_text = """\
+action_ledger:
+  storage: memory
+  memory_storage_policy: allow
+  tools: [my_tool]
+tools:
+  my_tool:
+    side_effect_class: read
+"""
+        with pytest.raises(ConfigError, match="memory_storage_policy.*warn.*error.*allow"):
             load_config_from_string(yaml_text)
 
     def test_no_warning_for_read_tools(self) -> None:

--- a/sdk/tests/test_storage_backends.py
+++ b/sdk/tests/test_storage_backends.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 import time
 import uuid
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -16,11 +17,18 @@ from mycelium import (
     LedgerHardBlockError,
     LedgerPendingError,
     RedisLedgerStorage,
+    SideEffectBoundary,
     SideEffectClass,
     SqliteLedgerStorage,
     TerminalOutcome,
     ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+    ledger_sync,
+    load_config_from_string,
+    side_effect,
 )
+from mycelium.action_ledger import get_active_transition
 
 
 def _entry(request_id: str, *, status: str = "in-flight") -> LedgerEntry:
@@ -460,3 +468,141 @@ def test_config_sqlite_requires_path() -> None:
 
     with pytest.raises(ConfigError, match="requires a 'path'"):
         MyceliumConfig._build_ledger_storage({"storage": "sqlite"})
+
+
+def test_sqlite_yaml_loads_without_optional_dependencies(tmp_path: Path) -> None:
+    """SQLite is stdlib — YAML load + storage build must not import redis/psycopg."""
+    from mycelium.config import MyceliumConfig
+
+    yaml_text = f"""\
+transition:
+  agent_id: demo
+  policy_version: "1"
+  scope_from: {{}}
+  reclaim_requires_death_signal: true
+action_ledger:
+  storage: sqlite
+  path: {tmp_path / "mycelium-ledger.db"}
+  unclassified_policy: strict
+  tools: [charge]
+tools:
+  charge:
+    side_effect_class: non_idempotent_mutate
+"""
+    config = load_config_from_string(yaml_text)
+    assert config.action_ledger is not None
+    assert config.action_ledger["storage"] == "sqlite"
+    ledger_cfg = config.tools["charge"].ledger
+    assert ledger_cfg is not None
+    storage = MyceliumConfig._build_ledger_storage(ledger_cfg)
+    assert isinstance(storage, SqliteLedgerStorage)
+
+
+class _ProcessCrash(BaseException):
+    """Simulates process death before the ledger can record failure."""
+
+
+def test_sqlite_completed_result_survives_new_ledger_instance(tmp_path: Path) -> None:
+    """A new ActionLedger on the same SQLite file returns the stored result."""
+    db = tmp_path / "ledger.db"
+    executions: list[str] = []
+
+    storage1 = SqliteLedgerStorage(db)
+
+    @ledger_sync(storage=storage1, transition_binding=_payment_binding())
+    def charge(amount: float) -> dict[str, bool]:
+        executions.append("first")
+        return {"charged": True}
+
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+        first = charge(amount=10.0, tool_call_id="c1")
+
+    storage2 = SqliteLedgerStorage(db)
+
+    @ledger_sync(storage=storage2, transition_binding=_payment_binding())
+    def charge(amount: float) -> dict[str, bool]:  # noqa: F811
+        executions.append("second")
+        return {"charged": True}
+
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+        replay = charge(amount=10.0, tool_call_id="c1")
+
+    assert first == replay == {"charged": True}
+    assert executions == ["first"]
+
+
+def test_sqlite_maybe_crossed_survives_restart_and_does_not_reexecute(
+    tmp_path: Path,
+) -> None:
+    """Crash inside side_effect() must persist maybe_crossed and block redispatch.
+
+    A new ledger instance on the same SQLite file must not run the body again.
+    Proves persistence *and* non-reexecution, not merely that SQLite wrote a row.
+    """
+    db = tmp_path / "ledger.db"
+    executions: list[str] = []
+    request_ids: list[str] = []
+    lease_ttl = 0.05
+
+    storage1 = SqliteLedgerStorage(db)
+
+    @ledger_sync(
+        storage=storage1,
+        transition_binding=_payment_binding(),
+        lease_ttl=lease_ttl,
+        lease_renew_interval=0,
+        poll_interval=0.01,
+        poll_timeout=0.2,
+        reclaim_requires_death_signal=True,
+    )
+    def charge(amount: float) -> dict[str, bool]:
+        executions.append("first")
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        with side_effect():
+            raise _ProcessCrash("killed inside side_effect()")
+
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+        with pytest.raises(_ProcessCrash):
+            charge(amount=10.0, tool_call_id="c1")
+
+    assert request_ids, "first instance never claimed a transition"
+    crashed = storage1.get(request_ids[0])
+    assert crashed is not None, "crash window entry was not written to SQLite"
+    assert crashed.side_effect_boundary == SideEffectBoundary.MAYBE_CROSSED.value
+    assert crashed.terminal_outcome == TerminalOutcome.IN_FLIGHT.value
+
+    # Process is gone: lease is no longer renewed. Persist expiry on the
+    # same row so the next instance sees EXPIRED + maybe_crossed.
+    storage1.set(replace(crashed, lease_until=time.time() - 1))
+
+    storage2 = SqliteLedgerStorage(db)
+    restarted = storage2.get(crashed.request_id)
+    assert restarted is not None
+    assert restarted.side_effect_boundary == SideEffectBoundary.MAYBE_CROSSED.value
+    assert restarted.request_id == crashed.request_id
+    assert restarted.resolved_terminal_outcome() == TerminalOutcome.EXPIRED
+
+    @ledger_sync(
+        storage=storage2,
+        transition_binding=_payment_binding(),
+        lease_ttl=lease_ttl,
+        lease_renew_interval=0,
+        poll_interval=0.01,
+        poll_timeout=0.2,
+        reclaim_requires_death_signal=True,
+    )
+    def charge(amount: float) -> dict[str, bool]:  # noqa: F811
+        executions.append("second")
+        with side_effect():
+            return {"charged": True}
+
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+        with pytest.raises(LedgerHardBlockError):
+            charge(amount=10.0, tool_call_id="c1")
+
+    assert executions == ["first"]
+    blocked = storage2.get(crashed.request_id)
+    assert blocked is not None
+    assert blocked.side_effect_boundary == SideEffectBoundary.MAYBE_CROSSED.value


### PR DESCRIPTION
## Intent

Implement production-safe crash persistence for Mycelium’s action ledger.

Repository constraints:
- Work inside sdk/.
- Python 3.10+, Pydantic v2, PyYAML only for core dependencies.
- Preserve the flat public API: export new public symbols from mycelium/__init__.py.
- Do not add top-level docs/ or sandbox/.
- Do not change sdk/pyproject.toml version or cut a release.
- Add changelog notes only under ## Unreleased.
- Preserve unrelated working-tree changes.
- After code changes, run graphify update.

Goal:
A side-effecting tool must not silently use an in-memory ledger in production, because ledger state disappears after a process restart and deduplication can no longer identify an already-executed operation.

1. Add an explicit production safety policy for memory storage.
- Keep storage: memory available for tests and local development.
- Add configuration allowing memory storage to be rejected for side-effecting tools, not merely warned about.
- Prefer action_ledger.memory_storage_policy: error, with warn for backward compatibility.
- Choose backward-compatible defaults unless the existing configuration/versioning contract clearly permits a stricter default.
- Reads may continue using memory storage.
- Side-effecting classes include idempotent_mutate, keyed_mutate, non_idempotent_mutate, and irreversible.
- Raise ConfigError during configuration loading when policy is error.
- The error must name the affected tool and recommend file/sqlite/redis/postgres.

2. Make the safe configuration path obvious.
- Update shipped YAML templates so their action ledger uses SQLite where appropriate, with unclassified_policy: strict and reclaim_requires_death_signal: true.
- Do not convert configurations that are intentionally test/demo-only without documenting the reason.
- Update SDK documentation to distinguish memory/file/sqlite/redis/postgres use cases.

3. Preserve fail-closed crash behavior.
- Verify that a durable maybe_crossed side-effect boundary survives restart.
- On redispatch after a crash inside side_effect(), a mutating tool must hard-block or enter reconciliation; it must not execute again blindly.
- Do not weaken lease, owner-fencing, CAS, tombstone, or worker-death gates.

4. Add focused tests for warn/error/read/sqlite/invalid policy/omitted field compatibility, plus a restart/crash-window test that proves both persistence and non-reexecution.

5. Documentation guidance: durable storage solves loss of ledger state but cannot alone determine whether an external provider completed during the crash window. Recommend the full production pattern (durable Redis/Postgres ledger, stable identity, provider idempotency key, record_external_operation before the provider call, side_effect around the external call, read-only Reconciler, unclassified_policy: strict, reclaim_requires_death_signal: true). Unresolved ambiguity must remain fail-closed.

Default remains warn for compatibility. Do not bump the package version.

## What Changed

- Add a backward-compatible `action_ledger.memory_storage_policy` with `warn` and `error` modes, rejecting memory-backed ledgers for side-effecting tools while allowing reads.
- Default shipped configurations to SQLite with strict unclassified-tool handling and death-signal-gated reclaim, and document durable backend use cases and fail-closed crash recovery.
- Add coverage for policy validation and compatibility, SQLite configuration, persisted results, and non-reexecution after a durable `maybe_crossed` crash boundary.

## Risk Assessment

🚨 High: The implementation is otherwise well-bounded and preserves fail-closed behavior, but it directly contradicts an authoritative repository-boundary requirement and therefore needs explicit human approval before merge.

## Testing

After unsupported host-runtime baselines, focused Python 3.12 tests passed; manual public-API evidence confirmed policy behavior and showed a persisted SQLite `maybe_crossed` record surviving restart and hard-blocking redispatch without re-executing the tool body. All transient worktree artifacts were removed.

<details>
<summary>Evidence: Public API memory-policy behavior</summary>

```text
{
  "omitted_default": {
    "outcome": "loaded",
    "warning": "tool 'charge' is side-effecting (non_idempotent_mutate) but its ledger uses memory storage; the duplicate-side-effect guard only holds within this process. Use file/sqlite/redis/postgres for production deployments."
  },
  "production_error": {
    "outcome": "rejected",
    "message": "tool 'charge' is side-effecting (non_idempotent_mutate) but the action ledger uses memory storage; memory_storage_policy is 'error'. Use file/sqlite/redis/postgres so ledger state survives a process restart."
  },
  "read_with_error_policy": {
    "outcome": "loaded"
  },
  "invalid_policy": {
    "outcome": "rejected",
    "message": "'action_ledger.memory_storage_policy' must be 'warn' or 'error', got 'allow'"
  }
}
```
</details>
<details>
<summary>Evidence: SQLite restart/crash fail-closed proof</summary>

```text
{
  "durable_db_exists": true,
  "boundary_after_restart": "maybe_crossed",
  "outcome_after_restart": "EXPIRED",
  "redispatch": "HARD_BLOCK",
  "tool_body_runs": [
    "crash-process"
  ],
  "double_execution_prevented": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"543a09d10277d6cce1b036d4ad80a4c32ffdb65f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `CHANGELOG.md:10` - The required repository constraint says “Work inside sdk/,” but this change adds the memory-storage-policy changelog entry to the top-level `CHANGELOG.md`. Confirm an exception for the repository changelog or move the note under `sdk/` before merging.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python -m pytest ...` (baseline unavailable: no `python` executable)</code>
- <code>`python3 -m pytest ...` (baseline collection unavailable: host Python 3.9 is below the supported Python 3.10+ floor)</code>
- `uv run --python 3.12 --extra dev python -m pytest -q tests/test_fail_closed_storage.py::TestMemorySideEffectWarning tests/test_storage_backends.py::test_sqlite_maybe_crossed_survives_restart_and_does_not_reexecute`
- <code>Public `load_config_from_string` exercise covering omitted/warn compatibility, `error`, read-only allowance, and invalid policy</code>
- <code>Public SQLite ledger/decorator restart simulation: crash inside `side_effect()`, reopen storage, redispatch the same tool call, and verify `HARD_BLOCK` with only one body execution</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
