### PR TITLE
Add AF-010 secret-in-args protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 Release policy: **batch; calm over velocity.** Prefer one coherent cut over many
 small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEASE.md).
 
+## Unreleased
+
+### Added
+
+- **Secret-in-args (AF-010):** optional `secret_args:` scans tool arguments
+  before claim, fingerprinting, receipts, execution, logs, and outcomes.
+  Default omitted config keeps existing behavior. `policy: error` raises
+  `SecretInArgsError` before any side effect; `redact` may pass a redacted
+  copy only when that cannot change required tool semantics, otherwise
+  fail-closed; `warn` preserves compatibility in development but sanitizes
+  every persisted or emitted representation. Production consequential tools
+  require `error`. Pass `secret://…` references instead of credentials;
+  applications must `register_secret_resolver` (no default env-var
+  resolver). Fail-closed pre-execution blocking is the primary protection;
+  redaction is defense-in-depth. Mycelium cannot sanitize logs created
+  inside arbitrary application or provider code. `allow_fields` /
+  `allow_tools` weaken protection and should be scoped per tool, not
+  globally trusted. `mycelium doctor` reports scanning, fail-closed
+  production, resolver registration, broad allowlists, and labels host
+  logs / third-party providers `not_verifiable`.
+  `mycelium verify --scenario secret-in-args` searches generated artifacts
+  for synthetic credentials.
+
 ## 1.32.0 (2026-08-13)
 
 MINOR: production verification batch. Read-only readiness diagnosis, synthetic

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The taxonomy **is** the product story. Each ID is a real failure class from prod
 | **AF-006** | Context corruption | Stale or broken tool/history context is caught before the next turn |
 | **AF-007** | Premature termination | Required checklist items must complete before the run can declare success |
 | **AF-008** | Cascading permission | The run tool allowlist freezes; mid-run / handoff widen is refused |
+| **AF-010** | Secret-in-args | Raw credentials are blocked before claim; pass `secret://` references |
 | AF-001 / AF-005 / AF-009 | Hallucination · goal misalignment · injection | Roadmap / judgment tier — not claimed as deterministic SDK guards yet |
 
 Full definitions (shipped vs roadmap): [sdk/docs/FAILURE_MODE_CATALOG.md](sdk/docs/FAILURE_MODE_CATALOG.md).
@@ -57,7 +58,8 @@ Mycelium wraps tool calls after the LLM returns `tool_calls` and returns a verdi
 
 - **AF-003 Infinite loops** — `loop_guard:` · soft → hard → `mycelium loops release`
 - **AF-004 Tool misuse** — `@bounded` / registry · block bad args (incl. `array` / `object`) and out-of-scope tools / paths
