### PR TITLE
Resolve symlinks in allowed path scope validation

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -213,8 +213,15 @@ internally; no Pydantic imports in your code.
 - `@bounded` / `bounded_sync`: validate tool args against your field spec **before** the function runs
 - `output_schema`: validate the return value **after** the function runs; bad results are not propagated
 - `allowed_paths` / `entity_pattern`: user-defined scope gates (paths under
-  allowlisted roots after `..` / `.` normalization, entity ID format)
+  allowlisted roots after canonical path and symlink resolution, entity ID
+  format). Missing descendants are supported. Resolution errors fail closed.
 - On failure, raises `ToolBoundaryError` with `llm_message` for the agent loop; does not retry by itself
+
+`allowed_paths` validates the resolved path immediately before dispatch, but
+it is not a filesystem sandbox. Another process that can replace path
+components after validation can create a time-of-check/time-of-use race. Use
+OS sandboxing or descriptor-relative operations inside the tool when the
+filesystem is writable by an adversary.
 
 ## ToolRegistry
 

--- a/sdk/docs/FAILURE_MODE_CATALOG.md
+++ b/sdk/docs/FAILURE_MODE_CATALOG.md
@@ -100,6 +100,12 @@ LLM.
 **Guards:** `@bounded` / `bounded_sync` (input/output/entity/path) ·
 `ToolRegistry` · `ToolRunner`.
 
+**Filesystem boundary:** `allowed_paths` resolves existing symlinks and fails
+closed on resolution errors before dispatch. It is not a sandbox and cannot
+prevent a concurrent writer from replacing path components after validation.
+Use OS isolation or descriptor-relative file operations for hostile shared
+filesystems.
+
 ---
 
 ## AF-005 Goal misalignment

--- a/sdk/mycelium/tool_boundary.py
+++ b/sdk/mycelium/tool_boundary.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import functools
 import inspect
-import os
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from pathlib import PurePath
+from pathlib import Path
 from typing import Any, ParamSpec, TypeVar
 
 from pydantic import BaseModel, ValidationError
