### PR TITLE
Gate release tagging on successful full CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,9 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
   workflow_dispatch:
     inputs:
       setup_branch_protection:
@@ -20,14 +21,39 @@ concurrency:
 
 jobs:
   release:
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.setup_branch_protection != 'true'
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.event.inputs.setup_branch_protection != 'true')
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Resolve and verify release source
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          echo "sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+          SUCCESSFUL_PUSH_RUNS=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${SOURCE_SHA}&status=completed&per_page=100" \
+            --jq '[.workflow_runs[] | select(.event == "push" and .conclusion == "success")] | length')
+          if [ "$SUCCESSFUL_PUSH_RUNS" -lt 1 ]; then
+            echo "::error::No successful push-triggered CI run found for ${SOURCE_SHA}."
+            echo "::error::Refusing to create a release tag for an unverified commit."
+            exit 1
+          fi
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -45,6 +71,38 @@ jobs:
             echo "should_release=false" >> "$GITHUB_OUTPUT"
           else
             echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check package version consistency
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.check.outputs.version }}"
+          LOCK_VERSION=$(python - <<'PY'
+          import tomllib
+
+          with open("sdk/uv.lock", "rb") as handle:
+              packages = tomllib.load(handle)["package"]
+          matches = [
+              package["version"]
+              for package in packages
+              if package.get("name") == "mycelium-runtime"
+              and package.get("source", {}).get("editable") == "."
+          ]
+          if len(matches) != 1:
+              raise SystemExit(
+                  f"expected one editable mycelium-runtime entry in sdk/uv.lock, found {len(matches)}"
+              )
+          print(matches[0])
+          PY
+          )
+          if [ "$LOCK_VERSION" != "$VERSION" ]; then
+            echo "::error::sdk/pyproject.toml is ${VERSION}, but sdk/uv.lock is ${LOCK_VERSION}."
+            exit 1
+          fi
+          if ! grep -qE "^## ${VERSION}( |$)" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no matching '## ${VERSION}' section."
+            exit 1
           fi
 
       - name: Install SDK
@@ -96,7 +154,7 @@ jobs:
           if git ls-remote --tags "$REMOTE" "refs/tags/v${VERSION}" | grep -q .; then
             echo "Tag v${VERSION} already on remote — skipping tag push."
           else
-            git tag -a "v${VERSION}" -m "v${VERSION}" "${{ github.sha }}"
+            git tag -a "v${VERSION}" -m "v${VERSION}" "${{ steps.source.outputs.sha }}"
             git push "$REMOTE" "v${VERSION}"
           fi
 
@@ -104,12 +162,12 @@ jobs:
             echo "GitHub Release v${VERSION} already exists — skipping create."
           elif [ -s /tmp/release-notes.md ]; then
             gh release create "v${VERSION}" \
-              --target "${{ github.sha }}" \
+              --target "${{ steps.source.outputs.sha }}" \
               --title "v${VERSION}" \
               --notes-file /tmp/release-notes.md
           else
             gh release create "v${VERSION}" \
-              --target "${{ github.sha }}" \
+              --target "${{ steps.source.outputs.sha }}" \
               --title "v${VERSION}" \
               --generate-notes
           fi

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.31.0"
+version = "1.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- trigger release evaluation only after the `CI` workflow completes successfully for a push to `main`
- check out and tag the exact SHA that passed CI
- require a successful push-triggered CI run for manual release dispatches as well
- verify `pyproject.toml`, `uv.lock`, and `CHANGELOG.md` version consistency before tagging
- synchronize the stale editable-package version in `sdk/uv.lock`

## Why

The full CI workflow provisions Redis and Postgres and prevents the flagship backend proofs from silently skipping. The previous release workflow ran independently with only `sdk[dev]`, so tag creation relied on branch protection and process discipline rather than a recorded successful CI result for the released SHA.

## Verification

- `actionlint .github/workflows/release.yml`
- YAML parse with PyYAML
- local version consistency check: `pyproject.toml == uv.lock == 1.32.0`
- verified the Actions API query finds the successful push-triggered CI run for the current upstream SHA

Closes #83