-- **Budget / runaway spend (not AF-010)** — `budget:` · ceilings + `@budget_guard` / `instrument_llm` (auto `check("llm")`) · `mycelium budget release`
+- **Budget / runaway spend (unnumbered)** — `budget:` · ceilings + `@budget_guard` / `instrument_llm` (auto `check("llm")`) · `mycelium budget release`
+- **AF-010 Secret-in-args** — `secret_args:` · block raw credentials before claim · pass `secret://` references · `mycelium verify --scenario secret-in-args`
 - **AF-006 Context corruption** — `@protect` / Session · optional message/history validation
 - **AF-007 Premature termination** — `completion:` host checklist · refuse or warn-and-allow
 - **AF-008 Scope escalation** — `scope_guard:` freeze allowlist · re-check every step

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -6,7 +6,7 @@
 **The reliability layer for AI agents** — installable as `mycelium-runtime`
 (current version on [PyPI](https://pypi.org/project/mycelium-runtime/)).
 
-The public story is the [failure-mode catalog](docs/FAILURE_MODE_CATALOG.md) (**AF-001…AF-009**): each ID is a real runtime failure class; each shipped surface is a deterministic guard. The taxonomy is the product promise; envelope fields and gates are how AF-002 is implemented underneath.
+The public story is the [failure-mode catalog](docs/FAILURE_MODE_CATALOG.md) (**AF-001…AF-010**): each ID is a real runtime failure class; each shipped surface is a deterministic guard. The taxonomy is the product promise; envelope fields and gates are how AF-002 is implemented underneath.
 
 **Releases:** batch; calm over velocity — [release policy & pre-release checklist](docs/RELEASE.md).
 
@@ -61,7 +61,8 @@ Mycelium sits between your agent loop and your tools (after the LLM returns `too
 |---|---------------|-------------------|
 | **Core** | **AF-002 Observability black hole** | **Flagship:** any tool, any provider — prove run-or-not, at-most-once. Ledger · lease · gates · `Reconciler` · operator release · receipts (Gmail/Stripe adapters = demos) |
 | **Opt-in** | **AF-003 Infinite action loops** | `loop_guard:` — action-hash streak across *new* `tool_call_id`s; soft then hard; operator `mycelium loops release` |
-| **Opt-in** | **Budget / runaway spend (not AF-010)** | `budget:` — `max_duration` / `max_steps` / `max_tokens` / `max_usd`; tools auto-wrapped; **LLM turns auto-wired** on LangGraph/LangChain; `missing_usage_policy`; operator `mycelium budget release` |
+| **Opt-in** | **Budget / runaway spend (unnumbered)** | `budget:` — `max_duration` / `max_steps` / `max_tokens` / `max_usd`; tools auto-wrapped; **LLM turns auto-wired** on LangGraph/LangChain; `missing_usage_policy`; operator `mycelium budget release` |
+| **Opt-in** | **AF-010 Secret-in-args** | `secret_args:` — block raw credentials before claim; pass `secret://` references; shared sanitizer on evidence. Fail-closed is primary; redaction is defense-in-depth |
 | **Opt-in** | **AF-004 Tool misuse** | `@bounded` input/output/scope checks; optional `ToolRegistry` allowlist — block before the tool runs |
 | **Opt-in** | **AF-006 Context corruption** | TTL cache (`@protect` / `Session`); optional `MessageValidator` / `HistoryGuard` before the next LLM turn |
 | **Opt-in** | **AF-007 Premature termination** | `completion:` — host checklist; unmarked **required** → refuse terminal; unmarked **optional** → warn and allow |
@@ -513,7 +514,7 @@ See [examples/failure_cases/](examples/failure_cases/)
 - Resolve redispatches through **gates** (see [Resolution gates](#resolution-gates)) instead of re-running blindly
 - Persist failed attempts with **terminal outcomes** (`FAILED_BEFORE_EFFECT`, `FAILED_AFTER_EFFECT`, `UNKNOWN`, `EXPIRED`, etc.) for audit and reconciliation
 
-**Failure-mode catalog.** Stable AF-001…AF-009 definitions (shipped vs roadmap)
+**Failure-mode catalog.** Stable AF-001…AF-010 definitions (shipped vs roadmap)
 live in [`docs/FAILURE_MODE_CATALOG.md`](docs/FAILURE_MODE_CATALOG.md).
 
 **Failure & threat model.** What this core can and cannot protect you from is
@@ -1104,9 +1105,10 @@ run. LangGraph's adapter copies an existing framework `run_id` into
 `execution_scope` — do not pass a duplicate when the adapter already provides
 one.
 
-Wrapper order: `@budget_guard` → `@loop_guard` → `@ledger` → `@bounded` → `@protect` → `func`.
+Wrapper order: `@secret_args` → `@state_authority` → `@scope_guard` →
+`@budget_guard` → `@loop_guard` → `@ledger` → `@bounded` → `@protect` → `func`.
 
-### Budget guard (not AF-010)
+### Budget guard (unnumbered)
 
 Loop guard stops *identical* action thrash. Budget stops **total burn** when
 every call is different — including pure LLM chat loops with no tools.
@@ -1183,6 +1185,53 @@ mycelium loops release <run_id> --verified clear|allow-once|abort-run \
 
 Demo: `python examples/loop_guard_db_search.py` (from `sdk/`).
 
+### Secret-in-args (AF-010)
+
+Raw credentials must not reach the tool boundary. Pass **references**, not
+secrets:
+
+```yaml
+secret_args:
+  enabled: true
+  policy: error          # error | redact | warn
+  allow_fields: []       # weaken protection; scope per tool, not globally
+  allow_tools: []
+  entropy_detection: true
+
+tools:
+  charge:
+    side_effect_class: non_idempotent_mutate
+    secret_fields: [api_key]   # may hold secret://… refs
+```
+
+```python
+from mycelium import register_secret_resolver
+
+register_secret_resolver(lambda ref: vault.get(ref))  # host-owned; none is built in
+charge(api_key="secret://stripe/production/api-key")
+```
+
+`policy: error` raises `SecretInArgsError` **before** ledger claim, argument
+fingerprinting, receipts, execution, or telemetry. `redact` may pass a
+redacted copy only when that cannot change required tool semantics;
+otherwise it fail-closes. `warn` keeps compatibility in development and
+still sanitizes every persisted or emitted representation. Production
+consequential tools require `error`. Omitted `secret_args:` keeps existing
+behavior.
+
+Fail-closed pre-execution blocking is the primary protection. Redaction of
+Mycelium-owned evidence (ledgers, receipts, outcomes, Doctor/Verify/CLI
+JSON, structured logs) is defense-in-depth. Mycelium **cannot** sanitize
+logs created inside arbitrary application or provider code after a
+resolved value is handed over. `allow_fields` / `allow_tools` weaken the
+guard — keep them empty or tool-narrow.
+
+`mycelium doctor` reports whether scanning is enabled, whether production
+consequential tools fail closed, whether a resolver is registered, and
+labels host logs / third-party providers `not_verifiable`.
+`mycelium verify --scenario secret-in-args` searches generated artifacts
+for synthetic credentials.
+
 ### Scope guard (AF-008): freeze run tool allowlist
 
 AF-008 is when a narrow grant **widens mid-run** (handoff, dynamic
@@ -1213,8 +1262,8 @@ with execution_scope(TransitionScope(run_id="r1", thread_id="t")):
     fetch_customer(customer_id="c1")  # ok; tools outside the freeze soft-block
 ```
 
-Wrapper order: `@scope_guard` → `@loop_guard` → `@ledger` → `@bounded` →
-`@protect`. CLI: `mycelium scope status|bind`. Demo:
+Wrapper order: `@secret_args` → `@scope_guard` → `@loop_guard` → `@ledger` →
+`@bounded` → `@protect`. CLI: `mycelium scope status|bind`. Demo:
 `python examples/scope_guard_allowlist.py` (from `sdk/`).
 
 ### Completion contract (AF-007): refuse terminal while required subtasks pending
@@ -1329,8 +1378,8 @@ def refund(amount: float, *, tool_call_id: str, state_ref: str) -> dict:
     ...
 ```
 
-Wrapper order: `@state_authority` → `@scope_guard` → `@loop_guard` →
-`@ledger` → `@bounded` → `@protect` → `func`.
+Wrapper order: `@secret_args` → `@state_authority` → `@scope_guard` →
+`@loop_guard` → `@ledger` → `@bounded` → `@protect` → `func`.
 
 `decision_id` / `state_ref` are bookkeeping kwargs (excluded from the args
 fingerprint) and are stored on `LedgerEntry` at claim for audit. Enforcement
@@ -1490,6 +1539,9 @@ policies:
   single-node only. `storage: redis` needs `persistence: required` (AOF
   or equivalently durable Redis; Mycelium cannot verify the server).
   Emission failure is fail-closed.
+- `secret_args.policy: error` when `secret_args:` is enabled and
+  consequential tools exist. Weaker `warn` / `redact` under production
+  is rejected. Omitted `secret_args:` stays backward compatible.
 
 Explicit weaker settings (`warn`, `derived`, memory outcomes) under
 production are rejected (`ConfigError`), not silently weakened. Omit
@@ -1536,6 +1588,13 @@ budget:
   path: ./mycelium-budget.json
   missing_usage_policy: error
 
+secret_args:
+  enabled: true
+  policy: error
+  allow_fields: []
+  allow_tools: []
+  entropy_detection: true
+
 outcome_emit:
   storage: postgres
   url_env: DATABASE_URL
@@ -1563,7 +1622,8 @@ $ mycelium doctor --config mycelium.yaml --strict --json   # CI gate
 
 It checks profile defaults, tool classification, business request identity,
 durable ActionLedger / outcome backends, run-id guard policies, completion and
-budget adapter selection, and optional `deployment.topology`. It never executes
+budget adapter selection, secret-in-args scanning / fail-closed production,
+and optional `deployment.topology`. It never executes
 application tools, never calls an LLM, never writes ledger/outcome rows, and
 never repairs config.
 
@@ -1585,7 +1645,7 @@ $ mycelium verify --config mycelium.yaml --scenario all --strict --json
 ```
 
 Scenarios: `redispatch`, `contention`, `storage-outage`, `worker-crash`,
-`ambiguous-effect`, `reconcile`, or `all` (that order). Verify never executes
+`ambiguous-effect`, `reconcile`, `secret-in-args`, or `all` (that order). Verify never executes
 application tools, never calls an LLM, never contacts a real business provider,
 and never inspects or alters existing production transitions. Test data uses a
 unique `mycelium:verify:<uuid>:` namespace and is deleted unless

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -205,6 +205,14 @@ section; the tests are concrete `file::test_name` entries.
     repeated task id (deduplicated across processes when storage is durable).
     *Where:* [Quickstart: task-level idempotency](../README.md#quickstart-task-level-idempotency).
 
+17. **Secret-in-args (when `secret_args:` is enabled).** Raw credentials,
+    tokens, passwords, and private keys are blocked or sanitized before
+    claim, fingerprinting, receipts, outcomes, CLI dumps, and Doctor/Verify
+    JSON. `policy: error` raises `SecretInArgsError` before any side effect.
+    Pass `secret://…` references; resolve only at the trusted tool call for
+    declared fields. Omitted `secret_args:` keeps pre-AF-010 behavior.
+    *Where:* [Secret-in-args (AF-010)](../README.md#secret-in-args-af-010).
+
 ---
 
 ## D. What we do not protect
@@ -236,7 +244,7 @@ than the code makes.
   across new dispatch ids; it is **not** a general spend/time budget. Without a
   stable `run_id` the detector skips (default `missing_run_id_policy: warn`).
   Set `error` so an enabled guard cannot run unprotected. Optional
-  `budget:` (not AF-010) hard-stops on host-declared duration/steps/tokens/USD
+  `budget:` (unnumbered) hard-stops on host-declared duration/steps/tokens/USD
   ceilings before the next step. Supported LangGraph/LangChain model
   boundaries are wired automatically. Residual risk remains for custom
   providers if the host skips `instrument_llm` / `@budget_llm` (or manual
@@ -282,8 +290,16 @@ than the code makes.
   orchestrator recovery semantics.
 - **The optional guard surface.** `@protect` / `HistoryGuard` /
   `MessageValidator` / `@bounded` / `Session` / `loop_guard` / `completion` /
-  `scope_guard` / `state_authority` are documented elsewhere and are not part
-  of this threat model.
+  `scope_guard` / `state_authority` / `secret_args` are documented elsewhere
+  and are not part of the ledger-core guarantee set unless enabled.
+- **Application and provider logs (AF-010 residual).** Mycelium cannot
+  sanitize logs, traces, or exceptions created inside arbitrary application
+  or third-party provider code after a resolved secret is handed to that
+  call. Redaction of Mycelium-owned evidence is defense-in-depth;
+  fail-closed pre-execution blocking is the primary protection. Doctor
+  labels host logs and third-party providers `not_verifiable`.
+  `allow_fields` / `allow_tools` weaken the guard and must stay
+  tool-narrow.
 
 ---
 
@@ -314,6 +330,7 @@ are cited once. "Where documented" links the README section.
 | Provider idempotency-key enforcement (opt-in) | README § [Enforcing the same provider idempotency key](../README.md#enforcing-the-same-provider-idempotency-key-provider_idempotency_key_param) | `test_provider_idempotency_key.py::test_gate_hard_blocks_different_provider_key` · `test_provider_idempotency_key.py::test_gate_hard_blocks_missing_incoming_key` · `test_provider_idempotency_key.py::test_gate_hard_blocks_missing_stored_key` · `test_provider_idempotency_key.py::test_declared_key_is_excluded_from_transition_key` · `test_provider_key_validity.py::test_same_key_expired_ttl_hard_blocks` · `test_provider_key_validity.py::test_unknown_same_key_valid_ttl_allows` · `test_provider_key_validity.py::test_unknown_same_key_expired_ttl_hard_blocks` · `test_provider_key_validity.py::test_unknown_same_key_prefers_reconciler_over_reexec` |
 | Key derivation soundness | README § [Transition identity and host-owned `request_id`](../README.md#transition-identity-and-host-owned-request_id) | `test_transition.py::test_same_inputs_produce_same_transition_key` · `test_transition.py::test_different_tool_call_id_produces_different_key` · `test_transition.py::test_ledger_deduplicates_by_transition_key` · `test_property_transitions.py::test_transition_key_invariants` (property test) · `test_explicit_request_id.py` |
 | Task-level idempotency | README § [Quickstart: task-level idempotency](../README.md#quickstart-task-level-idempotency) | `test_cli_run.py::test_run_instruments_sync_tool_and_task_across_processes` |
+| Secret-in-args (when enabled) | README § [Secret-in-args (AF-010)](../README.md#secret-in-args-af-010) | `test_secret_protection.py` · `test_verify.py::test_cli_smoke_each_scenario` (`secret-in-args`) |
 | Single-key state machine invariants (executions ≤ 1 + not-executed verdicts; COMPLETED terminal; CAS out of IN_FLIGHT) | this doc, § C / [NOT_EXECUTED reset CAS](../README.md#not_executed-reset-cas-v118) | `test_property_transitions.py::test_transition_key_invariants` (Hypothesis, file + Redis) · `test_payment_provider_mock.py::test_redispatch_storm_never_double_charges` |
 
 <sup>1</sup> `test_postgres_storage_atomic_claim` runs when `psycopg` is
@@ -359,6 +376,11 @@ Still can go wrong — even with everything above configured correctly:
 - **Wall-clock leases.** Leases rely on `time.time()`. Clock skew can renew or
   expire leases early; extreme skew is a deployment concern, not something the
   runtime compensates for.
+- **Secrets after the trusted call (AF-010).** Once a declared
+  `secret://` reference is resolved and passed into application or
+  provider code, Mycelium cannot prevent that code from logging the
+  value. Do not print resolved secrets; keep `secret_args.policy: error`
+  for consequential tools.
 - **Silent duplicates are invisible without opt-in telemetry.** The guard
   prevents unauthorized re-execution, but a violation (lying reconciler,
   caller escaping the key, bug in the runtime) only surfaces as

--- a/sdk/docs/FAILURE_MODE_CATALOG.md
+++ b/sdk/docs/FAILURE_MODE_CATALOG.md
@@ -1,4 +1,4 @@
-# Failure-mode catalog (AF-001…AF-009)
+# Failure-mode catalog (AF-001…AF-010)
 
 **The taxonomy is the product story.** Mycelium is the reliability layer for AI
 agents; these IDs are the public promise. Stable across the SDK README,
@@ -16,6 +16,7 @@ LangGraph, CrewAI, AutoGen, Cline, OpenHands, and related stacks.
 | AF-007 | Premature termination | `completion:` / `complete_run` |
 | AF-008 | Cascading permission | `scope_guard:` / `@scope_guard` |
 | AF-009 | Instruction injection | (MCP gateway revisit; not in SDK) |
+| AF-010 | Secret-in-args | `secret_args:` / `SecretInArgsError` · `secret://` references · shared sanitizer |
 
 ---
 
@@ -191,7 +192,32 @@ mechanically enforceable. Complementary to dedicated prompt-injection products.
 
 ---
 
-## Budget enforcement (not AF-010)
+## AF-010 Secret-in-args
+
+**Class:** Credential / evidence leakage
+
+**One line:** Raw credentials, tokens, passwords, and private keys must not
+reach tool arguments, receipts, ledgers, logs, exceptions, telemetry,
+outcomes, fingerprints, or verification artifacts.
+
+**What users hit:** an LLM or caller pastes an API key into a tool call;
+the value is fingerprinted, claimed, receipted, logged, and left in
+Doctor/Verify dumps.
+
+**Guard:** optional `secret_args:` (`error` | `redact` | `warn`). Fail-closed
+pre-execution blocking is the primary protection. Redaction of persisted
+and emitted representations is defense-in-depth. Pass `secret://…`
+references instead of credentials; resolve only at the trusted
+tool/provider call for fields the tool declared. Applications must
+`register_secret_resolver` — Mycelium does not invent a default
+environment-variable resolver. `allow_fields` / `allow_tools` weaken
+protection and must be scoped narrowly by tool, not globally trusted.
+Mycelium cannot sanitize logs created inside arbitrary application or
+provider code; Doctor labels those paths `not_verifiable`.
+
+---
+
+## Budget enforcement (unnumbered)
 
 **Class:** Run-level reliability / blast-radius
 
@@ -209,7 +235,7 @@ gate; atomic `record_usage` for tokens/USD; `missing_usage_policy`; soft warn
 then `LedgerHardBlockError`
 on the next step (never mid-flight kill). Operator
 `mycelium budget status|release`. Loop guard (AF-003) ≠ spend budget.
-**AF-010 not assigned** until corpus naming is settled. See
+Budget is intentionally **not** given an AF-00N id. See
 `notes/catalog/budget-enforcement.md`.
 
 ---
@@ -223,4 +249,4 @@ on the next step (never mid-flight kill). Operator
   [FAILURE_AND_THREAT_MODEL.md](FAILURE_AND_THREAT_MODEL.md); other AF modules
   are optional guards documented in the SDK README.
 - **Budget enforcement** ships as `budget:` / `@budget_guard` and is
-  intentionally **not** given an AF-00N id yet.
+  intentionally **not** given an AF-00N id. AF-010 is secret-in-args.

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -199,6 +199,17 @@ from mycelium.scope_guard import (
     scope_guard,
     scope_guard_sync,
 )
+from mycelium.secret_protection import (
+    REDACTED_MARKER,
+    SecretInArgsError,
+    declare_secret_fields,
+    is_secret_reference,
+    register_secret_hmac_key,
+    register_secret_resolver,
+    resolve_secret_reference,
+    sanitize_secrets,
+    scan_secrets,
+)
 from mycelium.session import Session
 from mycelium.state_authority import (
     ON_MISMATCH_HARD,
@@ -458,6 +469,15 @@ __all__ = [
     "load_config_from_string",
     "protect",
     "protect_sync",
+    "REDACTED_MARKER",
+    "SecretInArgsError",
+    "declare_secret_fields",
+    "is_secret_reference",
+    "register_secret_hmac_key",
+    "register_secret_resolver",
+    "resolve_secret_reference",
+    "sanitize_secrets",
+    "scan_secrets",
     "Session",
     "StateFlush",
     "StateFlushError",

--- a/sdk/mycelium/__main__.py
+++ b/sdk/mycelium/__main__.py
@@ -324,7 +324,15 @@ def cmd_transitions_list(args: argparse.Namespace) -> int:
         )
     entries.sort(key=lambda entry: entry.started_at)
     if args.json:
-        print(json.dumps([_entry_row(entry, now) for entry in entries], indent=2, default=str))
+        from mycelium.secret_protection import sanitize_for_evidence
+
+        print(
+            json.dumps(
+                sanitize_for_evidence([_entry_row(entry, now) for entry in entries]),
+                indent=2,
+                default=str,
+            )
+        )
         return 0
     if not entries:
         print("no transitions found" + (" (stuck only)" if args.stuck else ""))
@@ -354,8 +362,10 @@ def cmd_transitions_show(args: argparse.Namespace) -> int:
     resolved = entry.resolved_terminal_outcome()
     print(f"request_id: {entry.request_id}")
     print(f"tool: {entry.tool}")
-    print(f"args: {json.dumps(entry.args, default=str)}")
-    print(f"kwargs: {json.dumps(entry.kwargs, default=str)}")
+    from mycelium.secret_protection import sanitize_for_evidence, sanitize_text
+
+    print(f"args: {json.dumps(sanitize_for_evidence(entry.args), default=str)}")
+    print(f"kwargs: {json.dumps(sanitize_for_evidence(entry.kwargs), default=str)}")
     print(f"status: {entry.status}")
     print(f"resolved_outcome: {resolved.value}")
     print(f"parent_request_id: {entry.parent_request_id or '-'}")
@@ -374,8 +384,8 @@ def cmd_transitions_show(args: argparse.Namespace) -> int:
     else:
         print("provider_key_first_attempt_at: -")
     print(f"external_operation_ref: {entry.external_operation_ref or '-'}")
-    print(f"error: {entry.error or '-'}")
-    print(f"result: {json.dumps(entry.result, default=str)}")
+    print(f"error: {sanitize_text(entry.error) if entry.error else '-'}")
+    print(f"result: {json.dumps(sanitize_for_evidence(entry.result), default=str)}")
     print(f"receipt_ref: {entry.receipt_ref or '-'}")
     print(f"operator_resolution: {entry.operator_resolution or '-'}")
     print(f"resolved_by: {entry.resolved_by or '-'}")
@@ -1116,7 +1126,8 @@ def main(argv: list[str] | None = None) -> int:
         metavar="NAME",
         help=(
             "Scenario to run (repeatable): redispatch, contention, "
-            "worker-crash, storage-outage, ambiguous-effect, reconcile, or all"
+            "worker-crash, storage-outage, ambiguous-effect, reconcile, "
+            "secret-in-args, or all"
         ),
     )
     verify_parser.add_argument(

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -1573,11 +1573,12 @@ class ActionLedger:
             parent_raw = active_handoff.parent_request_id
         if handoff_raw is None and active_handoff is not None:
             handoff_raw = active_handoff.handoff_id
+        stored_args, stored_kwargs = _evidence_args(bound["args"], bound["kwargs"])
         return LedgerEntry(
             request_id=request_id,
             tool=tool,
-            args=bound["args"],
-            kwargs=bound["kwargs"],
+            args=stored_args,
+            kwargs=stored_kwargs,
             status=legacy_status_from_terminal(TerminalOutcome.IN_FLIGHT),
             terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
             owner=_ledger_owner(),
@@ -2702,7 +2703,7 @@ class ActionLedger:
             existing,
             status=legacy_status_from_terminal(TerminalOutcome.COMPLETED),
             terminal_outcome=TerminalOutcome.COMPLETED.value,
-            result=result,
+            result=_evidence_value(result),
             finished_at=time.time(),
             lease_until=None,
             side_effect_boundary=SideEffectBoundary.CROSSED.value,
@@ -2752,7 +2753,7 @@ class ActionLedger:
             existing,
             status=legacy_status_from_terminal(terminal),
             terminal_outcome=terminal.value,
-            error=f"{type(error).__name__}: {error}",
+            error=_evidence_error(error),
             finished_at=time.time(),
             lease_until=None,
             side_effect_boundary=boundary,
@@ -3220,6 +3221,12 @@ class ActionLedger:
 
     @staticmethod
     def _hash_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+        from mycelium.secret_protection import fingerprint_args, get_active_secret_policy
+
+        policy = get_active_secret_policy()
+        if policy is not None and policy.enabled:
+            digest = fingerprint_args(args, kwargs)
+            return digest[:16]
         payload = json.dumps(
             {"args": args, "kwargs": kwargs},
             sort_keys=True,
@@ -3283,15 +3290,59 @@ def _args_drift_exclude_keys(
     return frozenset({binding.provider_idempotency_key_param})
 
 
+def _evidence_value(value: Any) -> Any:
+    from mycelium.secret_protection import get_active_secret_policy, sanitize_for_evidence
+
+    policy = get_active_secret_policy()
+    if policy is None or not policy.enabled:
+        return value
+    return sanitize_for_evidence(value)
+
+
+def _evidence_args(args: Any, kwargs: Any) -> tuple[list[Any], dict[str, Any]]:
+    from mycelium.secret_protection import get_active_secret_policy, sanitize_secrets
+
+    policy = get_active_secret_policy()
+    if policy is None or not policy.enabled:
+        return list(args), dict(kwargs)
+    safe = sanitize_secrets(
+        {"args": list(args), "kwargs": dict(kwargs)},
+        entropy_detection=policy.entropy_detection,
+        allow_fields=policy.allow_fields,
+    )
+    return list(safe["args"]), dict(safe["kwargs"])
+
+
+def _evidence_error(error: BaseException) -> str:
+    from mycelium.secret_protection import (
+        get_active_secret_policy,
+        sanitize_exception,
+        sanitize_text,
+    )
+
+    policy = get_active_secret_policy()
+    if policy is None or not policy.enabled:
+        return f"{type(error).__name__}: {error}"
+    safe = sanitize_exception(error)
+    return sanitize_text(f"{type(safe).__name__}: {safe}")
+
+
 def _args_drift_fingerprint(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
     *,
     exclude: frozenset[str],
 ) -> str:
-    if not exclude:
-        return args_fingerprint(args, kwargs)
-    filtered = {key: value for key, value in kwargs.items() if key not in exclude}
+    from mycelium.secret_protection import fingerprint_args, get_active_secret_policy
+
+    filtered = (
+        kwargs
+        if not exclude
+        else {key: value for key, value in kwargs.items() if key not in exclude}
+    )
+    policy = get_active_secret_policy()
+    if policy is not None and policy.enabled:
+        return fingerprint_args(args, filtered)
     return args_fingerprint(args, filtered)
 
 
@@ -3587,9 +3638,29 @@ def _run_ledgered(
         _ActiveTransition(ledger, request_id, transition_binding)
     )
     try:
+        from mycelium.secret_protection import (
+            get_active_secret_policy,
+            resolve_declared_secret_fields,
+        )
+
+        policy = get_active_secret_policy()
+        extra = policy.secret_fields if policy is not None else frozenset()
+        exec_args, exec_kwargs = resolve_declared_secret_fields(
+            func, args, clean_kwargs, extra_fields=extra
+        )
         with _lease_auto_renew(ledger, request_id):
-            result = func(*args, **clean_kwargs)
+            result = func(*exec_args, **exec_kwargs)
     except Exception as exc:
+        from mycelium.secret_protection import (
+            get_active_secret_policy,
+        )
+        from mycelium.secret_protection import (
+            sanitize_exception as _sanitize_exc,
+        )
+
+        policy = get_active_secret_policy()
+        if policy is not None and policy.enabled:
+            exc = _sanitize_exc(exc)
         # A storage failure while recording the failure must not mask the
         # original tool exception — log it, then re-raise the tool's own error.
         # An outcome-already-set error also does not mask — the transition was
@@ -3631,7 +3702,7 @@ def _run_ledgered(
                 "original tool error follows",
                 request_id,
             )
-        raise
+        raise exc
     finally:
         _active_transition_var.reset(token)
 
@@ -3767,9 +3838,29 @@ async def _run_ledgered_async(
         _ActiveTransition(ledger, request_id, transition_binding)
     )
     try:
+        from mycelium.secret_protection import (
+            get_active_secret_policy,
+            resolve_declared_secret_fields,
+        )
+
+        policy = get_active_secret_policy()
+        extra = policy.secret_fields if policy is not None else frozenset()
+        exec_args, exec_kwargs = resolve_declared_secret_fields(
+            func, args, clean_kwargs, extra_fields=extra
+        )
         with _lease_auto_renew(ledger, request_id):
-            result = await func(*args, **clean_kwargs)
+            result = await func(*exec_args, **exec_kwargs)
     except Exception as exc:
+        from mycelium.secret_protection import (
+            get_active_secret_policy,
+        )
+        from mycelium.secret_protection import (
+            sanitize_exception as _sanitize_exc,
+        )
+
+        policy = get_active_secret_policy()
+        if policy is not None and policy.enabled:
+            exc = _sanitize_exc(exc)
         # A storage failure while recording the failure must not mask the
         # original tool exception — log it, then re-raise the tool's own error.
         # An outcome-already-set error also does not mask — the transition was
@@ -3811,7 +3902,7 @@ async def _run_ledgered_async(
                 "original tool error follows",
                 request_id,
             )
-        raise
+        raise exc
     finally:
         _active_transition_var.reset(token)
 

--- a/sdk/mycelium/audit_receipt.py
+++ b/sdk/mycelium/audit_receipt.py
@@ -241,6 +241,13 @@ class AuditReceiptEmitter:
 
         receipt_id = f"rcpt-{uuid.uuid4().hex[:16]}"
         timestamp = time.time()
+        from mycelium.secret_protection import get_active_secret_policy, sanitize_for_evidence
+
+        policy = get_active_secret_policy()
+        if policy is not None and policy.enabled:
+            inputs = sanitize_for_evidence(inputs)
+            outputs = sanitize_for_evidence(outputs)
+            error = sanitize_for_evidence(error) if error is not None else None
         payload = {
             "receipt_id": receipt_id,
             "agent_id": self.agent_id,

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -101,6 +101,11 @@ from mycelium.scope_guard import (
     ScopeGuardStorage,
     apply_scope_guard,
 )
+from mycelium.secret_protection import (
+    SECRET_ARGS_POLICIES,
+    SecretArgsPolicy,
+    apply_secret_args,
+)
 from mycelium.session import Session
 from mycelium.state_authority import (
     ON_MISMATCH_HARD,
@@ -184,6 +189,7 @@ _GUARD_MARKERS = (
     "_mycelium_budget_guarded",
     "_mycelium_scope_guarded",
     "_mycelium_state_authority",
+    "_mycelium_secret_args",
     "_mycelium_langgraph_integration",
 )
 
@@ -300,6 +306,10 @@ class ToolConfig:
     scope_guard: dict[str, Any] | bool | None = None
     # Per-tool state_authority: None=inherit global, False=disable, dict=overrides
     state_authority: dict[str, Any] | bool | None = None
+    # Fields that may hold secret:// references (resolved only at execution).
+    secret_fields: tuple[str, ...] = ()
+    # Per-tool secret_args: None=inherit global, False=disable
+    secret_args: bool | None = None
 
     def is_noop(self) -> bool:
         return (
@@ -311,6 +321,8 @@ class ToolConfig:
             and self.budget_guard is None
             and self.scope_guard is None
             and self.state_authority is None
+            and not self.secret_fields
+            and self.secret_args is None
         )
 
 
@@ -360,6 +372,7 @@ class MyceliumConfig:
     completion: dict[str, Any] | None = None
     deployment: dict[str, Any] | None = None
     verify: dict[str, Any] | None = None
+    secret_args: dict[str, Any] | None = None
     profile: str = PROFILE_DEVELOPMENT
     _audit_emitter: AuditReceiptEmitter | None = None
     _outcome_emitter: OutcomeEmitter | None = None
@@ -381,9 +394,9 @@ class MyceliumConfig:
         function is returned unchanged.
 
         Guard order (outermost first, after optional LangGraph instrument):
-        ``@state_authority`` -> ``@scope_guard`` -> ``@budget_guard`` ->
-        ``@loop_guard`` -> ``@ledger`` -> ``@bounded`` -> ``@protect`` ->
-        ``func``
+        ``@secret_args`` -> ``@state_authority`` -> ``@scope_guard`` ->
+        ``@budget_guard`` -> ``@loop_guard`` -> ``@ledger`` -> ``@bounded`` ->
+        ``@protect`` -> ``func``
         """
         return self.apply_tool(func.__name__, func)
 
@@ -457,6 +470,22 @@ class MyceliumConfig:
                 return False
         return True
 
+    def secret_args_applies(
+        self, name: str, tool_config: ToolConfig | None = None
+    ) -> bool:
+        """Whether secret-in-args scanning should wrap this tool."""
+        if self.secret_args is None:
+            return False
+        policy = secret_args_policy_from_mapping(self.secret_args)
+        if not policy.enabled:
+            return False
+        cfg = tool_config if tool_config is not None else self.tools.get(name)
+        if cfg is not None and cfg.secret_args is False:
+            return False
+        if name in policy.allow_tools:
+            return False
+        return True
+
     def apply_tool(
         self,
         name: str,
@@ -470,18 +499,24 @@ class MyceliumConfig:
         applies_budget = self.budget_guard_applies(name, tool_config)
         applies_scope = self.scope_guard_applies(name, tool_config)
         applies_state = self.state_authority_applies(name, tool_config)
+        applies_secret = self.secret_args_applies(name, tool_config)
+        if tool_config.secret_fields:
+            setattr(func, "_mycelium_secret_fields", tool_config.secret_fields)
         if (
             tool_config.is_noop()
             and not applies_loop
             and not applies_budget
             and not applies_scope
             and not applies_state
+            and not applies_secret
         ):
             return func
         if _check_existing_config_wrapper(func, kind="tool", name=name):
             return func
 
         func = _callable_with_name(func, name)
+        if tool_config.secret_fields:
+            setattr(func, "_mycelium_secret_fields", tool_config.secret_fields)
         is_async = inspect.iscoroutinefunction(func)
 
         # Apply protect first so it sits inside bounded.
@@ -576,12 +611,41 @@ class MyceliumConfig:
                 side_effect_class=tool_config.side_effect_class,
             )
 
+        # Secret-in-args outside every other guard: scan before claim/fingerprint.
+        if applies_secret:
+            from mycelium.transition import CONSEQUENTIAL_SIDE_EFFECT_CLASSES
+
+            policy = secret_args_policy_from_mapping(self.secret_args or {})
+            consequential = (
+                tool_config.side_effect_class in CONSEQUENTIAL_SIDE_EFFECT_CLASSES
+                if tool_config.side_effect_class is not None
+                else False
+            )
+            if (
+                self.profile == PROFILE_PRODUCTION
+                and consequential
+                and policy.policy != "error"
+            ):
+                raise ConfigError(
+                    f"profile is {PROFILE_PRODUCTION!r} but secret_args.policy "
+                    f"is {policy.policy!r}; consequential tool {name!r} requires "
+                    "'error'"
+                )
+            func = apply_secret_args(
+                func,
+                policy,
+                tool_name=name,
+                secret_fields=tool_config.secret_fields,
+                consequential=consequential,
+            )
+
         # LangGraph outermost so it can inject scope/dispatch before inner guards.
         if self.langgraph_enabled and (
             tool_config.ledger is not None
             or applies_loop
             or applies_scope
             or applies_state
+            or applies_secret
         ):
             try:
                 func = instrument_langgraph_tool(func)
@@ -1933,6 +1997,26 @@ def _parse_tool_config(
             f"tool '{name}'.state_authority must be a bool or a mapping"
         )
 
+    secret_fields_raw = raw.get("secret_fields")
+    secret_fields: tuple[str, ...] = ()
+    if secret_fields_raw is not None:
+        if not isinstance(secret_fields_raw, list) or not all(
+            isinstance(item, str) and item.strip() for item in secret_fields_raw
+        ):
+            raise ConfigError(
+                f"tool '{name}'.secret_fields must be a list of non-empty strings"
+            )
+        secret_fields = tuple(item.strip() for item in secret_fields_raw)
+
+    secret_args_raw = raw.get("secret_args")
+    secret_args_cfg: bool | None
+    if secret_args_raw is None:
+        secret_args_cfg = None
+    elif isinstance(secret_args_raw, bool):
+        secret_args_cfg = secret_args_raw
+    else:
+        raise ConfigError(f"tool '{name}'.secret_args must be a bool")
+
     return ToolConfig(
         name=name,
         protect=protect,
@@ -1951,6 +2035,8 @@ def _parse_tool_config(
         budget_guard=budget_guard_cfg,
         scope_guard=scope_guard_cfg,
         state_authority=state_authority_cfg,
+        secret_fields=secret_fields,
+        secret_args=secret_args_cfg,
     )
 
 
@@ -2055,6 +2141,8 @@ def _apply_action_ledger_tools(
             budget_guard=existing.budget_guard,
             scope_guard=existing.scope_guard,
             state_authority=existing.state_authority,
+            secret_fields=existing.secret_fields,
+            secret_args=existing.secret_args,
         )
 
 
@@ -2640,6 +2728,88 @@ def _parse_verify(data: dict[str, Any]) -> dict[str, Any] | None:
     return {"allow_temporary_schema": allow}
 
 
+def secret_args_policy_from_mapping(raw: dict[str, Any]) -> SecretArgsPolicy:
+    """Build a :class:`SecretArgsPolicy` from a validated mapping."""
+    return SecretArgsPolicy(
+        enabled=bool(raw.get("enabled", True)),
+        policy=str(raw.get("policy", "error")),
+        allow_fields=frozenset(str(item) for item in (raw.get("allow_fields") or [])),
+        allow_tools=frozenset(str(item) for item in (raw.get("allow_tools") or [])),
+        entropy_detection=bool(raw.get("entropy_detection", True)),
+    )
+
+
+def _parse_secret_args(
+    data: dict[str, Any],
+    *,
+    profile: str,
+    tools: dict[str, ToolConfig],
+) -> dict[str, Any] | None:
+    """Optional AF-010 secret-in-args section. Omitted keeps existing behavior."""
+    raw = data.get("secret_args")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError("'secret_args' must be a mapping")
+    allowed_keys = {
+        "enabled",
+        "policy",
+        "allow_fields",
+        "allow_tools",
+        "entropy_detection",
+    }
+    unknown = set(raw) - allowed_keys
+    if unknown:
+        names = ", ".join(sorted(str(name) for name in unknown))
+        raise ConfigError(f"unsupported 'secret_args' option(s): {names}")
+
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise ConfigError("'secret_args.enabled' must be a boolean")
+    policy = raw.get("policy", "error")
+    if policy not in SECRET_ARGS_POLICIES:
+        raise ConfigError(
+            "'secret_args.policy' must be one of "
+            f"{sorted(SECRET_ARGS_POLICIES)}, got {policy!r}"
+        )
+    allow_fields = raw.get("allow_fields", [])
+    if not isinstance(allow_fields, list) or not all(
+        isinstance(item, str) and item.strip() for item in allow_fields
+    ):
+        raise ConfigError(
+            "'secret_args.allow_fields' must be a list of non-empty strings; "
+            "scope allowlists narrowly by tool, not as a global trust list"
+        )
+    allow_tools = raw.get("allow_tools", [])
+    if not isinstance(allow_tools, list) or not all(
+        isinstance(item, str) and item.strip() for item in allow_tools
+    ):
+        raise ConfigError("'secret_args.allow_tools' must be a list of tool names")
+    entropy = raw.get("entropy_detection", True)
+    if not isinstance(entropy, bool):
+        raise ConfigError("'secret_args.entropy_detection' must be a boolean")
+
+    parsed = {
+        "enabled": enabled,
+        "policy": str(policy),
+        "allow_fields": [str(item).strip() for item in allow_fields],
+        "allow_tools": [str(item).strip() for item in allow_tools],
+        "entropy_detection": entropy,
+    }
+    if enabled and profile == PROFILE_PRODUCTION and parsed["policy"] != "error":
+        from mycelium.transition import CONSEQUENTIAL_SIDE_EFFECT_CLASSES
+
+        consequential = [
+            name
+            for name, tool in tools.items()
+            if tool.side_effect_class in CONSEQUENTIAL_SIDE_EFFECT_CLASSES
+            and name not in parsed["allow_tools"]
+        ]
+        if consequential:
+            _reject_weaker_production_policy("secret_args.policy", parsed["policy"])
+    return parsed
+
+
 def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
     if not isinstance(data, dict):
         raise ConfigError("config root must be a mapping")
@@ -2877,6 +3047,8 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
         if not isinstance(exclude, list):
             raise ConfigError("'state_authority.exclude' must be a list of tool names")
 
+    secret_args_raw = _parse_secret_args(data, profile=profile, tools=tools)
+
     message_validator_raw = data.get("message_validator", False)
     if isinstance(message_validator_raw, dict):
         message_validator = bool(message_validator_raw.get("enabled", True))
@@ -2912,6 +3084,7 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
         completion=completion_raw,
         deployment=deployment,
         verify=verify,
+        secret_args=secret_args_raw,
         profile=profile,
         _audit_auto=audit_auto,
     )

--- a/sdk/mycelium/doctor/checks.py
+++ b/sdk/mycelium/doctor/checks.py
@@ -1149,6 +1149,210 @@ def check_topology(ctx: DoctorContext) -> Iterable[DoctorCheck]:
     )
 
 
+@doctor_check("secret_args")
+def check_secret_args(ctx: DoctorContext) -> Iterable[DoctorCheck]:
+    """AF-010: report secret-in-args scanning, fail-closed production, allowlists."""
+    from mycelium.budget_llm import registered_llm_budget_adapters
+    from mycelium.completion_contract import registered_terminal_adapters
+    from mycelium.secret_protection import registered_secret_resolver
+
+    cfg = ctx.config
+    raw = cfg.secret_args
+    consequential = _consequential_tools(cfg)
+    declared_fields = [
+        f"{name}:{','.join(tool.secret_fields)}"
+        for name, tool in cfg.tools.items()
+        if tool.secret_fields
+    ]
+
+    if raw is None:
+        yield _check(
+            id="secrets.scanning",
+            category="Secret-in-args",
+            status=DoctorStatus.SKIP,
+            summary="secret_args is not configured (existing behavior)",
+            details=(
+                "Omitted secret_args preserves pre-AF-010 behavior. "
+                f"consequential_tools={consequential or 'none'}."
+            ),
+            remediation=(
+                "Add secret_args: {enabled: true, policy: error} so raw "
+                "credentials are blocked before claim. Pass secret:// "
+                "references instead of credentials."
+            ),
+            evidence=EVIDENCE_STATIC,
+            blocking=False,
+        )
+        if cfg.profile == PROFILE_PRODUCTION and consequential:
+            yield _check(
+                id="secrets.production_fail_closed",
+                category="Secret-in-args",
+                status=DoctorStatus.SKIP,
+                summary="Production consequential tools do not fail closed on secrets",
+                details=(
+                    "profile=production but secret_args is omitted; "
+                    f"tools={consequential}. This is not a promised production default."
+                ),
+                remediation="Enable secret_args.policy: error for consequential tools.",
+                evidence=EVIDENCE_STATIC,
+                blocking=False,
+            )
+    else:
+        enabled = bool(raw.get("enabled", True))
+        policy = str(raw.get("policy", "error"))
+        allow_fields = list(raw.get("allow_fields") or [])
+        allow_tools = list(raw.get("allow_tools") or [])
+        yield _check(
+            id="secrets.scanning",
+            category="Secret-in-args",
+            status=DoctorStatus.PASS if enabled else DoctorStatus.WARN,
+            summary=(
+                "Secret scanning is enabled"
+                if enabled
+                else "Secret scanning is configured but disabled"
+            ),
+            details=(
+                f"enabled={enabled}; policy={policy!r}; "
+                f"allow_fields={allow_fields or 'none'}; "
+                f"allow_tools={allow_tools or 'none'}; "
+                f"entropy_detection={raw.get('entropy_detection', True)}"
+            ),
+            remediation="" if enabled else "Set secret_args.enabled: true.",
+            evidence=EVIDENCE_STATIC,
+            blocking=not enabled,
+        )
+        fail_closed = enabled and policy == "error"
+        if cfg.profile == PROFILE_PRODUCTION and consequential:
+            if fail_closed:
+                yield _check(
+                    id="secrets.production_fail_closed",
+                    category="Secret-in-args",
+                    status=DoctorStatus.PASS,
+                    summary="Production consequential tools fail closed on raw secrets",
+                    details=f"policy=error; tools={consequential}",
+                    evidence=EVIDENCE_STATIC,
+                )
+            else:
+                yield _check(
+                    id="secrets.production_fail_closed",
+                    category="Secret-in-args",
+                    status=DoctorStatus.FAIL,
+                    summary="Production consequential tools do not fail closed",
+                    details=f"policy={policy!r}; tools={consequential}",
+                    remediation="Set secret_args.policy: error under profile: production.",
+                    evidence=EVIDENCE_STATIC,
+                )
+        if allow_fields:
+            yield _check(
+                id="secrets.allow_fields",
+                category="Secret-in-args",
+                status=DoctorStatus.WARN,
+                summary="Global allow_fields weakens secret-in-args protection",
+                details=(
+                    f"allow_fields={allow_fields}. Scope allowlists narrowly "
+                    "by tool (tools.<name>.secret_fields), not as a global trust list."
+                ),
+                remediation="Prefer per-tool secret_fields and empty global allow_fields.",
+                evidence=EVIDENCE_STATIC,
+                blocking=False,
+            )
+        if allow_tools:
+            overlap = [name for name in allow_tools if name in consequential]
+            yield _check(
+                id="secrets.allow_tools",
+                category="Secret-in-args",
+                status=DoctorStatus.WARN,
+                summary="allow_tools skips secret scanning",
+                details=(
+                    f"allow_tools={allow_tools}; consequential_exempt={overlap or 'none'}"
+                ),
+                remediation="Do not exempt consequential tools from secret scanning.",
+                evidence=EVIDENCE_STATIC,
+                blocking=False,
+            )
+
+    resolver = registered_secret_resolver()
+    if declared_fields:
+        if resolver is None:
+            yield _check(
+                id="secrets.resolver",
+                category="Secret-in-args",
+                status=DoctorStatus.WARN,
+                summary="Tools declare secret_fields but no resolver is registered",
+                details=f"declared={declared_fields}",
+                remediation="Call register_secret_resolver before resolving secret:// refs.",
+                evidence=EVIDENCE_RUNTIME,
+                blocking=False,
+            )
+        else:
+            yield _check(
+                id="secrets.resolver",
+                category="Secret-in-args",
+                status=DoctorStatus.PASS,
+                summary="Secret resolver is registered for declared secret_fields",
+                details=f"declared={declared_fields}",
+                evidence=EVIDENCE_RUNTIME,
+            )
+    elif resolver is not None:
+        yield _check(
+            id="secrets.resolver",
+            category="Secret-in-args",
+            status=DoctorStatus.PASS,
+            summary="Secret resolver is registered",
+            evidence=EVIDENCE_RUNTIME,
+        )
+    else:
+        yield _check(
+            id="secrets.resolver",
+            category="Secret-in-args",
+            status=DoctorStatus.SKIP,
+            summary="No secret resolver registered (none required)",
+            details="Applications must register a resolver explicitly; none is built in.",
+            evidence=EVIDENCE_RUNTIME,
+            blocking=False,
+        )
+
+    custom_adapters = sorted(
+        set(registered_terminal_adapters()) | set(registered_llm_budget_adapters())
+    )
+    if custom_adapters:
+        yield _check(
+            id="secrets.custom_adapters",
+            category="Secret-in-args",
+            status=DoctorStatus.WARN,
+            summary="Custom adapters cannot be verified to sanitize evidence",
+            details=f"adapters={custom_adapters}",
+            remediation=(
+                "Host-owned adapters must call sanitize_secrets before emitting "
+                "or logging tool arguments."
+            ),
+            evidence=EVIDENCE_NOT_VERIFIABLE,
+            blocking=False,
+        )
+    else:
+        yield _check(
+            id="secrets.custom_adapters",
+            category="Secret-in-args",
+            status=DoctorStatus.PASS,
+            summary="No custom evidence adapters registered",
+            evidence=EVIDENCE_RUNTIME,
+        )
+
+    yield _check(
+        id="secrets.host_logs",
+        category="Secret-in-args",
+        status=DoctorStatus.SKIP,
+        summary="Host logs and third-party providers are not verifiable",
+        details=(
+            "Mycelium cannot inspect application logs, provider SDKs, or "
+            "operator terminals. Redaction is defense-in-depth; fail-closed "
+            "pre-execution blocking is the primary protection."
+        ),
+        evidence=EVIDENCE_NOT_VERIFIABLE,
+        blocking=False,
+    )
+
+
 def ensure_builtin_checks_registered() -> None:
     """Import side effect: decorators already registered this module's checks."""
     return None

--- a/sdk/mycelium/doctor/render.py
+++ b/sdk/mycelium/doctor/render.py
@@ -10,7 +10,13 @@ from mycelium.doctor.types import DoctorReport, DoctorStatus
 
 def render_json(report: DoctorReport) -> str:
     """Stable machine-readable JSON for CI (no secrets)."""
-    return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    from mycelium.secret_protection import sanitize_secrets
+
+    return json.dumps(
+        sanitize_secrets(report.to_dict(), entropy_detection=False),
+        indent=2,
+        sort_keys=True,
+    )
 
 
 def render_human(report: DoctorReport, *, verbose: bool = False) -> str:
@@ -53,10 +59,11 @@ def render_human(report: DoctorReport, *, verbose: bool = False) -> str:
 
 def _format_check_line(check: object, *, verbose: bool) -> str:
     from mycelium.doctor.types import DoctorCheck
+    from mycelium.secret_protection import sanitize_text
 
     assert isinstance(check, DoctorCheck)
     pad_cat = f"{check.category:<20}"
-    line = f"[{check.status.value}] {pad_cat} {check.summary}"
+    line = f"[{check.status.value}] {pad_cat} {sanitize_text(check.summary)}"
     if check.status in (DoctorStatus.WARN, DoctorStatus.FAIL) and check.remediation:
         line += f"\n         → {check.remediation}"
     if verbose:

--- a/sdk/mycelium/loop_guard.py
+++ b/sdk/mycelium/loop_guard.py
@@ -94,7 +94,15 @@ class MissingRunIdentityError(Exception):
 
 def action_hash(tool: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
     """Stable hash of tool name + canonical args (no dispatch identity)."""
-    payload = f"{tool}:{args_fingerprint(args, kwargs)}"
+    from mycelium.secret_protection import fingerprint_args, get_active_secret_policy
+
+    policy = get_active_secret_policy()
+    digest = (
+        fingerprint_args(args, kwargs)
+        if policy is not None and policy.enabled
+        else args_fingerprint(args, kwargs)
+    )
+    payload = f"{tool}:{digest}"
     return hashlib.sha256(payload.encode()).hexdigest()
 
 

--- a/sdk/mycelium/outcome_emit.py
+++ b/sdk/mycelium/outcome_emit.py
@@ -276,6 +276,16 @@ class OutcomeEmitter:
         parent_request_id: str | None = None,
         handoff_id: str | None = None,
     ) -> None:
+        from mycelium.secret_protection import get_active_secret_policy, sanitize_text
+
+        policy = get_active_secret_policy()
+        if policy is not None and policy.enabled:
+            if resolution_reason:
+                resolution_reason = sanitize_text(resolution_reason)
+            if error_class:
+                error_class = sanitize_text(error_class)
+            if external_operation_ref:
+                external_operation_ref = sanitize_text(external_operation_ref)
         self.emit(
             OutcomeRow(
                 ts=time.time(),

--- a/sdk/mycelium/secret_protection.py
+++ b/sdk/mycelium/secret_protection.py
@@ -1,0 +1,983 @@
+"""AF-010 Secret-in-args: keep credentials out of the tool boundary.
+
+Fail-closed pre-execution blocking is the primary protection. Redaction of
+persisted and emitted representations is defense-in-depth. Mycelium cannot
+sanitize logs created inside arbitrary application or provider code.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import hmac
+import inspect
+import logging
+import math
+import re
+import threading
+import warnings
+from collections.abc import Callable, Mapping, Sequence
+from contextvars import ContextVar
+from dataclasses import dataclass, fields, is_dataclass, replace
+from typing import Any, ParamSpec, Protocol, TypeVar
+from urllib.parse import urlsplit, urlunsplit
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+REDACTED_MARKER = "[REDACTED]"
+SECRET_REF_PREFIX = "secret://"
+
+POLICY_ERROR = "error"
+POLICY_REDACT = "redact"
+POLICY_WARN = "warn"
+SECRET_ARGS_POLICIES = frozenset({POLICY_ERROR, POLICY_REDACT, POLICY_WARN})
+
+SENSITIVE_FIELD_NAMES = frozenset(
+    {
+        "api_key",
+        "api_secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "password",
+        "passwd",
+        "authorization",
+        "cookie",
+        "client_secret",
+        "private_key",
+        "signing_key",
+        "webhook_secret",
+    }
+)
+
+_HEADER_ALIASES = frozenset({"authorization", "cookie", "x-api-key", "x_api_key"})
+_WEAK_NAME_PARTS = ("secret", "token", "passwd", "password", "apikey", "api_key")
+
+_JWT_RE = re.compile(r"^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$")
+_PEM_RE = re.compile(
+    r"-----BEGIN (?:RSA |EC |OPENSSH |ENCRYPTED )?PRIVATE KEY-----"
+)
+_AWS_KEY_RE = re.compile(r"\bAKIA[0-9A-Z]{16}\b")
+_STRIPE_RE = re.compile(r"\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}\b")
+_GITHUB_RE = re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b")
+_GITHUB_PAT_RE = re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b")
+_SLACK_RE = re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+(\S+)")
+_BASIC_RE = re.compile(r"(?i)\bBasic\s+([A-Za-z0-9+/=_-]{8,})")
+_URL_USERINFO_RE = re.compile(
+    r"(?i)\b([a-z][a-z0-9+.-]*://)([^/\s:@]+):([^/\s@]+)@"
+)
+_URL_TOKEN_RE = re.compile(
+    r"(?i)([?&](?:access_token|refresh_token|id_token|api_key|token|key)=)([^&\s#]+)"
+)
+_PASSWORD_ASSIGN_RE = re.compile(
+    r"(?i)\b(password|passwd|pwd|client_secret|api_secret)\s*=\s*([^\s\"']+)"
+)
+_SECRET_REF_RE = re.compile(
+    r"^secret://[A-Za-z0-9._~-]+(?:/[A-Za-z0-9._~-]+)+$"
+)
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+_HEX_RE = re.compile(r"^[0-9a-f]{16,}$", re.IGNORECASE)
+
+_logger = logging.getLogger("mycelium.secret_protection")
+_policy_var: ContextVar[Any] = ContextVar("mycelium_secret_args_policy", default=None)
+_resolver_lock = threading.RLock()
+_resolver: SecretResolver | None = None
+_hmac_key: bytes | None = None
+_log_filter_installed = False
+_SECRET_FIELDS_ATTR = "_mycelium_secret_fields"
+
+
+class SecretResolver(Protocol):
+    """Host-registered mapping from ``secret://…`` references to values."""
+
+    def __call__(self, reference: str) -> str: ...
+
+
+class SecretInArgsError(Exception):
+    """Raised when a raw secret is present in tool arguments.
+
+    The message and attributes never include the original secret value.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tool: str | None = None,
+        paths: tuple[str, ...] = (),
+        kinds: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.tool = tool
+        self.paths = paths
+        self.kinds = kinds
+
+
+@dataclass(frozen=True)
+class SecretFinding:
+    """A detected secret location. Never stores the original value."""
+
+    path: str
+    kind: str
+    field: str | None = None
+
+
+@dataclass(frozen=True)
+class SecretArgsPolicy:
+    """Validated secret-in-args policy (not a storage constructor argument)."""
+
+    enabled: bool = False
+    policy: str = POLICY_ERROR
+    allow_fields: frozenset[str] = frozenset()
+    allow_tools: frozenset[str] = frozenset()
+    entropy_detection: bool = True
+    secret_fields: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        if self.policy not in SECRET_ARGS_POLICIES:
+            raise ValueError(
+                f"secret_args.policy must be one of {sorted(SECRET_ARGS_POLICIES)}, "
+                f"got {self.policy!r}"
+            )
+
+
+def is_secret_reference(value: Any) -> bool:
+    """True when *value* is an opaque ``secret://…`` identifier."""
+    return isinstance(value, str) and bool(_SECRET_REF_RE.fullmatch(value))
+
+
+def register_secret_resolver(resolver: SecretResolver | None) -> None:
+    """Register the process-wide secret-reference resolver.
+
+    Applications must register one explicitly. Mycelium does not invent a
+    default environment-variable resolver.
+    """
+    with _resolver_lock:
+        global _resolver
+        _resolver = resolver
+
+
+def registered_secret_resolver() -> SecretResolver | None:
+    with _resolver_lock:
+        return _resolver
+
+
+def register_secret_hmac_key(key: bytes | str | None) -> None:
+    """Host-owned key material for optional correlation HMAC digests."""
+    with _resolver_lock:
+        global _hmac_key
+        if key is None:
+            _hmac_key = None
+            return
+        _hmac_key = key.encode("utf-8") if isinstance(key, str) else bytes(key)
+
+
+def secret_hmac_digest(value: str, *, key: bytes | None = None) -> str:
+    """Keyed HMAC of a secret. Never use an unsalted hash for correlation."""
+    material = key if key is not None else _hmac_key
+    if not material:
+        raise SecretInArgsError(
+            "HMAC correlation requires host-owned key material; "
+            "call register_secret_hmac_key first"
+        )
+    digest = hmac.new(material, value.encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"{REDACTED_MARKER}:hmac:{digest[:16]}"
+
+
+def resolve_secret_reference(reference: str) -> str:
+    """Resolve a ``secret://…`` reference via the registered resolver.
+
+    Failures never include the resolved value. Missing resolvers and invalid
+    references raise :class:`SecretInArgsError`.
+    """
+    if not is_secret_reference(reference):
+        raise SecretInArgsError("not a secret reference")
+    resolver = registered_secret_resolver()
+    if resolver is None:
+        raise SecretInArgsError(
+            "no secret resolver is registered; "
+            "call register_secret_resolver before resolving references"
+        )
+    try:
+        value = resolver(reference)
+    except SecretInArgsError:
+        raise
+    except Exception as exc:
+        raise SecretInArgsError(
+            f"secret resolver failed ({type(exc).__name__})"
+        ) from None
+    if not isinstance(value, str) or not value:
+        raise SecretInArgsError("secret resolver returned an empty value")
+    return value
+
+
+def declare_secret_fields(*names: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Mark tool parameters that may hold ``secret://…`` references."""
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        setattr(func, _SECRET_FIELDS_ATTR, tuple(_normalize_field(n) for n in names))
+        return func
+
+    return decorator
+
+
+def secret_fields_for(func: Callable[..., Any] | None) -> frozenset[str]:
+    if func is None:
+        return frozenset()
+    seen: set[int] = set()
+    current: Any = func
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        raw = getattr(current, _SECRET_FIELDS_ATTR, ())
+        if raw:
+            return frozenset(str(item) for item in raw)
+        current = getattr(current, "__wrapped__", None)
+    return frozenset()
+
+
+def get_active_secret_policy() -> SecretArgsPolicy | None:
+    return _policy_var.get()
+
+
+def set_active_secret_policy(
+    policy: SecretArgsPolicy | None,
+) -> Any:
+    return _policy_var.set(policy)
+
+
+def reset_active_secret_policy(token: Any) -> None:
+    _policy_var.reset(token)
+
+
+def reset_secret_protection_state() -> None:
+    """Test helper: clear resolver, HMAC key, and active policy."""
+    register_secret_resolver(None)
+    register_secret_hmac_key(None)
+    _policy_var.set(None)
+
+
+def _normalize_field(name: str) -> str:
+    return str(name).strip().lower().replace("-", "_")
+
+
+def _field_allowed(name: str | None, allow_fields: frozenset[str]) -> bool:
+    if not name:
+        return False
+    return _normalize_field(name) in allow_fields
+
+
+def _is_sensitive_field(name: str | None) -> bool:
+    if not name:
+        return False
+    normalized = _normalize_field(name)
+    if normalized in SENSITIVE_FIELD_NAMES or normalized in _HEADER_ALIASES:
+        return True
+    leaf = normalized.rsplit(".", 1)[-1]
+    return leaf in SENSITIVE_FIELD_NAMES or leaf in _HEADER_ALIASES
+
+
+def _shannon_entropy(text: str) -> float:
+    if not text:
+        return 0.0
+    counts: dict[str, int] = {}
+    for char in text:
+        counts[char] = counts.get(char, 0) + 1
+    length = len(text)
+    return -sum((n / length) * math.log2(n / length) for n in counts.values())
+
+
+def _looks_like_high_entropy_token(text: str) -> bool:
+    if len(text) < 40 or " " in text or "\n" in text:
+        return False
+    if _UUID_RE.fullmatch(text) or _HEX_RE.fullmatch(text):
+        return False
+    if text.isalpha() or text.isdigit():
+        return False
+    if not re.fullmatch(r"[A-Za-z0-9/+=._~-]+", text):
+        return False
+    return _shannon_entropy(text) >= 4.5
+
+
+def _string_kind(
+    text: str,
+    *,
+    field: str | None,
+    entropy_detection: bool,
+) -> str | None:
+    if is_secret_reference(text):
+        return None
+    if _PEM_RE.search(text):
+        return "private_key"
+    if _JWT_RE.fullmatch(text.strip()):
+        return "jwt"
+    if _AWS_KEY_RE.search(text) or _STRIPE_RE.search(text):
+        return "credential_format"
+    if _GITHUB_RE.search(text) or _GITHUB_PAT_RE.search(text) or _SLACK_RE.search(text):
+        return "credential_format"
+    if _BEARER_RE.search(text) or _BASIC_RE.search(text):
+        return "authorization"
+    if _URL_USERINFO_RE.search(text) or _URL_TOKEN_RE.search(text):
+        return "url_credential"
+    if _PASSWORD_ASSIGN_RE.search(text):
+        return "password_assignment"
+    if _is_sensitive_field(field) and text.strip():
+        return "sensitive_field"
+    if entropy_detection and _looks_like_high_entropy_token(text):
+        if field and any(part in _normalize_field(field) for part in _WEAK_NAME_PARTS):
+            return "entropy"
+    return None
+
+
+def scan_secrets(
+    value: Any,
+    *,
+    entropy_detection: bool = True,
+    allow_fields: frozenset[str] | Sequence[str] = (),
+    _path: str = "$",
+    _field: str | None = None,
+    _seen: set[int] | None = None,
+) -> list[SecretFinding]:
+    """Recursively find secrets. Findings never include original values."""
+    allowed = (
+        allow_fields
+        if isinstance(allow_fields, frozenset)
+        else frozenset(_normalize_field(item) for item in allow_fields)
+    )
+    seen = _seen if _seen is not None else set()
+    findings: list[SecretFinding] = []
+
+    if _field_allowed(_field, allowed) or _field_allowed(_path.rsplit(".", 1)[-1], allowed):
+        return findings
+
+    obj_id = id(value)
+    if obj_id in seen:
+        return findings
+    if isinstance(value, (dict, list, tuple)) or is_dataclass(value):
+        seen.add(obj_id)
+
+    if isinstance(value, str):
+        kind = _string_kind(value, field=_field, entropy_detection=entropy_detection)
+        if kind is not None:
+            findings.append(SecretFinding(path=_path, kind=kind, field=_field))
+        return findings
+
+    if isinstance(value, bytes):
+        try:
+            decoded = value.decode("utf-8")
+        except UnicodeDecodeError:
+            return findings
+        return scan_secrets(
+            decoded,
+            entropy_detection=entropy_detection,
+            allow_fields=allowed,
+            _path=_path,
+            _field=_field,
+            _seen=seen,
+        )
+
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            key_name = str(key)
+            child_field = _normalize_field(key_name)
+            child_path = f"{_path}.{key_name}"
+            if isinstance(key, str):
+                key_kind = _string_kind(
+                    key, field=None, entropy_detection=entropy_detection
+                )
+                if key_kind is not None:
+                    findings.append(
+                        SecretFinding(path=f"{_path}[{key_name}]", kind=key_kind)
+                    )
+            if _is_sensitive_field(child_field) and not _field_allowed(child_field, allowed):
+                if isinstance(item, str) and is_secret_reference(item):
+                    continue
+                if item not in (None, ""):
+                    findings.append(
+                        SecretFinding(
+                            path=child_path,
+                            kind="sensitive_field",
+                            field=child_field,
+                        )
+                    )
+                    continue
+            findings.extend(
+                scan_secrets(
+                    item,
+                    entropy_detection=entropy_detection,
+                    allow_fields=allowed,
+                    _path=child_path,
+                    _field=child_field,
+                    _seen=seen,
+                )
+            )
+        return findings
+
+    if isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            findings.extend(
+                scan_secrets(
+                    item,
+                    entropy_detection=entropy_detection,
+                    allow_fields=allowed,
+                    _path=f"{_path}[{index}]",
+                    _field=_field,
+                    _seen=seen,
+                )
+            )
+        return findings
+
+    if is_dataclass(value) and not isinstance(value, type):
+        payload = {item.name: getattr(value, item.name) for item in fields(value)}
+        return scan_secrets(
+            payload,
+            entropy_detection=entropy_detection,
+            allow_fields=allowed,
+            _path=_path,
+            _field=_field,
+            _seen=seen,
+        )
+
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        try:
+            payload = dump()
+        except Exception:  # noqa: BLE001 — treat as opaque
+            return findings
+        return scan_secrets(
+            payload,
+            entropy_detection=entropy_detection,
+            allow_fields=allowed,
+            _path=_path,
+            _field=_field,
+            _seen=seen,
+        )
+    return findings
+
+
+def _redact_string(text: str, *, hmac_key: bytes | None) -> str:
+    if is_secret_reference(text):
+        return text
+    redacted = text
+    redacted = _PEM_RE.sub(REDACTED_MARKER, redacted)
+    redacted = _URL_USERINFO_RE.sub(r"\1***@", redacted)
+    redacted = _URL_TOKEN_RE.sub(rf"\1{REDACTED_MARKER}", redacted)
+    redacted = _PASSWORD_ASSIGN_RE.sub(rf"\1={REDACTED_MARKER}", redacted)
+    redacted = _BEARER_RE.sub(f"Bearer {REDACTED_MARKER}", redacted)
+    redacted = _BASIC_RE.sub(f"Basic {REDACTED_MARKER}", redacted)
+    redacted = _STRIPE_RE.sub(REDACTED_MARKER, redacted)
+    redacted = _AWS_KEY_RE.sub(REDACTED_MARKER, redacted)
+    redacted = _GITHUB_PAT_RE.sub(REDACTED_MARKER, redacted)
+    redacted = _GITHUB_RE.sub(REDACTED_MARKER, redacted)
+    redacted = _SLACK_RE.sub(REDACTED_MARKER, redacted)
+    if _JWT_RE.fullmatch(redacted.strip()):
+        redacted = REDACTED_MARKER
+    if redacted == text and hmac_key is not None and _looks_like_high_entropy_token(text):
+        return secret_hmac_digest(text, key=hmac_key)
+    if redacted == text and (
+        _PEM_RE.search(text)
+        or _JWT_RE.fullmatch(text.strip())
+        or _URL_USERINFO_RE.search(text)
+    ):
+        return REDACTED_MARKER
+    return redacted
+
+
+def _sanitize_url(text: str) -> str:
+    try:
+        parts = urlsplit(text)
+    except ValueError:
+        return _redact_string(text, hmac_key=None)
+    if parts.username or parts.password:
+        host = parts.hostname or ""
+        if parts.port:
+            host = f"{host}:{parts.port}"
+        netloc = f"***@{host}" if host else "***"
+        text = urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+    return _redact_string(text, hmac_key=None)
+
+
+def sanitize_secrets(
+    value: Any,
+    *,
+    hmac_key: bytes | None = None,
+    entropy_detection: bool = True,
+    allow_fields: frozenset[str] | Sequence[str] = (),
+    _field: str | None = None,
+    _seen: dict[int, Any] | None = None,
+) -> Any:
+    """Return a copy with detected secrets replaced by ``[REDACTED]``.
+
+    Never stores or returns the original secret. ``secret://`` references are
+    preserved. Caller-owned containers are not mutated.
+    """
+    allowed = (
+        allow_fields
+        if isinstance(allow_fields, frozenset)
+        else frozenset(_normalize_field(item) for item in allow_fields)
+    )
+    seen = _seen if _seen is not None else {}
+    if _field_allowed(_field, allowed):
+        return value
+
+    obj_id = id(value)
+    if obj_id in seen:
+        return seen[obj_id]
+
+    if isinstance(value, str):
+        if is_secret_reference(value):
+            return value
+        if _is_sensitive_field(_field) and value.strip():
+            if hmac_key is not None:
+                return secret_hmac_digest(value, key=hmac_key)
+            return REDACTED_MARKER
+        if "://" in value:
+            return _sanitize_url(value)
+        kind = _string_kind(value, field=_field, entropy_detection=entropy_detection)
+        if kind is None:
+            return value
+        if hmac_key is not None:
+            return secret_hmac_digest(value, key=hmac_key)
+        redacted = _redact_string(value, hmac_key=hmac_key)
+        return redacted if redacted != value else REDACTED_MARKER
+
+    if isinstance(value, bytes):
+        try:
+            decoded = value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value
+        sanitized = sanitize_secrets(
+            decoded,
+            hmac_key=hmac_key,
+            entropy_detection=entropy_detection,
+            allow_fields=allowed,
+            _field=_field,
+            _seen=seen,
+        )
+        if sanitized == decoded:
+            return value
+        return REDACTED_MARKER.encode("utf-8")
+
+    if isinstance(value, Mapping):
+        out: dict[Any, Any] = {}
+        seen[obj_id] = out
+        for key, item in value.items():
+            key_name = str(key)
+            child_field = _normalize_field(key_name)
+            safe_key: Any = key
+            if isinstance(key, str):
+                key_kind = _string_kind(
+                    key, field=None, entropy_detection=entropy_detection
+                )
+                if key_kind is not None:
+                    safe_key = REDACTED_MARKER
+            out[safe_key] = sanitize_secrets(
+                item,
+                hmac_key=hmac_key,
+                entropy_detection=entropy_detection,
+                allow_fields=allowed,
+                _field=child_field,
+                _seen=seen,
+            )
+        return out
+
+    if isinstance(value, list):
+        out_list: list[Any] = []
+        seen[obj_id] = out_list
+        for item in value:
+            out_list.append(
+                sanitize_secrets(
+                    item,
+                    hmac_key=hmac_key,
+                    entropy_detection=entropy_detection,
+                    allow_fields=allowed,
+                    _field=_field,
+                    _seen=seen,
+                )
+            )
+        return out_list
+
+    if isinstance(value, tuple):
+        return tuple(
+            sanitize_secrets(
+                item,
+                hmac_key=hmac_key,
+                entropy_detection=entropy_detection,
+                allow_fields=allowed,
+                _field=_field,
+                _seen=seen,
+            )
+            for item in value
+        )
+
+    if is_dataclass(value) and not isinstance(value, type):
+        payload = {
+            item.name: sanitize_secrets(
+                getattr(value, item.name),
+                hmac_key=hmac_key,
+                entropy_detection=entropy_detection,
+                allow_fields=allowed,
+                _field=_normalize_field(item.name),
+                _seen=seen,
+            )
+            for item in fields(value)
+        }
+        try:
+            return replace(value, **payload)
+        except Exception:  # noqa: BLE001
+            return payload
+
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        try:
+            payload = dump()
+        except Exception:  # noqa: BLE001
+            return value
+        return sanitize_secrets(
+            payload,
+            hmac_key=hmac_key,
+            entropy_detection=entropy_detection,
+            allow_fields=allowed,
+            _field=_field,
+            _seen=seen,
+        )
+    return value
+
+
+def sanitize_text(text: str) -> str:
+    """Sanitize a free-form string (logs, exceptions, CLI, YAML/JSON)."""
+    policy = get_active_secret_policy()
+    entropy = policy.entropy_detection if policy is not None else False
+    result = sanitize_secrets(text, entropy_detection=entropy)
+    return result if isinstance(result, str) else REDACTED_MARKER
+
+
+def sanitize_for_evidence(value: Any) -> Any:
+    """Sanitize a value for any persisted or emitted representation."""
+    policy = get_active_secret_policy()
+    if policy is None or not policy.enabled:
+        return sanitize_secrets(value, entropy_detection=False)
+    return sanitize_secrets(
+        value,
+        hmac_key=_hmac_key,
+        entropy_detection=policy.entropy_detection,
+        allow_fields=policy.allow_fields,
+    )
+
+
+def sanitize_exception(exc: BaseException) -> BaseException:
+    """Preserve exception type; expose only a sanitized message."""
+    original = str(exc)
+    message = sanitize_text(original)
+    if message == original:
+        return exc
+    try:
+        safe = type(exc)(message)
+    except Exception:  # noqa: BLE001
+        safe = RuntimeError(f"{type(exc).__name__}: {message}")
+    return safe
+
+
+def fingerprint_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+    """Argument fingerprint that never unsalted-hashes raw secrets."""
+    from mycelium.transition import args_fingerprint
+
+    policy = get_active_secret_policy()
+    if policy is None or not policy.enabled:
+        return args_fingerprint(args, kwargs)
+    safe_args, safe_kwargs = sanitize_secrets(
+        (args, dict(kwargs)),
+        hmac_key=_hmac_key,
+        entropy_detection=policy.entropy_detection,
+        allow_fields=policy.allow_fields,
+    )
+    return args_fingerprint(tuple(safe_args), dict(safe_kwargs))
+
+
+def redact_is_safe(
+    findings: Sequence[SecretFinding],
+    *,
+    secret_fields: frozenset[str],
+    consequential: bool,
+) -> bool:
+    """True only when redacting cannot change required tool semantics."""
+    for finding in findings:
+        field = finding.field
+        if field and field in secret_fields:
+            return False
+        if finding.kind in {
+            "sensitive_field",
+            "credential_format",
+            "authorization",
+            "private_key",
+            "jwt",
+        }:
+            return False
+        if consequential and finding.kind != "entropy":
+            return False
+    return True
+
+
+def enforce_secret_args(
+    tool: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    policy: SecretArgsPolicy,
+    secret_fields: frozenset[str] = frozenset(),
+    consequential: bool = False,
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Scan arguments and apply the configured policy.
+
+    Does not mutate the caller's original containers. Returns the args that
+    inner layers should see (original, or a redacted copy when safe).
+    """
+    if not policy.enabled or tool in policy.allow_tools:
+        return args, kwargs
+    findings = scan_secrets(
+        {"args": args, "kwargs": kwargs},
+        entropy_detection=policy.entropy_detection,
+        allow_fields=policy.allow_fields,
+    )
+    raw = [item for item in findings if item.kind != "reference"]
+    if not raw:
+        return args, kwargs
+
+    paths = tuple(item.path for item in raw)
+    kinds = tuple(sorted({item.kind for item in raw}))
+    message = (
+        f"SecretInArgsError: tool {tool!r} received raw secret material "
+        f"at {', '.join(paths)} ({', '.join(kinds)}). "
+        "Pass secret:// references instead of credentials."
+    )
+
+    if policy.policy == POLICY_ERROR:
+        raise SecretInArgsError(message, tool=tool, paths=paths, kinds=kinds)
+
+    if policy.policy == POLICY_REDACT:
+        if not redact_is_safe(
+            raw, secret_fields=secret_fields, consequential=consequential
+        ):
+            raise SecretInArgsError(message, tool=tool, paths=paths, kinds=kinds)
+        safe = sanitize_secrets(
+            {"args": args, "kwargs": kwargs},
+            hmac_key=_hmac_key,
+            entropy_detection=policy.entropy_detection,
+            allow_fields=policy.allow_fields,
+        )
+        return tuple(safe["args"]), dict(safe["kwargs"])
+
+    warnings.warn(message, stacklevel=3)
+    _logger.warning("%s", message)
+    return args, kwargs
+
+
+def resolve_declared_secret_fields(
+    func: Callable[..., Any] | None,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    extra_fields: frozenset[str] = frozenset(),
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Resolve ``secret://`` refs on declared fields only, on a copy."""
+    declared = secret_fields_for(func) | extra_fields
+    if not declared:
+        return args, kwargs
+    merged = dict(kwargs)
+    names: list[str] = []
+    if func is not None:
+        try:
+            bound = inspect.signature(func).bind_partial(*args, **kwargs)
+            names = list(bound.arguments)
+            for name, value in bound.arguments.items():
+                if name not in merged and name not in {"args", "kwargs"}:
+                    merged[name] = value
+        except (TypeError, ValueError):
+            names = []
+
+    changed = False
+    resolved_kwargs = dict(kwargs)
+    resolved_args = list(args)
+    for field_name in declared:
+        if field_name not in merged:
+            continue
+        value = merged[field_name]
+        if not is_secret_reference(value):
+            continue
+        resolved = resolve_secret_reference(value)
+        changed = True
+        if field_name in resolved_kwargs:
+            resolved_kwargs[field_name] = resolved
+        elif field_name in names:
+            index = names.index(field_name)
+            if index < len(resolved_args):
+                resolved_args[index] = resolved
+            else:
+                resolved_kwargs[field_name] = resolved
+        else:
+            resolved_kwargs[field_name] = resolved
+    if not changed:
+        return args, kwargs
+    return tuple(resolved_args), resolved_kwargs
+
+
+def _mark_secret_args(func: Callable[..., Any]) -> None:
+    func._mycelium_secret_args = True  # type: ignore[attr-defined]
+
+
+def apply_secret_args(
+    func: Callable[..., Any],
+    policy: SecretArgsPolicy,
+    *,
+    tool_name: str | None = None,
+    secret_fields: frozenset[str] | Sequence[str] = (),
+    consequential: bool = False,
+) -> Callable[..., Any]:
+    """Wrap *func* so secrets are scanned before any inner guard or claim."""
+    name = tool_name or getattr(func, "__name__", "tool")
+    declared = (
+        secret_fields
+        if isinstance(secret_fields, frozenset)
+        else frozenset(_normalize_field(item) for item in secret_fields)
+    )
+    effective = replace(policy, secret_fields=policy.secret_fields | declared)
+    if declared:
+        setattr(func, _SECRET_FIELDS_ATTR, tuple(declared))
+    _ensure_log_filter()
+
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            call_args, call_kwargs = enforce_secret_args(
+                name,
+                args,
+                kwargs,
+                policy=effective,
+                secret_fields=secret_fields_for(func) | declared,
+                consequential=consequential,
+            )
+            token = set_active_secret_policy(effective)
+            try:
+                ledgered = getattr(func, "_mycelium_ledger", False) or getattr(
+                    func, "_mycelium_task_ledger", False
+                )
+                if not ledgered:
+                    call_args, call_kwargs = resolve_declared_secret_fields(
+                        func,
+                        call_args,
+                        call_kwargs,
+                        extra_fields=secret_fields_for(func) | declared,
+                    )
+                return await func(*call_args, **call_kwargs)
+            except SecretInArgsError:
+                raise
+            except Exception as exc:
+                safe = sanitize_exception(exc)
+                if safe is exc:
+                    raise
+                raise safe from None
+            finally:
+                reset_active_secret_policy(token)
+
+        _mark_secret_args(async_wrapper)
+        return async_wrapper
+
+    @functools.wraps(func)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        call_args, call_kwargs = enforce_secret_args(
+            name,
+            args,
+            kwargs,
+            policy=effective,
+            secret_fields=secret_fields_for(func) | declared,
+            consequential=consequential,
+        )
+        token = set_active_secret_policy(effective)
+        try:
+            ledgered = getattr(func, "_mycelium_ledger", False) or getattr(
+                func, "_mycelium_task_ledger", False
+            )
+            if not ledgered:
+                call_args, call_kwargs = resolve_declared_secret_fields(
+                    func,
+                    call_args,
+                    call_kwargs,
+                    extra_fields=secret_fields_for(func) | declared,
+                )
+            return func(*call_args, **call_kwargs)
+        except SecretInArgsError:
+            raise
+        except Exception as exc:
+            safe = sanitize_exception(exc)
+            if safe is exc:
+                raise
+            raise safe from None
+        finally:
+            reset_active_secret_policy(token)
+
+    _mark_secret_args(sync_wrapper)
+    return sync_wrapper
+
+
+class _SecretLogFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            rendered = record.getMessage()
+            record.msg = sanitize_text(rendered)
+            record.args = ()
+        except Exception:  # noqa: BLE001 — logging must never raise
+            record.msg = REDACTED_MARKER
+            record.args = ()
+        return True
+
+
+def _ensure_log_filter() -> None:
+    global _log_filter_installed
+    if _log_filter_installed:
+        return
+    filt = _SecretLogFilter()
+    logging.getLogger("mycelium").addFilter(filt)
+    for name, logger in logging.Logger.manager.loggerDict.items():
+        if isinstance(logger, logging.Logger) and name.startswith("mycelium"):
+            logger.addFilter(filt)
+    _log_filter_installed = True
+
+
+__all__ = [
+    "POLICY_ERROR",
+    "POLICY_REDACT",
+    "POLICY_WARN",
+    "REDACTED_MARKER",
+    "SECRET_ARGS_POLICIES",
+    "SECRET_REF_PREFIX",
+    "SENSITIVE_FIELD_NAMES",
+    "SecretArgsPolicy",
+    "SecretFinding",
+    "SecretInArgsError",
+    "SecretResolver",
+    "apply_secret_args",
+    "declare_secret_fields",
+    "enforce_secret_args",
+    "fingerprint_args",
+    "get_active_secret_policy",
+    "is_secret_reference",
+    "register_secret_hmac_key",
+    "register_secret_resolver",
+    "registered_secret_resolver",
+    "reset_secret_protection_state",
+    "resolve_declared_secret_fields",
+    "resolve_secret_reference",
+    "sanitize_exception",
+    "sanitize_for_evidence",
+    "sanitize_secrets",
+    "sanitize_text",
+    "scan_secrets",
+    "secret_fields_for",
+    "secret_hmac_digest",
+    "set_active_secret_policy",
+]

--- a/sdk/mycelium/task_ledger.py
+++ b/sdk/mycelium/task_ledger.py
@@ -182,11 +182,12 @@ class TaskLedger:
         Raises TaskLedgerPendingError if the task is currently in-flight.
         """
         bound = _bind_args(args, kwargs)
+        stored_args, stored_kwargs = _evidence_args(bound["args"], bound["kwargs"])
         entry = TaskLedgerEntry(
             request_id=request_id,
             task=task,
-            args=bound["args"],
-            kwargs=bound["kwargs"],
+            args=stored_args,
+            kwargs=stored_kwargs,
             status="in-flight",
         )
         outcome, existing = self._storage.try_claim_inflight(entry)
@@ -208,7 +209,7 @@ class TaskLedger:
             args=existing.args,
             kwargs=existing.kwargs,
             status="completed",
-            result=result,
+            result=_evidence_value(result),
             started_at=existing.started_at,
             finished_at=time.time(),
         )
@@ -225,7 +226,7 @@ class TaskLedger:
             args=existing.args,
             kwargs=existing.kwargs,
             status="failed",
-            error=f"{type(error).__name__}: {error}",
+            error=_evidence_error(error),
             started_at=existing.started_at,
             finished_at=time.time(),
         )
@@ -283,6 +284,43 @@ class TaskLedger:
         return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
+def _evidence_value(value: Any) -> Any:
+    from mycelium.secret_protection import get_active_secret_policy, sanitize_for_evidence
+
+    policy = get_active_secret_policy()
+    if policy is None or not policy.enabled:
+        return value
+    return sanitize_for_evidence(value)
+
+
+def _evidence_args(args: Any, kwargs: Any) -> tuple[list[Any], dict[str, Any]]:
+    from mycelium.secret_protection import get_active_secret_policy, sanitize_secrets
+
+    policy = get_active_secret_policy()
+    if policy is None or not policy.enabled:
+        return list(args), dict(kwargs)
+    safe = sanitize_secrets(
+        {"args": list(args), "kwargs": dict(kwargs)},
+        entropy_detection=policy.entropy_detection,
+        allow_fields=policy.allow_fields,
+    )
+    return list(safe["args"]), dict(safe["kwargs"])
+
+
+def _evidence_error(error: BaseException) -> str:
+    from mycelium.secret_protection import (
+        get_active_secret_policy,
+        sanitize_exception,
+        sanitize_text,
+    )
+
+    policy = get_active_secret_policy()
+    if policy is None or not policy.enabled:
+        return f"{type(error).__name__}: {error}"
+    safe = sanitize_exception(error)
+    return sanitize_text(f"{type(safe).__name__}: {safe}")
+
+
 def _bind_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
     """Store a serializable snapshot of the call arguments."""
     return {
@@ -323,11 +361,31 @@ def _run_task_ledgered(
         return existing.result
 
     try:
-        result = func(*args, **clean_kwargs)
+        from mycelium.secret_protection import (
+            get_active_secret_policy,
+            resolve_declared_secret_fields,
+        )
+
+        policy = get_active_secret_policy()
+        extra = policy.secret_fields if policy is not None else frozenset()
+        exec_args, exec_kwargs = resolve_declared_secret_fields(
+            func, args, clean_kwargs, extra_fields=extra
+        )
+        result = func(*exec_args, **exec_kwargs)
     except Exception as exc:
+        from mycelium.secret_protection import (
+            get_active_secret_policy,
+        )
+        from mycelium.secret_protection import (
+            sanitize_exception as _sanitize_exc,
+        )
+
+        policy = get_active_secret_policy()
+        if policy is not None and policy.enabled:
+            exc = _sanitize_exc(exc)
         ledger.fail(request_id, exc)
         _emit_task_receipt(audit_emitter, ledger, request_id)
-        raise
+        raise exc
 
     ledger.complete(request_id, result)
     _emit_task_receipt(audit_emitter, ledger, request_id)
@@ -349,11 +407,31 @@ async def _run_task_ledgered_async(
         return existing.result
 
     try:
-        result = await func(*args, **clean_kwargs)
+        from mycelium.secret_protection import (
+            get_active_secret_policy,
+            resolve_declared_secret_fields,
+        )
+
+        policy = get_active_secret_policy()
+        extra = policy.secret_fields if policy is not None else frozenset()
+        exec_args, exec_kwargs = resolve_declared_secret_fields(
+            func, args, clean_kwargs, extra_fields=extra
+        )
+        result = await func(*exec_args, **exec_kwargs)
     except Exception as exc:
+        from mycelium.secret_protection import (
+            get_active_secret_policy,
+        )
+        from mycelium.secret_protection import (
+            sanitize_exception as _sanitize_exc,
+        )
+
+        policy = get_active_secret_policy()
+        if policy is not None and policy.enabled:
+            exc = _sanitize_exc(exc)
         ledger.fail(request_id, exc)
         _emit_task_receipt(audit_emitter, ledger, request_id)
-        raise
+        raise exc
 
     ledger.complete(request_id, result)
     _emit_task_receipt(audit_emitter, ledger, request_id)

--- a/sdk/mycelium/templates/mycelium.minimal.yaml
+++ b/sdk/mycelium/templates/mycelium.minimal.yaml
@@ -4,6 +4,8 @@
 #
 # Deployments: add `profile: production` so side-effecting memory storage
 #   and missing run_id cannot silently skip protection.
+# Optional AF-010: secret_args: {enabled: true, policy: error}
+#   Pass secret:// references instead of credentials.
 #
 # side_effect_class required only for tools listed under action_ledger.tools:
 #   read | idempotent_mutate | keyed_mutate | non_idempotent_mutate | irreversible

--- a/sdk/mycelium/templates/mycelium.template.yaml
+++ b/sdk/mycelium/templates/mycelium.template.yaml
@@ -6,7 +6,8 @@
 #   Required for transition guards:  transition, action_ledger (+ tools entries you ledger)
 #   Optional:  integrations, task_ledger, state_flush, audit_receipt, outcome_emit,
 #              loop_guard, completion, state_authority, registry, runner,
-#              history_guard, message_validator, deployment, verify — delete unused sections
+#              history_guard, message_validator, deployment, verify,
+#              secret_args — delete unused sections
 #
 # Next steps
 #   1. Allowlist first: rename tools: / tasks: stubs, then copy those exact
@@ -78,6 +79,8 @@
 #   → loop_guard / scope_guard missing_run_id_policy: error (when enabled)
 #   → outcome_emit: required, durable storage, on_failure: error
 #   → completion: requires a verified terminal adapter at startup
+#   → secret_args.policy: error when secret_args is enabled and
+#     consequential tools exist (warn/redact rejected)
 #   Weaker explicit warn/derived/memory-outcome settings are rejected.
 #   unclassified_policy: warn remains an accepted product choice.
 # Verify with:
@@ -254,7 +257,24 @@ loop_guard:
   # Per-tool: tools.my_tool.loop_guard: { consecutive_soft: 20 }  or  false
 
 # ---------------------------------------------------------------------------
-# budget  (not AF-010 — cost / time / step ceilings; refuse next step)
+# secret_args  (AF-010 — block raw credentials before claim / evidence)
+# Omitted = existing behavior. Production + consequential tools require
+#   policy: error. Pass secret:// refs; register_secret_resolver in app
+#   code (no default env-var resolver). allow_fields weakens protection —
+#   scope narrowly by tool (tools.<name>.secret_fields), not globally.
+# Fail-closed pre-execution blocking is primary; redaction is
+#   defense-in-depth. Mycelium cannot sanitize app/provider logs.
+# ---------------------------------------------------------------------------
+# secret_args:
+#   enabled: true
+#   policy: error          # error | redact | warn
+#   allow_fields: []
+#   allow_tools: []
+#   entropy_detection: true
+# Per tool: secret_fields: [api_key]  and/or  secret_args: false
+
+# ---------------------------------------------------------------------------
+# budget  (unnumbered — cost / time / step ceilings; refuse next step)
 # LangGraph/LangChain LLM turns are wired automatically from YAML.
 # Storage: memory | file | sqlite | redis | postgres (atomic update()).
 # missing_usage_policy: warn (default) | error (required in production

--- a/sdk/mycelium/verify/registry.py
+++ b/sdk/mycelium/verify/registry.py
@@ -17,6 +17,7 @@ SCENARIO_ORDER = (
     "worker-crash",
     "ambiguous-effect",
     "reconcile",
+    "secret-in-args",
 )
 
 ScenarioFn = Callable[["ScenarioContext"], "VerificationEvidence"]
@@ -77,6 +78,7 @@ def ensure_builtin_scenarios_registered() -> None:
         contention,
         reconcile,
         redispatch,
+        secret_in_args,
         storage_outage,
         worker_crash,
     )

--- a/sdk/mycelium/verify/render.py
+++ b/sdk/mycelium/verify/render.py
@@ -16,11 +16,18 @@ _SCENARIO_LABELS = {
     "worker-crash": "Worker crash",
     "ambiguous-effect": "Ambiguous effect",
     "reconcile": "Reconcile",
+    "secret-in-args": "Secret-in-args",
 }
 
 
 def render_json(report: VerificationReport) -> str:
-    return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    from mycelium.secret_protection import sanitize_secrets
+
+    return json.dumps(
+        sanitize_secrets(report.to_dict(), entropy_detection=False),
+        indent=2,
+        sort_keys=True,
+    )
 
 
 def render_human(report: VerificationReport) -> str:

--- a/sdk/mycelium/verify/scenarios/secret_in_args.py
+++ b/sdk/mycelium/verify/scenarios/secret_in_args.py
@@ -1,0 +1,357 @@
+"""Secret-in-args: raw credentials never reach claim, evidence, or artifacts."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from mycelium.action_ledger import InMemoryLedgerStorage, ledger_sync
+from mycelium.secret_protection import (
+    REDACTED_MARKER,
+    SecretArgsPolicy,
+    SecretInArgsError,
+    apply_secret_args,
+    declare_secret_fields,
+    register_secret_resolver,
+    reset_secret_protection_state,
+)
+from mycelium.transition import TransitionScope, execution_scope
+from mycelium.verify.registry import ScenarioContext, verify_scenario
+from mycelium.verify.types import VerificationEvidence, VerificationStatus
+from mycelium.verify.workers import synthetic_binding
+
+# Synthetic only — never a real credential. Failure text must not echo it.
+_SYNTHETIC = "sk_test_MyceliumVerifyFakeSecretAF010xx"
+_FRAGMENTS = (
+    "sk_test_MyceliumVerify",
+    "MyceliumVerifyFakeSecretAF010",
+)
+_REF = "secret://stripe/verify/api-key"
+
+
+def _contains_secret(text: str) -> bool:
+    if _SYNTHETIC in text:
+        return True
+    return any(fragment in text for fragment in _FRAGMENTS)
+
+
+def _scan_payload(value: Any) -> bool:
+    try:
+        text = json.dumps(value, default=str)
+    except TypeError:
+        text = repr(value)
+    return _contains_secret(text)
+
+
+def _scan_paths(paths: list[str]) -> bool:
+    for raw in paths:
+        path = Path(raw)
+        try:
+            if path.is_file():
+                if _contains_secret(path.read_text(encoding="utf-8", errors="replace")):
+                    return True
+            elif path.is_dir():
+                for child in path.rglob("*"):
+                    if child.is_file() and _contains_secret(
+                        child.read_text(encoding="utf-8", errors="replace")
+                    ):
+                        return True
+        except OSError:
+            continue
+    return False
+
+
+class _RecordingStorage(InMemoryLedgerStorage):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self.events = events
+
+    def try_claim_inflight(self, entry, *, lease_ttl: float = 3600.0):
+        self.events.append("claim")
+        return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+    def set(self, entry) -> None:
+        if _scan_payload(entry.to_dict() if hasattr(entry, "to_dict") else entry):
+            raise RuntimeError("storage refused a payload that contained a secret")
+        return super().set(entry)
+
+
+class _BoomStorage(InMemoryLedgerStorage):
+    def set(self, entry) -> None:
+        raise RuntimeError(f"persist failed args={entry.args!r} kwargs={entry.kwargs!r}")
+
+
+class _BoomEmitter:
+    fail_closed = True
+
+    def emit_event(self, **payload: Any) -> None:
+        raise RuntimeError(f"emit failed {payload!r}")
+
+    def emit(self, row: Any) -> None:
+        payload = row.to_dict() if hasattr(row, "to_dict") else row
+        raise RuntimeError(f"emit failed {payload!r}")
+
+
+def _wrap(
+    storage,
+    *,
+    policy: SecretArgsPolicy,
+    events: list[str],
+    seen: list[Any],
+    fail_with_secret: bool = False,
+    outcome_emitter: Any = None,
+):
+    binding = synthetic_binding()
+
+    @declare_secret_fields("api_key")
+    def verify_charge(
+        amount: int,
+        api_key: str | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        events.append("body")
+        seen.append(api_key)
+        if fail_with_secret:
+            raise RuntimeError(f"provider rejected {_SYNTHETIC}")
+        return {"charged": True, "amount": amount, "payload": payload}
+
+    ledgered = ledger_sync(
+        storage=storage,
+        transition_binding=binding,
+        lease_ttl=30.0,
+        lease_renew_interval=0,
+        poll_interval=0.02,
+        poll_timeout=5.0,
+        outcome_emitter=outcome_emitter,
+    )(verify_charge)
+    return apply_secret_args(
+        ledgered,
+        policy,
+        tool_name="verify_charge",
+        secret_fields=["api_key"],
+        consequential=True,
+    )
+
+
+@verify_scenario("secret-in-args")
+def run_secret_in_args(ctx: ScenarioContext) -> VerificationEvidence:
+    started = time.time()
+    iso = ctx.isolation
+    artifact = iso.artifact_file("secret-in-args-")
+    dump = Path(iso.artifact_file("secret-in-args-dump-"))
+    failures: list[str] = []
+    decisions: list[str] = []
+    attempts = 0
+    bodies = 0
+    reset_secret_protection_state()
+
+    policy_error = SecretArgsPolicy(enabled=True, policy="error")
+    policy_warn = SecretArgsPolicy(enabled=True, policy="warn")
+    events: list[str] = []
+    seen: list[Any] = []
+    resolver_calls: list[str] = []
+
+    def resolver(reference: str) -> str:
+        resolver_calls.append(reference)
+        events.append("resolve")
+        return _SYNTHETIC
+
+    register_secret_resolver(resolver)
+
+    # 1. Raw secret is blocked before claim / body / side effect.
+    recording = _RecordingStorage(events)
+    rid_raw = iso.track(iso.namespace.request_id("secret-in-args", "raw"))
+    attempts += 1
+    with execution_scope(TransitionScope(thread_id="verify", run_id="verify")):
+        tool = _wrap(recording, policy=policy_error, events=events, seen=seen)
+        blocked = False
+        try:
+            tool(1, api_key=_SYNTHETIC, request_id=rid_raw)
+        except SecretInArgsError as exc:
+            blocked = True
+            if _contains_secret(str(exc)):
+                failures.append("SecretInArgsError echoed the synthetic secret")
+        except Exception:  # noqa: BLE001
+            failures.append("raw secret raised an unexpected exception type")
+    if not blocked:
+        failures.append("raw secret was not blocked")
+    if "body" in events or "claim" in recording.events:
+        failures.append("raw secret reached claim or tool body")
+    elif recording.get(rid_raw) is not None:
+        failures.append("raw secret created a ledger claim")
+    else:
+        decisions.append("raw-secret:blocked-before-claim")
+
+    # 2. Nested secret is detected.
+    events.clear()
+    rid_nested = iso.track(iso.namespace.request_id("secret-in-args", "nested"))
+    attempts += 1
+    with execution_scope(TransitionScope(thread_id="verify", run_id="verify")):
+        tool = _wrap(recording, policy=policy_error, events=events, seen=seen)
+        nested_blocked = False
+        try:
+            tool(
+                1,
+                payload={"nested": {"password": _SYNTHETIC}},
+                request_id=rid_nested,
+            )
+        except SecretInArgsError:
+            nested_blocked = True
+        except Exception:  # noqa: BLE001
+            failures.append("nested secret raised an unexpected exception type")
+    if not nested_blocked or "body" in events or recording.get(rid_nested) is not None:
+        failures.append("nested secret was not blocked before claim")
+    else:
+        decisions.append("nested-secret:blocked")
+
+    # 3. secret:// reference is allowed; resolver runs only at execution.
+    events.clear()
+    seen.clear()
+    resolver_calls.clear()
+    recording.events.clear()
+    rid_ref = iso.track(iso.namespace.request_id("secret-in-args", "ref"))
+    attempts += 1
+    with execution_scope(TransitionScope(thread_id="verify", run_id="verify")):
+        tool = _wrap(recording, policy=policy_error, events=events, seen=seen)
+        result = tool(2, api_key=_REF, request_id=rid_ref)
+    bodies += 1
+    if resolver_calls != [_REF]:
+        failures.append("resolver was not invoked exactly once with the reference")
+    if events[:2] != ["claim", "resolve"] or "body" not in events:
+        failures.append("resolver did not run after claim and before the body")
+    if seen != [_SYNTHETIC]:
+        failures.append("tool body did not receive the resolved value")
+    if result.get("charged") is not True:
+        failures.append("reference call did not complete")
+    entry = recording.get(rid_ref)
+    if entry is None:
+        failures.append("reference call did not persist a ledger row")
+    elif _scan_payload(entry.to_dict()):
+        failures.append("resolved secret leaked into the ledger row")
+    elif _REF not in json.dumps(entry.kwargs, default=str) and _REF not in json.dumps(
+        entry.args, default=str
+    ):
+        failures.append("ledger row lost the secret:// reference")
+    else:
+        decisions.append("reference:resolved-after-claim")
+
+    # 4. Storage / emission failures must not leak the secret (warn path).
+    boom = _BoomStorage()
+    rid_boom = iso.track(iso.namespace.request_id("secret-in-args", "boom"))
+    attempts += 1
+    with execution_scope(TransitionScope(thread_id="verify", run_id="verify")):
+        tool = _wrap(boom, policy=policy_warn, events=events, seen=seen)
+        try:
+            tool(1, api_key=_SYNTHETIC, request_id=rid_boom)
+            failures.append("warn-policy storage failure did not raise")
+        except Exception as exc:  # noqa: BLE001
+            if _contains_secret(str(exc)):
+                failures.append("storage failure leaked the synthetic secret")
+            else:
+                decisions.append("storage-failure:sanitized")
+
+    rid_emit = iso.track(iso.namespace.request_id("secret-in-args", "emit"))
+    attempts += 1
+    with execution_scope(TransitionScope(thread_id="verify", run_id="verify")):
+        tool = _wrap(
+            iso.open_storage(),
+            policy=policy_warn,
+            events=events,
+            seen=seen,
+            outcome_emitter=_BoomEmitter(),
+        )
+        try:
+            tool(1, api_key=_SYNTHETIC, request_id=rid_emit)
+            failures.append("warn-policy emission failure did not raise")
+        except Exception as exc:  # noqa: BLE001
+            if _contains_secret(str(exc)):
+                failures.append("emission failure leaked the synthetic secret")
+            else:
+                decisions.append("emission-failure:sanitized")
+
+    events.clear()
+    rid_exc = iso.track(iso.namespace.request_id("secret-in-args", "exc"))
+    attempts += 1
+    with execution_scope(TransitionScope(thread_id="verify", run_id="verify")):
+        tool = _wrap(
+            iso.open_storage(),
+            policy=policy_error,
+            events=events,
+            seen=seen,
+            fail_with_secret=True,
+        )
+        try:
+            tool(1, api_key=_REF, request_id=rid_exc)
+            failures.append("provider exception was swallowed")
+        except SecretInArgsError:
+            failures.append("protection replaced the provider exception")
+        except Exception as exc:  # noqa: BLE001
+            if _contains_secret(str(exc)):
+                failures.append("provider exception leaked the secret")
+            else:
+                decisions.append("provider-exception:sanitized")
+
+    # 5. Search every generated artifact and namespaced ledger row.
+    dump.write_text(
+        json.dumps(
+            {
+                "decisions": decisions,
+                "marker": REDACTED_MARKER,
+                "reference": _REF,
+                "entries": [
+                    item.to_dict()
+                    for item in (*recording.list_all(), *iso.open_storage().list_all())
+                ],
+            },
+            default=str,
+        ),
+        encoding="utf-8",
+    )
+    artifact_paths = [artifact, str(dump), *iso.artifact_paths()]
+    if _scan_paths(artifact_paths):
+        failures.append("synthetic secret found in generated artifacts")
+    for item in (*recording.list_all(), *iso.open_storage().list_all()):
+        if _scan_payload(item.to_dict()):
+            failures.append("synthetic secret found in a ledger row")
+            break
+    if any(not iso.namespace.owns(item) for item in iso.tracked_ids):
+        failures.append("tracked request_id escaped the verification namespace")
+    else:
+        decisions.append("cleanup:namespace-safe")
+
+    reset_secret_protection_state()
+    status = (
+        VerificationStatus.PASS if not failures else VerificationStatus.FAIL
+    )
+    return VerificationEvidence(
+        scenario="secret-in-args",
+        backend=iso.backend,
+        namespace=iso.namespace.prefix,
+        attempts=attempts,
+        body_executions=bodies,
+        ledger_decisions=decisions,
+        duration=time.time() - started,
+        expected_behavior=(
+            "Raw secrets are blocked before claim; secret:// refs resolve only "
+            "at execution; resolved values never appear in evidence or artifacts."
+        ),
+        observed_behavior="; ".join(failures or decisions),
+        artifacts=artifact_paths,
+        limitations=[
+            "Host logs and third-party provider SDKs are not_verifiable.",
+            "Synthetic credentials only; no real provider was contacted.",
+        ],
+        status=status,
+        summary=(
+            "Secret-in-args blocked raw credentials and kept references opaque"
+            if not failures
+            else "Secret-in-args leaked or failed to block a synthetic credential"
+        ),
+        remediation=(
+            ""
+            if not failures
+            else "Pass secret:// references; keep secret_args.policy: error."
+        ),
+    )

--- a/sdk/tests/test_doctor.py
+++ b/sdk/tests/test_doctor.py
@@ -477,3 +477,39 @@ def test_verbose_includes_evidence(tmp_path: Path) -> None:
     report = run_doctor(path, connectivity=False)
     text = render_human(report, verbose=True)
     assert "evidence=" in text
+
+
+def test_secret_args_omitted_is_skip_not_warn(tmp_path: Path) -> None:
+    path = _write(tmp_path, _single_node_prod(tmp_path))
+    report = run_doctor(path, connectivity=False)
+    scanning = next(c for c in report.checks if c.id == "secrets.scanning")
+    assert scanning.status == DoctorStatus.SKIP
+    host = next(c for c in report.checks if c.id == "secrets.host_logs")
+    assert host.evidence == "not_verifiable"
+    assert host.status == DoctorStatus.SKIP
+    assert not any(
+        c.id.startswith("secrets.") and c.status in (DoctorStatus.WARN, DoctorStatus.FAIL)
+        for c in report.checks
+    )
+
+
+def test_secret_args_enabled_reports_fail_closed(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        _single_node_prod(
+            tmp_path,
+            extra="""
+secret_args:
+  enabled: true
+  policy: error
+  allow_fields: [authorization]
+""",
+        ),
+    )
+    report = run_doctor(path, connectivity=False)
+    scanning = next(c for c in report.checks if c.id == "secrets.scanning")
+    assert scanning.status == DoctorStatus.PASS
+    closed = next(c for c in report.checks if c.id == "secrets.production_fail_closed")
+    assert closed.status == DoctorStatus.PASS
+    allow = next(c for c in report.checks if c.id == "secrets.allow_fields")
+    assert allow.status == DoctorStatus.WARN

--- a/sdk/tests/test_production_profile.py
+++ b/sdk/tests/test_production_profile.py
@@ -401,6 +401,31 @@ scope_guard:
     assert scope.missing_run_id_policy == "error"
 
 
+def test_production_accepts_secret_args_error_policy() -> None:
+    cfg = load_config_from_string(
+        """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [charge]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+secret_args:
+  enabled: true
+  policy: error
+tools:
+  charge:
+    side_effect_class: non_idempotent_mutate
+    secret_fields: [api_key]
+"""
+    )
+    assert cfg.secret_args is not None
+    assert cfg.secret_args["policy"] == "error"
+    assert cfg.tools["charge"].secret_fields == ("api_key",)
+
+
 def test_existing_configs_without_profile_still_load() -> None:
     cfg = load_config_from_string(
         """

--- a/sdk/tests/test_secret_protection.py
+++ b/sdk/tests/test_secret_protection.py
@@ -1,0 +1,493 @@
+"""AF-010 secret-in-args: scanner, policies, resolver, and evidence paths."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import logging
+import multiprocessing as mp
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from mycelium import (
+    ConfigError,
+    InMemoryLedgerStorage,
+    SecretInArgsError,
+    declare_secret_fields,
+    is_secret_reference,
+    ledger_sync,
+    load_config_from_string,
+    register_secret_hmac_key,
+    register_secret_resolver,
+    resolve_secret_reference,
+    sanitize_secrets,
+    scan_secrets,
+)
+from mycelium.action_ledger import ARGS_DRIFT_HARD
+from mycelium.audit_receipt import AuditReceiptEmitter, InMemoryAuditReceiptStorage
+from mycelium.doctor.types import DoctorStatus
+from mycelium.outcome_emit import InMemoryOutcomeStorage, OutcomeEmitter
+from mycelium.secret_protection import (
+    REDACTED_MARKER,
+    SecretArgsPolicy,
+    apply_secret_args,
+    fingerprint_args,
+    reset_active_secret_policy,
+    reset_secret_protection_state,
+    sanitize_exception,
+    sanitize_for_evidence,
+    sanitize_text,
+    secret_hmac_digest,
+    set_active_secret_policy,
+)
+from mycelium.transition import (
+    SideEffectClass,
+    ToolTransitionBinding,
+    TransitionScope,
+    args_fingerprint,
+    execution_scope,
+)
+
+# Fake material only. Assertions never interpolate these into messages.
+_FAKE = "sk_test_MyceliumUnitFakeSecretAF010xx"
+_FAKE_PASS = "mycelium-unit-fake-password"
+_FAKE_TOKEN = "mycelium-unit-fake-bearer-token"
+_REF = "secret://stripe/unit/api-key"
+_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJteWNlbGl1bS11bml0In0.fakesigpad"
+_PEM = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIFakePrivateKeyMaterialForTestsOnly\n"
+    "-----END PRIVATE KEY-----"
+)
+_ENTROPY = "n7Kq2Vx9Lm4Pz8Rw1Yt6Hs3Bd0Cf5Gj-Ae_Q9uW2"
+
+
+def _assert_absent(haystack: Any) -> None:
+    text = haystack if isinstance(haystack, str) else json.dumps(haystack, default=str)
+    if _FAKE in text or _FAKE_PASS in text or _FAKE_TOKEN in text:
+        raise AssertionError("synthetic secret leaked into an observed value")
+
+
+def _assert_present(haystack: Any, value: str) -> None:
+    text = haystack if isinstance(haystack, str) else json.dumps(haystack, default=str)
+    if value not in text:
+        raise AssertionError("expected identifier was missing")
+
+
+@pytest.fixture(autouse=True)
+def _reset_secrets() -> None:
+    reset_secret_protection_state()
+    yield
+    reset_secret_protection_state()
+
+
+def _policy(name: str = "error", **kwargs: Any) -> SecretArgsPolicy:
+    return SecretArgsPolicy(enabled=True, policy=name, **kwargs)
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="t",
+        policy_version="test",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def test_nested_containers_and_models() -> None:
+    @dataclass
+    class Payload:
+        password: str
+        nested: dict[str, Any]
+
+    class Model:
+        def model_dump(self) -> dict[str, Any]:
+            return {"api_key": _FAKE, "ok": True}
+
+    findings = scan_secrets(
+        {
+            "outer": [
+                {"token": _FAKE_TOKEN},
+                Payload(password=_FAKE_PASS, nested={"cookie": "a=b"}),
+            ],
+            "model": Model(),
+        }
+    )
+    kinds = {item.kind for item in findings}
+    assert "sensitive_field" in kinds
+    assert all(item.field != _FAKE for item in findings)
+    safe = sanitize_secrets(
+        {"outer": [{"token": _FAKE_TOKEN}], "password": _FAKE_PASS}
+    )
+    _assert_absent(safe)
+    assert safe["outer"][0]["token"] == REDACTED_MARKER
+
+
+def test_sensitive_field_names() -> None:
+    for name in (
+        "api_key",
+        "api_secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "password",
+        "passwd",
+        "authorization",
+        "cookie",
+        "client_secret",
+        "private_key",
+        "signing_key",
+        "webhook_secret",
+    ):
+        found = scan_secrets({name: "x"})
+        assert found, name
+        assert found[0].kind == "sensitive_field"
+
+
+def test_authorization_headers_and_urls() -> None:
+    findings = scan_secrets(
+        {
+            "authorization": f"Bearer {_FAKE_TOKEN}",
+            "page": f"https://user:{_FAKE_PASS}@example.com/v1",
+            "link": f"https://api.example.com/?access_token={_FAKE_TOKEN}",
+        }
+    )
+    kinds = {item.kind for item in findings}
+    assert "sensitive_field" in kinds or "authorization" in kinds
+    assert "url_credential" in kinds
+    safe = sanitize_secrets(
+        {
+            "authorization": f"Bearer {_FAKE_TOKEN}",
+            "page": f"https://user:{_FAKE_PASS}@example.com/v1",
+        }
+    )
+    _assert_absent(safe)
+
+
+def test_private_key_and_jwt() -> None:
+    kinds = {item.kind for item in scan_secrets({"pem": _PEM, "jwt": _JWT})}
+    assert "private_key" in kinds
+    assert "jwt" in kinds
+    safe = sanitize_secrets({"pem": _PEM, "jwt": _JWT})
+    assert _PEM not in json.dumps(safe)
+    assert _JWT not in json.dumps(safe)
+
+
+def test_entropy_false_positives() -> None:
+    payload = {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "hex": "aabbccddeeff00112233445566778899",
+        "token_count": 12,
+        "note": "a" * 48,
+    }
+    assert scan_secrets(payload) == []
+    session = scan_secrets({"session_token": _ENTROPY})
+    assert session and session[0].kind == "entropy"
+
+
+def test_caller_arguments_are_immutable() -> None:
+    payload = {"api_key": _FAKE, "nested": [_FAKE_PASS]}
+    original = copy.deepcopy(payload)
+    scan_secrets(payload)
+    sanitize_secrets(payload)
+    assert payload == original
+
+
+def test_error_policy_blocks_before_claim_and_side_effects() -> None:
+    storage = InMemoryLedgerStorage()
+    ran: list[str] = []
+
+    @declare_secret_fields("api_key")
+    def charge(api_key: str) -> str:
+        ran.append("body")
+        return "ok"
+
+    wrapped = apply_secret_args(
+        ledger_sync(storage=storage, transition_binding=_binding())(charge),
+        _policy("error"),
+        tool_name="charge",
+        secret_fields=["api_key"],
+        consequential=True,
+    )
+    with execution_scope(TransitionScope(thread_id="t", run_id="r")):
+        with pytest.raises(SecretInArgsError) as caught:
+            wrapped(api_key=_FAKE, request_id="rid-raw")
+    _assert_absent(str(caught.value))
+    assert ran == []
+    assert storage.get("rid-raw") is None
+
+
+def test_redact_policy_fails_closed_for_consequential_secrets() -> None:
+    def echo(api_key: str) -> str:
+        return api_key
+
+    wrapped = apply_secret_args(
+        echo,
+        _policy("redact"),
+        tool_name="echo",
+        secret_fields=["api_key"],
+        consequential=True,
+    )
+    with pytest.raises(SecretInArgsError):
+        wrapped(api_key=_FAKE)
+
+
+def test_redact_policy_safe_copy_for_read_only_entropy() -> None:
+    def echo(session_token: str) -> str:
+        return session_token
+
+    wrapped = apply_secret_args(
+        echo,
+        _policy("redact"),
+        tool_name="echo",
+        consequential=False,
+    )
+    assert wrapped(session_token=_ENTROPY) == REDACTED_MARKER
+
+
+def test_warn_policy_runs_but_sanitizes_evidence() -> None:
+    storage = InMemoryLedgerStorage()
+    receipts = InMemoryAuditReceiptStorage()
+    outcomes = InMemoryOutcomeStorage()
+
+    def charge(api_key: str) -> dict[str, str]:
+        return {"status": "ok"}
+
+    wrapped = apply_secret_args(
+        ledger_sync(
+            storage=storage,
+            transition_binding=_binding(),
+            audit_emitter=AuditReceiptEmitter(
+                agent_id="t",
+                signing_key="unit-test-signing-key",
+                storage=receipts,
+            ),
+            outcome_emitter=OutcomeEmitter(agent_id="t", storage=outcomes),
+        )(charge),
+        _policy("warn"),
+        tool_name="charge",
+        consequential=True,
+    )
+    with execution_scope(TransitionScope(thread_id="t", run_id="r")):
+        assert wrapped(api_key=_FAKE, request_id="rid-warn") == {"status": "ok"}
+    entry = storage.get("rid-warn")
+    assert entry is not None
+    _assert_absent(entry.to_dict())
+    _assert_absent([item.to_dict() for item in receipts.list_all()])
+    _assert_absent([item.to_dict() for item in outcomes.list_all()])
+
+
+def test_reference_resolution_timing_and_sanitized_resolver_error() -> None:
+    events: list[str] = []
+
+    class TimedStorage(InMemoryLedgerStorage):
+        def try_claim_inflight(self, entry, *, lease_ttl: float = 3600.0):
+            events.append("claim")
+            return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+    def resolver(reference: str) -> str:
+        events.append("resolve")
+        if reference.endswith("missing"):
+            raise RuntimeError(f"missing {_FAKE}")
+        return _FAKE
+
+    register_secret_resolver(resolver)
+    seen: list[str] = []
+
+    @declare_secret_fields("api_key")
+    def charge(api_key: str) -> str:
+        events.append("body")
+        seen.append(api_key)
+        return "ok"
+
+    wrapped = apply_secret_args(
+        ledger_sync(storage=TimedStorage(), transition_binding=_binding())(charge),
+        _policy("error"),
+        tool_name="charge",
+        secret_fields=["api_key"],
+        consequential=True,
+    )
+    with execution_scope(TransitionScope(thread_id="t", run_id="r")):
+        wrapped(api_key=_REF, request_id="rid-ref")
+    assert events[:3] == ["claim", "resolve", "body"]
+    assert seen == [_FAKE]
+    with pytest.raises(SecretInArgsError) as caught:
+        resolve_secret_reference("secret://stripe/unit/missing")
+    _assert_absent(str(caught.value))
+
+
+def test_async_parity_and_disabled_behavior() -> None:
+    async def echo(api_key: str) -> str:
+        return api_key
+
+    blocked = apply_secret_args(
+        echo, _policy("error"), tool_name="echo", consequential=True
+    )
+    with pytest.raises(SecretInArgsError):
+        asyncio.run(blocked(api_key=_FAKE))
+
+    omitted = SecretArgsPolicy(enabled=False)
+    passthrough = apply_secret_args(echo, omitted, tool_name="echo")
+    assert asyncio.run(passthrough(api_key=_FAKE)) == _FAKE
+
+
+def test_fingerprints_preserve_identity_without_raw_hashes() -> None:
+    args = (1,)
+    kwargs = {"q": "plain"}
+    assert fingerprint_args(args, kwargs) == args_fingerprint(args, kwargs)
+    token = set_active_secret_policy(_policy("error"))
+    try:
+        secret_fp = fingerprint_args((), {"api_key": _FAKE})
+        other_fp = fingerprint_args((), {"api_key": "other-fake"})
+        assert secret_fp == other_fp
+        assert secret_fp == fingerprint_args((), {"api_key": REDACTED_MARKER})
+    finally:
+        reset_active_secret_policy(token)
+
+
+def test_hmac_correlation_never_stores_raw_value() -> None:
+    register_secret_hmac_key(b"unit-hmac-key")
+    digest = secret_hmac_digest(_FAKE)
+    assert digest.startswith(f"{REDACTED_MARKER}:hmac:")
+    _assert_absent(digest)
+
+
+def test_logging_and_cli_text_are_redacted(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("mycelium.secret_protection")
+    apply_secret_args(lambda: None, _policy("warn"), tool_name="noop")
+    with caplog.at_level(logging.WARNING, logger="mycelium"):
+        logger.warning("token=%s", _FAKE)
+    _assert_absent(caplog.text)
+    _assert_absent(sanitize_text(f"password={_FAKE_PASS}"))
+
+
+def test_doctor_and_verify_render_redact() -> None:
+    from mycelium.doctor.render import render_json as doctor_json
+    from mycelium.doctor.types import DoctorCheck, DoctorReport
+    from mycelium.verify.render import render_json as verify_json
+    from mycelium.verify.types import VerificationEvidence, VerificationReport, VerificationStatus
+
+    report = DoctorReport(
+        overall_status=DoctorStatus.PASS,
+        profile="development",
+        checks=[
+            DoctorCheck(
+                id="x",
+                category="Secret-in-args",
+                status=DoctorStatus.PASS,
+                summary=f"ok {_FAKE}",
+            )
+        ],
+    )
+    _assert_absent(doctor_json(report))
+    evidence = VerificationEvidence(
+        scenario="secret-in-args",
+        backend="memory",
+        namespace="mycelium:verify:x:",
+        summary=f"ok {_FAKE}",
+        status=VerificationStatus.PASS,
+    )
+    vreport = VerificationReport(
+        overall_status=VerificationStatus.PASS,
+        config_path="x.yaml",
+        profile="development",
+        topology=None,
+        backend="memory",
+        scenarios=[evidence],
+    )
+    _assert_absent(verify_json(vreport))
+
+
+def test_production_rejects_weaker_secret_policy() -> None:
+    with pytest.raises(ConfigError, match="secret_args.policy"):
+        load_config_from_string(
+            """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [charge]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+secret_args:
+  enabled: true
+  policy: warn
+tools:
+  charge:
+    side_effect_class: non_idempotent_mutate
+"""
+        )
+
+
+def test_omitted_and_invalid_config() -> None:
+    cfg = load_config_from_string("tools:\n  search:\n    side_effect_class: read\n")
+    assert cfg.secret_args is None
+    assert cfg.secret_args_applies("search") is False
+    with pytest.raises(ConfigError, match="unsupported"):
+        load_config_from_string("secret_args:\n  hmac_key: nope\n")
+    with pytest.raises(ConfigError, match="policy"):
+        load_config_from_string("secret_args:\n  policy: drop\n")
+    with pytest.raises(ConfigError, match="allow_fields"):
+        load_config_from_string("secret_args:\n  allow_fields: [1]\n")
+
+
+def test_thread_and_process_scan() -> None:
+    results: list[int] = []
+
+    def worker() -> None:
+        results.append(len(scan_secrets({"password": "x"})))
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for item in threads:
+        item.start()
+    for item in threads:
+        item.join()
+    assert results == [1] * 8
+    with mp.get_context("spawn").Pool(1) as pool:
+        count = pool.apply(_child_scan, ({"api_key": "x"},))
+    assert count == 1
+
+
+def _child_scan(payload: dict[str, Any]) -> int:
+    from mycelium.secret_protection import scan_secrets as scan
+
+    return len(scan(payload))
+
+
+def test_public_helpers() -> None:
+    assert is_secret_reference(_REF)
+    assert not is_secret_reference("https://example.com")
+    register_secret_resolver(lambda ref: "resolved")
+    assert resolve_secret_reference(_REF) == "resolved"
+    safe = sanitize_for_evidence({"api_key": _FAKE})
+    _assert_absent(safe)
+    exc = sanitize_exception(RuntimeError(f"boom {_FAKE}"))
+    _assert_absent(str(exc))
+    assert isinstance(exc, RuntimeError)
+
+
+def test_args_drift_unchanged_without_secrets() -> None:
+    storage = InMemoryLedgerStorage()
+    calls = {"n": 0}
+
+    def search(q: str) -> str:
+        calls["n"] += 1
+        return q
+
+    wrapped = ledger_sync(
+        storage=storage,
+        transition_binding=ToolTransitionBinding.for_tool(
+            agent_id="t",
+            policy_version="test",
+            side_effect_class=SideEffectClass.READ,
+        ),
+        on_args_drift=ARGS_DRIFT_HARD,
+    )(search)
+    with execution_scope(TransitionScope(thread_id="t", run_id="r")):
+        assert wrapped(q="one", request_id="rid-plain") == "one"
+        assert wrapped(q="one", request_id="rid-plain") == "one"
+    assert calls["n"] == 1

--- a/sdk/tests/test_verify.py
+++ b/sdk/tests/test_verify.py
@@ -455,6 +455,7 @@ def test_cli_smoke_each_scenario(tmp_path: Path) -> None:
         "worker-crash",
         "ambiguous-effect",
         "reconcile",
+        "secret-in-args",
     ):
         code = main(
             [
@@ -664,6 +665,7 @@ def test_all_order_sqlite(tmp_path: Path, scenario: str) -> None:
         "worker-crash",
         "ambiguous-effect",
         "reconcile",
+        "secret-in-args",
     ]
     assert all(item.status == VerificationStatus.PASS for item in report.scenarios)
     assert report.empirically_verified is True


### PR DESCRIPTION
## Summary
- Optional `secret_args:` scans tool arguments before claim, fingerprinting, receipts, execution, logs, and outcomes. Omitted config keeps the existing runtime.
- Pass `secret://` references; apps must `register_secret_resolver`. Fail-closed is primary; redaction is defense-in-depth.
- Docs, templates, Doctor, and `mycelium verify --scenario secret-in-args` are updated. Version is **not** bumped — do not release yet.

## Test plan
- [x] Focused `test_secret_protection.py` plus Doctor/Verify/production-profile coverage
- [x] Full suite (1078 passed, 6 skipped) and Ruff
- [ ] Review CHANGELOG Unreleased + catalog AF-010 copy
- [ ] Confirm no `sdk/pyproject.toml` version bump before merge