@@ -261,18 +260,27 @@ def _validate_input(tool_name: str, schema: type[BaseModel], raw: dict[str, Any]
 
 
 def _path_is_under_allowed(path: str, allowed_paths: tuple[str, ...]) -> bool:
-    """True if normalized ``path`` equals or is under one of ``allowed_paths``.
+    """True if resolved ``path`` equals or is under an allowed root.
 
-    Collapses ``.`` / ``..`` so string-prefix tricks like
-    ``/workspace/src/../../etc/passwd`` cannot bypass the gate. Lexical only
-    (no symlink resolution) — tool args are strings, not opened paths.
+    ``Path.resolve(strict=False)`` collapses ``.`` / ``..`` and follows every
+    symlink in the existing portion of the path. Missing descendants remain
+    supported. Resolution errors, including symlink loops, fail closed.
+
+    This is pre-dispatch validation. A hostile process that can mutate the
+    filesystem between validation and tool execution can still create a
+    time-of-check/time-of-use race; callers needing that guarantee must use a
+    sandbox or descriptor-relative file operations in the tool itself.
     """
-    candidate = PurePath(os.path.normpath(path))
+    try:
+        candidate = Path(path).resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return False
+
     for prefix in allowed_paths:
-        root = PurePath(os.path.normpath(prefix))
         try:
+            root = Path(prefix).resolve(strict=False)
             candidate.relative_to(root)
-        except ValueError:
+        except (OSError, RuntimeError, ValueError):
             continue
         return True
     return False

--- a/sdk/mycelium/tool_boundary.py
+++ b/sdk/mycelium/tool_boundary.py
@@ -262,9 +262,10 @@ def _validate_input(tool_name: str, schema: type[BaseModel], raw: dict[str, Any]
 def _path_is_under_allowed(path: str, allowed_paths: tuple[str, ...]) -> bool:
     """True if resolved ``path`` equals or is under an allowed root.
 
-    ``Path.resolve(strict=False)`` collapses ``.`` / ``..`` and follows every
-    symlink in the existing portion of the path. Missing descendants remain
-    supported. Resolution errors, including symlink loops, fail closed.
+    Strict resolution detects symlink loops on every supported Python version.
+    A missing component alone falls back to non-strict resolution, preserving
+    missing descendants while still following symlinks in the existing path.
+    Other resolution errors fail closed.
 
     This is pre-dispatch validation. A hostile process that can mutate the
     filesystem between validation and tool execution can still create a
@@ -272,18 +273,27 @@ def _path_is_under_allowed(path: str, allowed_paths: tuple[str, ...]) -> bool:
     sandbox or descriptor-relative file operations in the tool itself.
     """
     try:
-        candidate = Path(path).resolve(strict=False)
+        candidate = _resolve_allow_missing(path)
     except (OSError, RuntimeError, ValueError):
         return False
 
     for prefix in allowed_paths:
         try:
-            root = Path(prefix).resolve(strict=False)
+            root = _resolve_allow_missing(prefix)
             candidate.relative_to(root)
         except (OSError, RuntimeError, ValueError):
             continue
         return True
     return False
+
+
+def _resolve_allow_missing(path: str) -> Path:
+    """Resolve ``path`` while allowing missing components but rejecting loops."""
+    candidate = Path(path)
+    try:
+        return candidate.resolve(strict=True)
+    except FileNotFoundError:
+        return candidate.resolve(strict=False)
 
 
 def _validate_scope(tool_name: str, raw: dict[str, Any], config: BoundedConfig) -> None:

--- a/sdk/tests/test_tool_boundary.py
+++ b/sdk/tests/test_tool_boundary.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from mycelium import ToolBoundaryError, bounded, bounded_sync
@@ -169,6 +171,160 @@ async def test_scope_gate_blocks_sibling_prefix_bypass() -> None:
 
     await delete_file(path="/workspace/ok.txt")
     assert calls == 1
+
+
+async def test_scope_gate_blocks_directory_symlink_escape(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    target = outside / "target.txt"
+    target.write_text("keep")
+    (allowed / "escape").symlink_to(outside, target_is_directory=True)
+    calls = 0
+
+    @bounded(schema=DELETE_FILE_SCHEMA, allowed_paths=[str(allowed)])
+    async def delete_file(path: str) -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        Path(path).unlink()
+        return {"deleted": path}
+
+    with pytest.raises(ToolBoundaryError) as exc:
+        await delete_file(path=str(allowed / "escape" / "target.txt"))
+
+    assert exc.value.violation == "scope_path"
+    assert calls == 0
+    assert target.read_text() == "keep"
+
+
+async def test_scope_gate_blocks_missing_target_through_symlink_escape(
+    tmp_path: Path,
+) -> None:
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    (allowed / "escape").symlink_to(outside, target_is_directory=True)
+    calls = 0
+
+    @bounded(schema=DELETE_FILE_SCHEMA, allowed_paths=[str(allowed)])
+    async def create_file(path: str) -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        Path(path).write_text("created")
+        return {"created": path}
+
+    target = outside / "new.txt"
+    with pytest.raises(ToolBoundaryError) as exc:
+        await create_file(path=str(allowed / "escape" / "new.txt"))
+
+    assert exc.value.violation == "scope_path"
+    assert calls == 0
+    assert not target.exists()
+
+
+def test_scope_gate_blocks_file_symlink_escape(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    target = outside / "target.txt"
+    target.write_text("private")
+    link = allowed / "target.txt"
+    link.symlink_to(target)
+    calls = 0
+
+    @bounded_sync(schema=DELETE_FILE_SCHEMA, allowed_paths=[str(allowed)])
+    def read_file(path: str) -> str:
+        nonlocal calls
+        calls += 1
+        return Path(path).read_text()
+
+    with pytest.raises(ToolBoundaryError) as exc:
+        read_file(path=str(link))
+
+    assert exc.value.violation == "scope_path"
+    assert calls == 0
+
+
+async def test_scope_gate_allows_symlink_resolving_inside_root(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    nested = allowed / "nested"
+    nested.mkdir(parents=True)
+    target = nested / "target.txt"
+    target.write_text("safe")
+    (allowed / "alias").symlink_to(nested, target_is_directory=True)
+
+    @bounded(schema=DELETE_FILE_SCHEMA, allowed_paths=[str(allowed)])
+    async def read_file(path: str) -> str:
+        return Path(path).read_text()
+
+    assert await read_file(path=str(allowed / "alias" / "target.txt")) == "safe"
+
+
+async def test_scope_gate_allows_missing_descendant_inside_root(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    candidate = allowed / "missing" / "new.txt"
+
+    @bounded(schema=DELETE_FILE_SCHEMA, allowed_paths=[str(allowed)])
+    async def prepare_file(path: str) -> dict[str, str]:
+        return {"path": path}
+
+    assert await prepare_file(path=str(candidate)) == {"path": str(candidate)}
+
+
+async def test_scope_gate_allows_relative_root_and_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    allowed = Path("allowed")
+    allowed.mkdir()
+    target = allowed / "target.txt"
+    target.write_text("safe")
+
+    @bounded(schema=DELETE_FILE_SCHEMA, allowed_paths=[str(allowed)])
+    async def read_file(path: str) -> str:
+        return Path(path).read_text()
+
+    assert await read_file(path=str(target)) == "safe"
+
+
+async def test_scope_gate_allows_allowed_root_that_is_a_symlink(tmp_path: Path) -> None:
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    target = storage / "target.txt"
+    target.write_text("safe")
+    allowed = tmp_path / "allowed"
+    allowed.symlink_to(storage, target_is_directory=True)
+
+    @bounded(schema=DELETE_FILE_SCHEMA, allowed_paths=[str(allowed)])
+    async def read_file(path: str) -> str:
+        return Path(path).read_text()
+
+    assert await read_file(path=str(allowed / "target.txt")) == "safe"
+
+
+async def test_scope_gate_fails_closed_on_symlink_loop(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    (allowed / "loop-a").symlink_to(allowed / "loop-b")
+    (allowed / "loop-b").symlink_to(allowed / "loop-a")
+    calls = 0
+
+    @bounded(schema=DELETE_FILE_SCHEMA, allowed_paths=[str(allowed)])
+    async def read_file(path: str) -> str:
+        nonlocal calls
+        calls += 1
+        return Path(path).read_text()
+
+    with pytest.raises(ToolBoundaryError) as exc:
+        await read_file(path=str(allowed / "loop-a" / "target.txt"))
+
+    assert exc.value.violation == "scope_path"
+    assert calls == 0
 
 
 async def test_entity_pattern_scope_gate() -> None:


### PR DESCRIPTION
## Summary

- resolve candidate paths and allowed roots with `Path.resolve(strict=False)` before containment checks
- fail closed when path resolution encounters an error or symlink loop
- preserve valid missing descendants, relative paths, safe internal symlinks, and symlinked allowed roots
- document the remaining time-of-check/time-of-use boundary and sandbox requirement

## Security model

This closes the static symlink traversal demonstrated in #81. It does not claim race-free filesystem confinement. A concurrent writer can still replace path components after validation, so hostile shared filesystems require OS sandboxing or descriptor-relative operations inside the tool.

## Verification

- `uv run --frozen pytest tests/test_tool_boundary.py -q` (`26 passed`)
- `uv run --frozen pytest tests -q` (`1051 passed, 9 skipped`)
- `uv run --frozen ruff check mycelium tests`
- `git diff --check`

Closes #81
