### PR TITLE
Add destination-policy entity_guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ### Added
 
+- **Entity / destination guard:** optional `entity_guard:` authorizes write
+  destinations (email, https URL, host, entity id) before ledger claim.
+  Each tool declares which argument is the destination; the host lists
+  exact allowed entities or constrained patterns. Destinations are
+  canonicalized (lowercase email/host, parsed https URL, normalized id).
+  Missing, malformed, dynamic, undeclared, or unapproved destinations
+  fail closed. Canonical destinations are bound into the operation
+  fingerprint so a retry cannot change recipients on the same
+  `request_id`. Evidence records tool, destination class / approved
+  entity id, policy version, and decision — never the sensitive payload.
+  Allowlists are host-controlled; the model cannot add recipients.
+  Omitted `entity_guard:` keeps existing behavior. Production requires
+  `missing_policy: error`. `mycelium doctor` reports coverage;
+  `mycelium verify --scenario entity-guard` proves unauthorized
+  destinations never claim.
+
 - **Secret-in-args (AF-010):** optional `secret_args:` scans tool arguments
   before claim, fingerprinting, receipts, execution, logs, and outcomes.
   Default omitted config keeps existing behavior. `policy: error` raises

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Mycelium wraps tool calls after the LLM returns `tool_calls` and returns a verdi
 - **AF-004 Tool misuse** — `@bounded` / registry · block bad args (incl. `array` / `object`) and out-of-scope tools / paths
 - **Budget / runaway spend (unnumbered)** — `budget:` · ceilings + `@budget_guard` / `instrument_llm` (auto `check("llm")`) · `mycelium budget release`
 - **AF-010 Secret-in-args** — `secret_args:` · block raw credentials before claim · pass `secret://` references · `mycelium verify --scenario secret-in-args`
+- **Entity / destination guard (unnumbered)** — `entity_guard:` · write tools declare the destination argument · host allowlist · fail closed before claim · `mycelium verify --scenario entity-guard`
 - **AF-006 Context corruption** — `@protect` / Session · optional message/history validation
 - **AF-007 Premature termination** — `completion:` host checklist · refuse or warn-and-allow
 - **AF-008 Scope escalation** — `scope_guard:` freeze allowlist · re-check every step

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -63,6 +63,7 @@ Mycelium sits between your agent loop and your tools (after the LLM returns `too
 | **Opt-in** | **AF-003 Infinite action loops** | `loop_guard:` — action-hash streak across *new* `tool_call_id`s; soft then hard; operator `mycelium loops release` |
 | **Opt-in** | **Budget / runaway spend (unnumbered)** | `budget:` — `max_duration` / `max_steps` / `max_tokens` / `max_usd`; tools auto-wrapped; **LLM turns auto-wired** on LangGraph/LangChain; `missing_usage_policy`; operator `mycelium budget release` |
 | **Opt-in** | **AF-010 Secret-in-args** | `secret_args:` — block raw credentials before claim; pass `secret://` references; shared sanitizer on evidence. Fail-closed is primary; redaction is defense-in-depth |
+| **Opt-in** | **Entity / destination guard (unnumbered)** | `entity_guard:` — a write may carry sensitive data only into a host-authorized destination; unknown destination means no execution |
 | **Opt-in** | **AF-004 Tool misuse** | `@bounded` input/output/scope checks; optional `ToolRegistry` allowlist — block before the tool runs |
 | **Opt-in** | **AF-006 Context corruption** | TTL cache (`@protect` / `Session`); optional `MessageValidator` / `HistoryGuard` before the next LLM turn |
 | **Opt-in** | **AF-007 Premature termination** | `completion:` — host checklist; unmarked **required** → refuse terminal; unmarked **optional** → warn and allow |
@@ -1105,8 +1106,9 @@ run. LangGraph's adapter copies an existing framework `run_id` into
 `execution_scope` — do not pass a duplicate when the adapter already provides
 one.
 
-Wrapper order: `@secret_args` → `@state_authority` → `@scope_guard` →
-`@budget_guard` → `@loop_guard` → `@ledger` → `@bounded` → `@protect` → `func`.
+Wrapper order: `@secret_args` → `@entity_guard` → `@state_authority` →
+`@scope_guard` → `@budget_guard` → `@loop_guard` → `@ledger` → `@bounded` →
+`@protect` → `func`.
 
 ### Budget guard (unnumbered)
 
@@ -1232,6 +1234,61 @@ labels host logs / third-party providers `not_verifiable`.
 `mycelium verify --scenario secret-in-args` searches generated artifacts
 for synthetic credentials.
 
+### Entity / destination guard (unnumbered)
+
+A write may contain sensitive data, but it can only cross into a destination
+the host explicitly authorized. Unknown destination means no execution. This
+is a tool-boundary allowlist, not prompt scanning.
+
+```yaml
+entity_guard:
+  enabled: true
+  missing_policy: error
+
+  tools:
+    send_email:
+      destinations:
+        - path: recipient
+          type: email
+          allow:
+            addresses: [billing@customer.com]
+            domains: [customer.com]
+        - path: cc
+          type: email
+          allow: []
+          required: false
+    http_post:
+      destinations:
+        - path: url
+          type: https_url
+          allow:
+            hosts: [api.stripe.com, hooks.slack.com]
+          reject_redirects: true
+    create_ticket:
+      destinations:
+        - path: project_id
+          type: entity_id
+          allow:
+            values: [SUPPORT, INCIDENTS]
+```
+
+Each consequential write tool declares which argument is the destination.
+Mycelium canonicalizes it (lowercase email domains/hosts, parsed https URL,
+normalized ids) and checks every recipient — `to` / `cc` / `bcc`, webhook
+URLs, redirect targets, and nested destination fields. Missing, malformed,
+dynamic, undeclared, or unapproved destinations raise `EntityGuardError`
+before ledger claim. Canonical destinations are bound into the operation
+fingerprint so a retry cannot change recipients on the same `request_id`.
+Evidence records tool, destination class or approved entity id, policy
+version, and decision — never the payload. Allowlists are host-controlled;
+the model cannot add recipients. Omitted `entity_guard:` keeps existing
+behavior. Production requires `missing_policy: error`.
+
+`mycelium doctor` reports whether destination policy is enabled and which
+consequential tools lack a declaration.
+`mycelium verify --scenario entity-guard` proves unauthorized destinations
+never claim.
+
 ### Scope guard (AF-008): freeze run tool allowlist
 
 AF-008 is when a narrow grant **widens mid-run** (handoff, dynamic
@@ -1262,7 +1319,7 @@ with execution_scope(TransitionScope(run_id="r1", thread_id="t")):
     fetch_customer(customer_id="c1")  # ok; tools outside the freeze soft-block
 ```
 
-Wrapper order: `@secret_args` → `@scope_guard` → `@loop_guard` → `@ledger` →
+Wrapper order: `@secret_args` → `@entity_guard` → `@scope_guard` → `@loop_guard` → `@ledger` →
 `@bounded` → `@protect`. CLI: `mycelium scope status|bind`. Demo:
 `python examples/scope_guard_allowlist.py` (from `sdk/`).
 
@@ -1378,7 +1435,7 @@ def refund(amount: float, *, tool_call_id: str, state_ref: str) -> dict:
     ...
 ```
 
-Wrapper order: `@secret_args` → `@state_authority` → `@scope_guard` →
+Wrapper order: `@secret_args` → `@entity_guard` → `@state_authority` → `@scope_guard` →
 `@loop_guard` → `@ledger` → `@bounded` → `@protect` → `func`.
 
 `decision_id` / `state_ref` are bookkeeping kwargs (excluded from the args
@@ -1542,6 +1599,8 @@ policies:
 - `secret_args.policy: error` when `secret_args:` is enabled and
   consequential tools exist. Weaker `warn` / `redact` under production
   is rejected. Omitted `secret_args:` stays backward compatible.
+- `entity_guard.missing_policy: error` when `entity_guard:` is enabled.
+  Omitted `entity_guard:` stays backward compatible.
 
 Explicit weaker settings (`warn`, `derived`, memory outcomes) under
 production are rejected (`ConfigError`), not silently weakened. Omit
@@ -1623,6 +1682,7 @@ $ mycelium doctor --config mycelium.yaml --strict --json   # CI gate
 It checks profile defaults, tool classification, business request identity,
 durable ActionLedger / outcome backends, run-id guard policies, completion and
 budget adapter selection, secret-in-args scanning / fail-closed production,
+destination-policy coverage,
 and optional `deployment.topology`. It never executes
 application tools, never calls an LLM, never writes ledger/outcome rows, and
 never repairs config.
@@ -1645,7 +1705,7 @@ $ mycelium verify --config mycelium.yaml --scenario all --strict --json
 ```
 
 Scenarios: `redispatch`, `contention`, `storage-outage`, `worker-crash`,
-`ambiguous-effect`, `reconcile`, `secret-in-args`, or `all` (that order). Verify never executes
+`ambiguous-effect`, `reconcile`, `secret-in-args`, `entity-guard`, or `all` (that order). Verify never executes
 application tools, never calls an LLM, never contacts a real business provider,
 and never inspects or alters existing production transitions. Test data uses a
 unique `mycelium:verify:<uuid>:` namespace and is deleted unless

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -213,6 +213,14 @@ section; the tests are concrete `file::test_name` entries.
     declared fields. Omitted `secret_args:` keeps pre-AF-010 behavior.
     *Where:* [Secret-in-args (AF-010)](../README.md#secret-in-args-af-010).
 
+18. **Destination policy (when `entity_guard:` is enabled).** A write may
+    carry sensitive payload only into a host-authorized destination.
+    Missing, malformed, dynamic, undeclared, or unapproved recipients /
+    hosts / entity ids fail closed before claim. Canonical destinations
+    are bound into the operation fingerprint. Evidence never stores the
+    payload. Omitted `entity_guard:` keeps existing behavior.
+    *Where:* [Entity / destination guard](../README.md#entity--destination-guard-unnumbered).
+
 ---
 
 ## D. What we do not protect
@@ -331,6 +339,7 @@ are cited once. "Where documented" links the README section.
 | Key derivation soundness | README § [Transition identity and host-owned `request_id`](../README.md#transition-identity-and-host-owned-request_id) | `test_transition.py::test_same_inputs_produce_same_transition_key` · `test_transition.py::test_different_tool_call_id_produces_different_key` · `test_transition.py::test_ledger_deduplicates_by_transition_key` · `test_property_transitions.py::test_transition_key_invariants` (property test) · `test_explicit_request_id.py` |
 | Task-level idempotency | README § [Quickstart: task-level idempotency](../README.md#quickstart-task-level-idempotency) | `test_cli_run.py::test_run_instruments_sync_tool_and_task_across_processes` |
 | Secret-in-args (when enabled) | README § [Secret-in-args (AF-010)](../README.md#secret-in-args-af-010) | `test_secret_protection.py` · `test_verify.py::test_cli_smoke_each_scenario` (`secret-in-args`) |
+| Destination policy (when enabled) | README § [Entity / destination guard](../README.md#entity--destination-guard-unnumbered) | `test_entity_guard.py` · `test_verify.py::test_cli_smoke_each_scenario` (`entity-guard`) |
 | Single-key state machine invariants (executions ≤ 1 + not-executed verdicts; COMPLETED terminal; CAS out of IN_FLIGHT) | this doc, § C / [NOT_EXECUTED reset CAS](../README.md#not_executed-reset-cas-v118) | `test_property_transitions.py::test_transition_key_invariants` (Hypothesis, file + Redis) · `test_payment_provider_mock.py::test_redispatch_storm_never_double_charges` |
 
 <sup>1</sup> `test_postgres_storage_atomic_claim` runs when `psycopg` is

--- a/sdk/docs/FAILURE_MODE_CATALOG.md
+++ b/sdk/docs/FAILURE_MODE_CATALOG.md
@@ -17,6 +17,7 @@ LangGraph, CrewAI, AutoGen, Cline, OpenHands, and related stacks.
 | AF-008 | Cascading permission | `scope_guard:` / `@scope_guard` |
 | AF-009 | Instruction injection | (MCP gateway revisit; not in SDK) |
 | AF-010 | Secret-in-args | `secret_args:` / `SecretInArgsError` · `secret://` references · shared sanitizer |
+| — | Exfil via write / destination policy | `entity_guard:` / `EntityGuardError` · host allowlist · fail closed before claim |
 
 ---
 
@@ -250,3 +251,5 @@ Budget is intentionally **not** given an AF-00N id. See
   are optional guards documented in the SDK README.
 - **Budget enforcement** ships as `budget:` / `@budget_guard` and is
   intentionally **not** given an AF-00N id. AF-010 is secret-in-args.
+- **Destination policy** ships as `entity_guard:` and is also unnumbered:
+  a write may carry sensitive data only into a host-authorized destination.

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -139,6 +139,16 @@ from mycelium.doctor import (
     run_doctor,
     run_doctor_on_config,
 )
+from mycelium.entity_guard import (
+    PAYLOAD_OMITTED,
+    EntityGuardError,
+    apply_entity_guard,
+    canonicalize_email,
+    canonicalize_entity_id,
+    canonicalize_host,
+    canonicalize_https_url,
+    enforce_entity_guard,
+)
 from mycelium.history_guard import HistoryGuard, HistoryTruncatedError
 from mycelium.loop_guard import (
     DEFAULT_CONSECUTIVE_SOFT,
@@ -469,6 +479,14 @@ __all__ = [
     "load_config_from_string",
     "protect",
     "protect_sync",
+    "PAYLOAD_OMITTED",
+    "EntityGuardError",
+    "apply_entity_guard",
+    "canonicalize_email",
+    "canonicalize_entity_id",
+    "canonicalize_host",
+    "canonicalize_https_url",
+    "enforce_entity_guard",
     "REDACTED_MARKER",
     "SecretInArgsError",
     "declare_secret_fields",

--- a/sdk/mycelium/__main__.py
+++ b/sdk/mycelium/__main__.py
@@ -1127,7 +1127,7 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Scenario to run (repeatable): redispatch, contention, "
             "worker-crash, storage-outage, ambiguous-effect, reconcile, "
-            "secret-in-args, or all"
+            "secret-in-args, entity-guard, or all"
         ),
     )
     verify_parser.add_argument(

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -3291,26 +3291,38 @@ def _args_drift_exclude_keys(
 
 
 def _evidence_value(value: Any) -> Any:
+    from mycelium.entity_guard import get_active_entity_policy, sanitize_entity_evidence
     from mycelium.secret_protection import get_active_secret_policy, sanitize_for_evidence
 
+    result = value
     policy = get_active_secret_policy()
-    if policy is None or not policy.enabled:
-        return value
-    return sanitize_for_evidence(value)
+    if policy is not None and policy.enabled:
+        result = sanitize_for_evidence(result)
+    if get_active_entity_policy() is not None:
+        if isinstance(result, dict):
+            _args, scrubbed = sanitize_entity_evidence((), result)
+            del _args
+            return scrubbed
+    return result
 
 
 def _evidence_args(args: Any, kwargs: Any) -> tuple[list[Any], dict[str, Any]]:
+    from mycelium.entity_guard import get_active_entity_policy, sanitize_entity_evidence
     from mycelium.secret_protection import get_active_secret_policy, sanitize_secrets
 
+    out_args: list[Any] = list(args)
+    out_kwargs: dict[str, Any] = dict(kwargs)
     policy = get_active_secret_policy()
-    if policy is None or not policy.enabled:
-        return list(args), dict(kwargs)
-    safe = sanitize_secrets(
-        {"args": list(args), "kwargs": dict(kwargs)},
-        entropy_detection=policy.entropy_detection,
-        allow_fields=policy.allow_fields,
-    )
-    return list(safe["args"]), dict(safe["kwargs"])
+    if policy is not None and policy.enabled:
+        safe = sanitize_secrets(
+            {"args": out_args, "kwargs": out_kwargs},
+            entropy_detection=policy.entropy_detection,
+            allow_fields=policy.allow_fields,
+        )
+        out_args, out_kwargs = list(safe["args"]), dict(safe["kwargs"])
+    if get_active_entity_policy() is not None:
+        out_args, out_kwargs = sanitize_entity_evidence(out_args, out_kwargs)
+    return out_args, out_kwargs
 
 
 def _evidence_error(error: BaseException) -> str:
@@ -3341,9 +3353,19 @@ def _args_drift_fingerprint(
         else {key: value for key, value in kwargs.items() if key not in exclude}
     )
     policy = get_active_secret_policy()
-    if policy is not None and policy.enabled:
-        return fingerprint_args(args, filtered)
-    return args_fingerprint(args, filtered)
+    digest = (
+        fingerprint_args(args, filtered)
+        if policy is not None and policy.enabled
+        else args_fingerprint(args, filtered)
+    )
+    from mycelium.entity_guard import destination_fingerprint, get_active_entity_decision
+
+    dests = destination_fingerprint(get_active_entity_decision())
+    if not dests:
+        return digest
+    import hashlib
+
+    return hashlib.sha256(f"{digest}|{'|'.join(dests)}".encode()).hexdigest()
 
 
 def _args_drift_scope_key(kwargs: dict[str, Any]) -> str | None:

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -57,6 +57,17 @@ from mycelium.completion_contract import (
     registered_terminal_adapters,
     set_active_completion_contract,
 )
+from mycelium.entity_guard import (
+    DEST_TYPES,
+    MISSING_POLICIES,
+    MISSING_POLICY_ERROR,
+    DestinationAllow,
+    DestinationSpec,
+    EntityGuardPolicy,
+    ToolDestinationPolicy,
+    apply_entity_guard,
+    entity_guard_policy_for_tool,
+)
 from mycelium.history_guard import HistoryGuard
 from mycelium.integrations.langgraph import (
     LangGraphIntegrationError,
@@ -190,6 +201,7 @@ _GUARD_MARKERS = (
     "_mycelium_scope_guarded",
     "_mycelium_state_authority",
     "_mycelium_secret_args",
+    "_mycelium_entity_guard",
     "_mycelium_langgraph_integration",
 )
 
@@ -310,6 +322,8 @@ class ToolConfig:
     secret_fields: tuple[str, ...] = ()
     # Per-tool secret_args: None=inherit global, False=disable
     secret_args: bool | None = None
+    # Per-tool entity_guard: None=inherit global, False=disable
+    entity_guard: bool | None = None
 
     def is_noop(self) -> bool:
         return (
@@ -323,6 +337,7 @@ class ToolConfig:
             and self.state_authority is None
             and not self.secret_fields
             and self.secret_args is None
+            and self.entity_guard is None
         )
 
 
@@ -373,6 +388,7 @@ class MyceliumConfig:
     deployment: dict[str, Any] | None = None
     verify: dict[str, Any] | None = None
     secret_args: dict[str, Any] | None = None
+    entity_guard: dict[str, Any] | None = None
     profile: str = PROFILE_DEVELOPMENT
     _audit_emitter: AuditReceiptEmitter | None = None
     _outcome_emitter: OutcomeEmitter | None = None
@@ -394,9 +410,9 @@ class MyceliumConfig:
         function is returned unchanged.
 
         Guard order (outermost first, after optional LangGraph instrument):
-        ``@secret_args`` -> ``@state_authority`` -> ``@scope_guard`` ->
-        ``@budget_guard`` -> ``@loop_guard`` -> ``@ledger`` -> ``@bounded`` ->
-        ``@protect`` -> ``func``
+        ``@secret_args`` -> ``@entity_guard`` -> ``@state_authority`` ->
+        ``@scope_guard`` -> ``@budget_guard`` -> ``@loop_guard`` ->
+        ``@ledger`` -> ``@bounded`` -> ``@protect`` -> ``func``
         """
         return self.apply_tool(func.__name__, func)
 
@@ -486,6 +502,20 @@ class MyceliumConfig:
             return False
         return True
 
+    def entity_guard_applies(
+        self, name: str, tool_config: ToolConfig | None = None
+    ) -> bool:
+        """Whether destination-policy checking should wrap this tool."""
+        if self.entity_guard is None:
+            return False
+        policy = entity_guard_policy_from_mapping(self.entity_guard)
+        if not policy.enabled:
+            return False
+        cfg = tool_config if tool_config is not None else self.tools.get(name)
+        if cfg is not None and cfg.entity_guard is False:
+            return False
+        return name in policy.tools
+
     def apply_tool(
         self,
         name: str,
@@ -500,6 +530,7 @@ class MyceliumConfig:
         applies_scope = self.scope_guard_applies(name, tool_config)
         applies_state = self.state_authority_applies(name, tool_config)
         applies_secret = self.secret_args_applies(name, tool_config)
+        applies_entity = self.entity_guard_applies(name, tool_config)
         if tool_config.secret_fields:
             setattr(func, "_mycelium_secret_fields", tool_config.secret_fields)
         if (
@@ -509,6 +540,7 @@ class MyceliumConfig:
             and not applies_scope
             and not applies_state
             and not applies_secret
+            and not applies_entity
         ):
             return func
         if _check_existing_config_wrapper(func, kind="tool", name=name):
@@ -611,6 +643,33 @@ class MyceliumConfig:
                 side_effect_class=tool_config.side_effect_class,
             )
 
+        # Destination policy outside claim: unauthorized recipients never execute.
+        if applies_entity:
+            from dataclasses import replace as _replace_policy
+
+            policy = entity_guard_policy_from_mapping(self.entity_guard or {})
+            if (
+                policy.policy_version == "unspecified"
+                and self.transition is not None
+            ):
+                policy = _replace_policy(
+                    policy, policy_version=self.transition.policy_version
+                )
+            if (
+                self.profile == PROFILE_PRODUCTION
+                and policy.missing_policy != MISSING_POLICY_ERROR
+            ):
+                raise ConfigError(
+                    f"profile is {PROFILE_PRODUCTION!r} but "
+                    f"entity_guard.missing_policy is {policy.missing_policy!r}; "
+                    "production requires 'error'"
+                )
+            func = apply_entity_guard(
+                func,
+                entity_guard_policy_for_tool(policy, name),
+                tool_name=name,
+            )
+
         # Secret-in-args outside every other guard: scan before claim/fingerprint.
         if applies_secret:
             from mycelium.transition import CONSEQUENTIAL_SIDE_EFFECT_CLASSES
@@ -646,6 +705,7 @@ class MyceliumConfig:
             or applies_scope
             or applies_state
             or applies_secret
+            or applies_entity
         ):
             try:
                 func = instrument_langgraph_tool(func)
@@ -2017,6 +2077,15 @@ def _parse_tool_config(
     else:
         raise ConfigError(f"tool '{name}'.secret_args must be a bool")
 
+    entity_guard_raw = raw.get("entity_guard")
+    entity_guard_cfg: bool | None
+    if entity_guard_raw is None:
+        entity_guard_cfg = None
+    elif isinstance(entity_guard_raw, bool):
+        entity_guard_cfg = entity_guard_raw
+    else:
+        raise ConfigError(f"tool '{name}'.entity_guard must be a bool")
+
     return ToolConfig(
         name=name,
         protect=protect,
@@ -2037,6 +2106,7 @@ def _parse_tool_config(
         state_authority=state_authority_cfg,
         secret_fields=secret_fields,
         secret_args=secret_args_cfg,
+        entity_guard=entity_guard_cfg,
     )
 
 
@@ -2143,6 +2213,7 @@ def _apply_action_ledger_tools(
             state_authority=existing.state_authority,
             secret_fields=existing.secret_fields,
             secret_args=existing.secret_args,
+            entity_guard=existing.entity_guard,
         )
 
 
@@ -2810,6 +2881,187 @@ def _parse_secret_args(
     return parsed
 
 
+def entity_guard_policy_from_mapping(raw: dict[str, Any]) -> EntityGuardPolicy:
+    """Build a :class:`EntityGuardPolicy` from a validated mapping."""
+    tools: dict[str, ToolDestinationPolicy] = {}
+    for name, tool_raw in (raw.get("tools") or {}).items():
+        destinations = []
+        for spec in tool_raw.get("destinations") or []:
+            allow_raw = spec.get("allow") or {}
+            destinations.append(
+                DestinationSpec(
+                    path=str(spec["path"]),
+                    dest_type=str(spec["type"]),
+                    allow=DestinationAllow(
+                        addresses=frozenset(
+                            str(item).strip().lower()
+                            for item in (allow_raw.get("addresses") or [])
+                        ),
+                        domains=frozenset(
+                            str(item).strip().lower()
+                            for item in (allow_raw.get("domains") or [])
+                        ),
+                        hosts=frozenset(
+                            str(item).strip().lower()
+                            for item in (allow_raw.get("hosts") or [])
+                        ),
+                        values=frozenset(
+                            str(item).strip() for item in (allow_raw.get("values") or [])
+                        ),
+                    ),
+                    required=bool(spec.get("required", True)),
+                    reject_redirects=bool(spec.get("reject_redirects", True)),
+                )
+            )
+        tools[str(name)] = ToolDestinationPolicy(destinations=tuple(destinations))
+    return EntityGuardPolicy(
+        enabled=bool(raw.get("enabled", True)),
+        missing_policy=str(raw.get("missing_policy", MISSING_POLICY_ERROR)),
+        policy_version=str(raw.get("policy_version") or "unspecified"),
+        tools=tools,
+    )
+
+
+def _parse_string_list(raw: Any, *, field: str) -> list[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or not all(
+        isinstance(item, str) and item.strip() for item in raw
+    ):
+        raise ConfigError(f"'{field}' must be a list of non-empty strings")
+    return [str(item).strip() for item in raw]
+
+
+def _parse_destination_spec(raw: Any, *, tool: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ConfigError(f"entity_guard.tools.{tool}.destinations entries must be mappings")
+    allowed_keys = {"path", "type", "allow", "required", "reject_redirects"}
+    unknown = set(raw) - allowed_keys
+    if unknown:
+        names = ", ".join(sorted(str(name) for name in unknown))
+        raise ConfigError(
+            f"unsupported entity_guard.tools.{tool} destination option(s): {names}"
+        )
+    path = raw.get("path")
+    if not isinstance(path, str) or not path.strip():
+        raise ConfigError(f"entity_guard.tools.{tool} destination path is required")
+    dest_type = raw.get("type")
+    if dest_type not in DEST_TYPES:
+        raise ConfigError(
+            f"entity_guard.tools.{tool} destination type must be one of "
+            f"{sorted(DEST_TYPES)}, got {dest_type!r}"
+        )
+    allow_raw = raw.get("allow", {})
+    if allow_raw is None or allow_raw == []:
+        allow_raw = {}
+    if not isinstance(allow_raw, dict):
+        raise ConfigError(f"entity_guard.tools.{tool} destination allow must be a mapping")
+    allow_keys = {"addresses", "domains", "hosts", "values"}
+    unknown_allow = set(allow_raw) - allow_keys
+    if unknown_allow:
+        names = ", ".join(sorted(str(name) for name in unknown_allow))
+        raise ConfigError(
+            f"unsupported entity_guard.tools.{tool} allow option(s): {names}"
+        )
+    required = raw.get("required", True)
+    if not isinstance(required, bool):
+        raise ConfigError(f"entity_guard.tools.{tool} destination required must be a bool")
+    reject_redirects = raw.get("reject_redirects", True)
+    if not isinstance(reject_redirects, bool):
+        raise ConfigError(
+            f"entity_guard.tools.{tool} destination reject_redirects must be a bool"
+        )
+    return {
+        "path": path.strip(),
+        "type": dest_type,
+        "allow": {
+            "addresses": _parse_string_list(
+                allow_raw.get("addresses"),
+                field=f"entity_guard.tools.{tool}.allow.addresses",
+            ),
+            "domains": _parse_string_list(
+                allow_raw.get("domains"),
+                field=f"entity_guard.tools.{tool}.allow.domains",
+            ),
+            "hosts": _parse_string_list(
+                allow_raw.get("hosts"), field=f"entity_guard.tools.{tool}.allow.hosts"
+            ),
+            "values": _parse_string_list(
+                allow_raw.get("values"), field=f"entity_guard.tools.{tool}.allow.values"
+            ),
+        },
+        "required": required,
+        "reject_redirects": reject_redirects,
+    }
+
+
+def _parse_entity_guard(data: dict[str, Any], *, profile: str) -> dict[str, Any] | None:
+    """Optional destination-policy section. Omitted keeps existing behavior."""
+    raw = data.get("entity_guard")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError("'entity_guard' must be a mapping")
+    allowed_keys = {"enabled", "missing_policy", "policy_version", "tools"}
+    unknown = set(raw) - allowed_keys
+    if unknown:
+        names = ", ".join(sorted(str(name) for name in unknown))
+        raise ConfigError(f"unsupported 'entity_guard' option(s): {names}")
+
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise ConfigError("'entity_guard.enabled' must be a boolean")
+    missing_policy = raw.get("missing_policy", MISSING_POLICY_ERROR)
+    if missing_policy not in MISSING_POLICIES:
+        raise ConfigError(
+            "'entity_guard.missing_policy' must be one of "
+            f"{sorted(MISSING_POLICIES)}, got {missing_policy!r}"
+        )
+    policy_version = raw.get("policy_version")
+    if policy_version is not None and (
+        not isinstance(policy_version, str) or not policy_version.strip()
+    ):
+        raise ConfigError("'entity_guard.policy_version' must be a non-empty string")
+    tools_raw = raw.get("tools", {})
+    if not isinstance(tools_raw, dict):
+        raise ConfigError("'entity_guard.tools' must be a mapping of tool names")
+
+    tools: dict[str, Any] = {}
+    for name, tool_raw in tools_raw.items():
+        if not isinstance(name, str) or not name.strip():
+            raise ConfigError("'entity_guard.tools' keys must be non-empty tool names")
+        if not isinstance(tool_raw, dict):
+            raise ConfigError(f"entity_guard.tools.{name} must be a mapping")
+        dests_raw = tool_raw.get("destinations")
+        if not isinstance(dests_raw, list) or not dests_raw:
+            raise ConfigError(
+                f"entity_guard.tools.{name}.destinations must be a non-empty list"
+            )
+        extra = set(tool_raw) - {"destinations"}
+        if extra:
+            names = ", ".join(sorted(str(item) for item in extra))
+            raise ConfigError(
+                f"unsupported entity_guard.tools.{name} option(s): {names}"
+            )
+        tools[name.strip()] = {
+            "destinations": [
+                _parse_destination_spec(item, tool=name.strip()) for item in dests_raw
+            ]
+        }
+
+    if enabled and profile == PROFILE_PRODUCTION and missing_policy != MISSING_POLICY_ERROR:
+        _reject_weaker_production_policy("entity_guard.missing_policy", str(missing_policy))
+
+    parsed = {
+        "enabled": enabled,
+        "missing_policy": str(missing_policy),
+        "tools": tools,
+    }
+    if policy_version is not None:
+        parsed["policy_version"] = str(policy_version).strip()
+    return parsed
+
+
 def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
     if not isinstance(data, dict):
         raise ConfigError("config root must be a mapping")
@@ -3048,6 +3300,7 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
             raise ConfigError("'state_authority.exclude' must be a list of tool names")
 
     secret_args_raw = _parse_secret_args(data, profile=profile, tools=tools)
+    entity_guard_raw = _parse_entity_guard(data, profile=profile)
 
     message_validator_raw = data.get("message_validator", False)
     if isinstance(message_validator_raw, dict):
@@ -3085,6 +3338,7 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
         deployment=deployment,
         verify=verify,
         secret_args=secret_args_raw,
+        entity_guard=entity_guard_raw,
         profile=profile,
         _audit_auto=audit_auto,
     )

--- a/sdk/mycelium/doctor/checks.py
+++ b/sdk/mycelium/doctor/checks.py
@@ -1353,6 +1353,102 @@ def check_secret_args(ctx: DoctorContext) -> Iterable[DoctorCheck]:
     )
 
 
+@doctor_check("entity_guard")
+def check_entity_guard(ctx: DoctorContext) -> Iterable[DoctorCheck]:
+    """Destination policy: writes may only reach host-authorized entities."""
+    cfg = ctx.config
+    raw = cfg.entity_guard
+    consequential = _consequential_tools(cfg)
+    declared = sorted((raw or {}).get("tools") or {}) if raw else []
+    missing = [name for name in consequential if name not in declared]
+
+    if raw is None:
+        yield _check(
+            id="entity.scanning",
+            category="Entity-guard",
+            status=DoctorStatus.SKIP,
+            summary="entity_guard is not configured (existing behavior)",
+            details=f"consequential_tools={consequential or 'none'}.",
+            remediation=(
+                "Add entity_guard: {enabled: true, missing_policy: error} "
+                "and declare destination paths per write tool. The model "
+                "must never add recipients to the allowlist."
+            ),
+            evidence=EVIDENCE_STATIC,
+            blocking=False,
+        )
+        return
+
+    enabled = bool(raw.get("enabled", True))
+    missing_policy = str(raw.get("missing_policy", "error"))
+    yield _check(
+        id="entity.scanning",
+        category="Entity-guard",
+        status=DoctorStatus.PASS if enabled else DoctorStatus.WARN,
+        summary=(
+            "Destination policy is enabled"
+            if enabled
+            else "Destination policy is configured but disabled"
+        ),
+        details=(
+            f"enabled={enabled}; missing_policy={missing_policy!r}; "
+            f"tools={declared or 'none'}"
+        ),
+        remediation="" if enabled else "Set entity_guard.enabled: true.",
+        evidence=EVIDENCE_STATIC,
+        blocking=not enabled,
+    )
+    fail_closed = enabled and missing_policy == "error"
+    if cfg.profile == PROFILE_PRODUCTION and declared:
+        yield _check(
+            id="entity.production_fail_closed",
+            category="Entity-guard",
+            status=DoctorStatus.PASS if fail_closed else DoctorStatus.FAIL,
+            summary=(
+                "Production destination checks fail closed"
+                if fail_closed
+                else "Production destination checks do not fail closed"
+            ),
+            details=f"missing_policy={missing_policy!r}; tools={declared}",
+            remediation=""
+            if fail_closed
+            else "Set entity_guard.missing_policy: error under profile: production.",
+            evidence=EVIDENCE_STATIC,
+        )
+    if enabled and missing:
+        yield _check(
+            id="entity.undeclared_tools",
+            category="Entity-guard",
+            status=DoctorStatus.WARN,
+            summary="Consequential tools have no destination declaration",
+            details=f"undeclared={missing}",
+            remediation=(
+                "Declare entity_guard.tools.<name>.destinations for each "
+                "write tool. Unknown destination means no execution."
+            ),
+            evidence=EVIDENCE_STATIC,
+            blocking=False,
+        )
+    elif enabled and declared:
+        yield _check(
+            id="entity.undeclared_tools",
+            category="Entity-guard",
+            status=DoctorStatus.PASS,
+            summary="Listed write tools declare destination paths",
+            details=f"tools={declared}",
+            evidence=EVIDENCE_STATIC,
+        )
+    yield _check(
+        id="entity.host_owned",
+        category="Entity-guard",
+        status=DoctorStatus.PASS if enabled else DoctorStatus.SKIP,
+        summary="Destination allowlists are host-controlled",
+        details="The model cannot add recipients, hosts, or entity IDs to the allowlist.",
+        evidence=EVIDENCE_STATIC,
+        blocking=False,
+    )
+
+
 def ensure_builtin_checks_registered() -> None:
     """Import side effect: decorators already registered this module's checks."""
     return None

--- a/sdk/mycelium/entity_guard.py
+++ b/sdk/mycelium/entity_guard.py
@@ -1,0 +1,1075 @@
+"""Destination-policy guard: writes may only reach host-authorized entities.
+
+A consequential write can carry sensitive payload, but it may cross only into
+a destination the host listed. Unknown, missing, malformed, or dynamic
+destinations fail closed before ledger claim. The model cannot mutate the
+allowlist. Policies live in host YAML / ``EntityGuardPolicy`` — never in
+prompt text.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import ipaddress
+from collections.abc import Callable, Mapping, Sequence
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field, replace
+from email.utils import getaddresses, parseaddr
+from typing import Any, ParamSpec, TypeVar
+from urllib.parse import unquote, urlsplit, urlunsplit
+
+from mycelium.tool_boundary import ToolBoundaryError
+from mycelium.transition import LEDGER_KWARG_KEYS
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+DEST_EMAIL = "email"
+DEST_HTTPS_URL = "https_url"
+DEST_ENTITY_ID = "entity_id"
+DEST_HOST = "host"
+DEST_TYPES = frozenset({DEST_EMAIL, DEST_HTTPS_URL, DEST_ENTITY_ID, DEST_HOST})
+
+MISSING_POLICY_ERROR = "error"
+MISSING_POLICY_WARN = "warn"
+MISSING_POLICIES = frozenset({MISSING_POLICY_ERROR, MISSING_POLICY_WARN})
+
+REASON_MISSING = "missing"
+REASON_MALFORMED = "malformed"
+REASON_DYNAMIC = "dynamic"
+REASON_NOT_ALLOWED = "not_allowed"
+REASON_UNDECLARED = "undeclared"
+
+PAYLOAD_OMITTED = "[PAYLOAD_OMITTED]"
+
+_EMAIL_FIELD_NAMES = frozenset(
+    {
+        "to",
+        "cc",
+        "bcc",
+        "recipient",
+        "recipients",
+        "from",
+        "sender",
+        "reply_to",
+        "reply-to",
+        "email",
+        "emails",
+    }
+)
+_URL_FIELD_NAMES = frozenset(
+    {
+        "url",
+        "uri",
+        "href",
+        "webhook",
+        "webhook_url",
+        "callback",
+        "callback_url",
+        "redirect",
+        "redirect_url",
+        "redirect_uri",
+        "endpoint",
+        "host",
+    }
+)
+_ID_FIELD_NAMES = frozenset(
+    {
+        "project_id",
+        "bucket",
+        "account",
+        "destination",
+        "workspace_id",
+        "org_id",
+        "team_id",
+        "channel_id",
+    }
+)
+_PAYLOAD_FIELD_NAMES = frozenset(
+    {
+        "body",
+        "content",
+        "text",
+        "html",
+        "message",
+        "payload",
+        "file",
+        "data",
+        "attachments",
+        "subject",
+        "title",
+        "description",
+        "markdown",
+        "bytes",
+    }
+)
+_HOMOGLYPH_DOTS = ("\u3002", "\uff0e", "\uff61", "\u2024")
+_DYNAMIC_MARKERS = ("{", "}", "{{", "}}", "${", "%s", "%(")
+_MISSING = object()
+
+_policy_var: ContextVar[EntityGuardPolicy | None] = ContextVar(
+    "mycelium_entity_guard_policy", default=None
+)
+_decision_var: ContextVar[EntityDecision | None] = ContextVar(
+    "mycelium_entity_guard_decision", default=None
+)
+
+
+class EntityGuardError(ToolBoundaryError):
+    """Destination missing, malformed, dynamic, undeclared, or not allowed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tool: str,
+        reason: str,
+        dest_class: str | None = None,
+        path: str | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            violation="entity_guard",
+            tool_name=tool,
+            llm_message=(
+                f"Destination policy blocked {tool!r}: {message}. "
+                "Use a host-authorized recipient, host, or entity id. "
+                "The tool body was not executed."
+            ),
+            field=path,
+            expected=dest_class,
+            recovery_hint=(
+                "Pass a destination the host listed in entity_guard.tools. "
+                "The model cannot add allowlist entries."
+            ),
+        )
+        self.tool = tool
+        self.reason = reason
+        self.dest_class = dest_class
+        self.path = path
+
+
+@dataclass(frozen=True)
+class DestinationAllow:
+    addresses: frozenset[str] = frozenset()
+    domains: frozenset[str] = frozenset()
+    hosts: frozenset[str] = frozenset()
+    values: frozenset[str] = frozenset()
+
+    def is_empty(self) -> bool:
+        return not (self.addresses or self.domains or self.hosts or self.values)
+
+
+@dataclass(frozen=True)
+class DestinationSpec:
+    path: str
+    dest_type: str
+    allow: DestinationAllow = field(default_factory=DestinationAllow)
+    required: bool = True
+    reject_redirects: bool = True
+
+    def deny_if_present(self) -> bool:
+        return self.allow.is_empty()
+
+
+@dataclass(frozen=True)
+class ToolDestinationPolicy:
+    destinations: tuple[DestinationSpec, ...]
+
+
+@dataclass(frozen=True)
+class EntityGuardPolicy:
+    """Host-owned destination policy. The model cannot add allowlist entries."""
+
+    enabled: bool = True
+    missing_policy: str = MISSING_POLICY_ERROR
+    policy_version: str = "unspecified"
+    tools: dict[str, ToolDestinationPolicy] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.missing_policy not in MISSING_POLICIES:
+            raise ValueError(
+                "entity_guard.missing_policy must be one of "
+                f"{sorted(MISSING_POLICIES)}, got {self.missing_policy!r}"
+            )
+
+
+@dataclass(frozen=True)
+class ApprovedDestination:
+    path: str
+    dest_class: str
+    entity: str
+
+
+@dataclass(frozen=True)
+class EntityDecision:
+    tool: str
+    destinations: tuple[ApprovedDestination, ...]
+    policy_version: str
+    decision: str
+    reason: str | None = None
+
+    def to_evidence(self) -> dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "destinations": [
+                {
+                    "class": item.dest_class,
+                    "entity": item.entity,
+                    "path": item.path,
+                }
+                for item in self.destinations
+            ],
+            "policy_version": self.policy_version,
+            "decision": self.decision,
+            **({"reason": self.reason} if self.reason else {}),
+        }
+
+
+def get_active_entity_policy() -> EntityGuardPolicy | None:
+    return _policy_var.get()
+
+
+def set_active_entity_policy(policy: EntityGuardPolicy | None) -> Token[EntityGuardPolicy | None]:
+    return _policy_var.set(policy)
+
+
+def reset_active_entity_policy(token: Token[EntityGuardPolicy | None]) -> None:
+    _policy_var.reset(token)
+
+
+def get_active_entity_decision() -> EntityDecision | None:
+    return _decision_var.get()
+
+
+def reset_entity_guard_state() -> None:
+    _policy_var.set(None)
+    _decision_var.set(None)
+
+
+def _is_dynamic(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if any(marker in stripped for marker in _DYNAMIC_MARKERS):
+        return True
+    if stripped in {"*", "?", "..."}:
+        return True
+    return False
+
+
+def _fully_unquote(value: str, *, rounds: int = 4) -> str:
+    current = value
+    for _ in range(rounds):
+        nxt = unquote(current)
+        if nxt == current:
+            return current
+        current = nxt
+    return current
+
+
+def _idna_host(host: str) -> str:
+    cleaned = host.strip(".").lower()
+    if not cleaned:
+        raise ValueError("empty host")
+    return cleaned.encode("idna").decode("ascii")
+
+
+def canonicalize_email(raw: Any, *, tool: str = "tool", path: str = "recipient") -> str:
+    if not isinstance(raw, str):
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_EMAIL,
+            path=path,
+        )
+    text = raw.strip()
+    if not text:
+        raise EntityGuardError(
+            "destination is missing",
+            tool=tool,
+            reason=REASON_MISSING,
+            dest_class=DEST_EMAIL,
+            path=path,
+        )
+    if _is_dynamic(text):
+        raise EntityGuardError(
+            "destination is dynamic",
+            tool=tool,
+            reason=REASON_DYNAMIC,
+            dest_class=DEST_EMAIL,
+            path=path,
+        )
+    _name, address = parseaddr(text)
+    if not address or "@" not in address or address.count("@") != 1:
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_EMAIL,
+            path=path,
+        )
+    local, domain = address.rsplit("@", 1)
+    if not local or not domain:
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_EMAIL,
+            path=path,
+        )
+    try:
+        host = _idna_host(domain)
+    except (UnicodeError, ValueError) as exc:
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_EMAIL,
+            path=path,
+        ) from exc
+    return f"{local.lower()}@{host}"
+
+
+def _emails_from_value(raw: Any, *, tool: str, path: str) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return ()
+        if "," in text or ";" in text:
+            pairs = getaddresses([text])
+            return tuple(
+                canonicalize_email(
+                    f"{name} <{addr}>" if name else addr, tool=tool, path=path
+                )
+                for name, addr in pairs
+                if addr
+            )
+        return (canonicalize_email(text, tool=tool, path=path),)
+    if isinstance(raw, (list, tuple)):
+        found: list[str] = []
+        for item in raw:
+            found.extend(_emails_from_value(item, tool=tool, path=path))
+        return tuple(found)
+    if isinstance(raw, Mapping):
+        found = []
+        for key, item in raw.items():
+            if str(key).lower() in _EMAIL_FIELD_NAMES:
+                found.extend(_emails_from_value(item, tool=tool, path=f"{path}.{key}"))
+        if found:
+            return tuple(found)
+    raise EntityGuardError(
+        "destination is malformed",
+        tool=tool,
+        reason=REASON_MALFORMED,
+        dest_class=DEST_EMAIL,
+        path=path,
+    )
+
+
+def _has_embedded_absolute_url(*parts: str) -> bool:
+    for part in parts:
+        lowered = unquote(part or "").lower()
+        if "https://" in lowered or "http://" in lowered:
+            return True
+    return False
+
+
+def canonicalize_https_url(
+    raw: Any,
+    *,
+    tool: str = "tool",
+    path: str = "url",
+    reject_redirects: bool = True,
+) -> str:
+    if not isinstance(raw, str):
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        )
+    text = raw.strip()
+    if not text:
+        raise EntityGuardError(
+            "destination is missing",
+            tool=tool,
+            reason=REASON_MISSING,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        )
+    if _is_dynamic(text):
+        raise EntityGuardError(
+            "destination is dynamic",
+            tool=tool,
+            reason=REASON_DYNAMIC,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        )
+    if "\\" in text or any(ch.isspace() for ch in text):
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        )
+    if any(dot in text for dot in _HOMOGLYPH_DOTS):
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        )
+    decoded = _fully_unquote(text)
+    parts = urlsplit(decoded)
+    if parts.scheme.lower() != "https":
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        )
+    if parts.username is not None or parts.password is not None:
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        )
+    host = parts.hostname
+    if not host:
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        )
+    try:
+        host = _idna_host(host)
+    except (UnicodeError, ValueError) as exc:
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        ) from exc
+    if reject_redirects and _has_embedded_absolute_url(
+        parts.path, parts.query, parts.fragment
+    ):
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        )
+    try:
+        port = parts.port
+    except ValueError as exc:
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HTTPS_URL,
+            path=path,
+        ) from exc
+    netloc = host if port in (None, 443) else f"{host}:{port}"
+    path_part = parts.path or "/"
+    return urlunsplit(("https", netloc, path_part, parts.query, ""))
+
+
+def canonicalize_host(raw: Any, *, tool: str = "tool", path: str = "host") -> str:
+    if isinstance(raw, str) and raw.strip().lower().startswith("https://"):
+        url = canonicalize_https_url(raw, tool=tool, path=path, reject_redirects=True)
+        host = urlsplit(url).hostname
+        if not host:
+            raise EntityGuardError(
+                "destination is malformed",
+                tool=tool,
+                reason=REASON_MALFORMED,
+                dest_class=DEST_HOST,
+                path=path,
+            )
+        return host
+    if not isinstance(raw, str):
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HOST,
+            path=path,
+        )
+    text = raw.strip()
+    if not text:
+        raise EntityGuardError(
+            "destination is missing",
+            tool=tool,
+            reason=REASON_MISSING,
+            dest_class=DEST_HOST,
+            path=path,
+        )
+    if _is_dynamic(text) or "/" in text or "\\" in text or "@" in text:
+        raise EntityGuardError(
+            "destination is malformed" if "/" in text or "@" in text else "destination is dynamic",
+            tool=tool,
+            reason=REASON_DYNAMIC if _is_dynamic(text) else REASON_MALFORMED,
+            dest_class=DEST_HOST,
+            path=path,
+        )
+    try:
+        return _idna_host(text.split(":")[0])
+    except (UnicodeError, ValueError) as exc:
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_HOST,
+            path=path,
+        ) from exc
+
+
+def canonicalize_entity_id(raw: Any, *, tool: str = "tool", path: str = "id") -> str:
+    if raw is None:
+        raise EntityGuardError(
+            "destination is missing",
+            tool=tool,
+            reason=REASON_MISSING,
+            dest_class=DEST_ENTITY_ID,
+            path=path,
+        )
+    if not isinstance(raw, (str, int)):
+        raise EntityGuardError(
+            "destination is malformed",
+            tool=tool,
+            reason=REASON_MALFORMED,
+            dest_class=DEST_ENTITY_ID,
+            path=path,
+        )
+    text = str(raw).strip()
+    if not text:
+        raise EntityGuardError(
+            "destination is missing",
+            tool=tool,
+            reason=REASON_MISSING,
+            dest_class=DEST_ENTITY_ID,
+            path=path,
+        )
+    if _is_dynamic(text):
+        raise EntityGuardError(
+            "destination is dynamic",
+            tool=tool,
+            reason=REASON_DYNAMIC,
+            dest_class=DEST_ENTITY_ID,
+            path=path,
+        )
+    return text
+
+
+def _host_from_url(url: str) -> str:
+    host = urlsplit(url).hostname
+    return host or ""
+
+
+def _is_ip(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return True
+
+
+def _email_allowed(canonical: str, allow: DestinationAllow) -> bool:
+    if canonical in allow.addresses:
+        return True
+    domain = canonical.rsplit("@", 1)[-1]
+    return domain in allow.domains
+
+
+def _host_allowed(host: str, allow: DestinationAllow) -> bool:
+    if host in allow.hosts:
+        return True
+    if _is_ip(host):
+        return host in allow.hosts
+    return False
+
+
+def _entity_allowed(canonical: str, allow: DestinationAllow) -> bool:
+    allowed = {item.casefold() for item in allow.values}
+    return canonical.casefold() in allowed
+
+
+def _lookup_path(mapping: Mapping[str, Any], path: str) -> Any:
+    current: Any = mapping
+    for part in path.split("."):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return _MISSING
+    return current
+
+
+def _set_path(mapping: dict[str, Any], path: str, value: Any) -> None:
+    parts = path.split(".")
+    current: Any = mapping
+    for part in parts[:-1]:
+        nxt = current.get(part)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            current[part] = nxt
+        current = nxt
+    current[parts[-1]] = value
+
+
+def _split_bookkeeping(
+    func: Callable[..., Any], kwargs: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    extra = {key: value for key, value in kwargs.items() if key in LEDGER_KWARG_KEYS}
+    known = {key: value for key, value in kwargs.items() if key not in LEDGER_KWARG_KEYS}
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return known, extra
+    if any(
+        param.kind is inspect.Parameter.VAR_KEYWORD
+        for param in signature.parameters.values()
+    ):
+        return known, extra
+    names = set(signature.parameters)
+    for key, value in list(known.items()):
+        if key not in names:
+            extra[key] = value
+            del known[key]
+    return known, extra
+
+
+def _bound_mapping(
+    func: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    try:
+        signature = inspect.signature(func)
+        bound = signature.bind_partial(*args, **kwargs)
+        return dict(bound.arguments)
+    except (TypeError, ValueError):
+        return dict(kwargs)
+
+
+def _rebuild_call(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    mapping: dict[str, Any],
+    extra: dict[str, Any],
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    new_args = list(args)
+    new_kwargs = dict(extra)
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        new_kwargs.update(mapping)
+        return tuple(new_args), new_kwargs
+    positional = [
+        param
+        for param in signature.parameters.values()
+        if param.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    for index, param in enumerate(positional):
+        if param.name in mapping and index < len(new_args):
+            new_args[index] = mapping[param.name]
+        elif param.name in mapping:
+            new_kwargs[param.name] = mapping[param.name]
+    for key, value in mapping.items():
+        if key not in {param.name for param in positional}:
+            new_kwargs[key] = value
+    return tuple(new_args), new_kwargs
+
+
+def _raise(
+    *,
+    tool: str,
+    reason: str,
+    dest_class: str | None,
+    path: str | None,
+    missing_policy: str,
+) -> None:
+    if reason == REASON_MISSING and missing_policy == MISSING_POLICY_WARN:
+        # Still fail closed: warn is not a license to execute.
+        pass
+    messages = {
+        REASON_MISSING: "destination is missing",
+        REASON_MALFORMED: "destination is malformed",
+        REASON_DYNAMIC: "destination is dynamic",
+        REASON_NOT_ALLOWED: "destination is not allowed",
+        REASON_UNDECLARED: "undeclared destination",
+    }
+    raise EntityGuardError(
+        messages.get(reason, "destination is not allowed"),
+        tool=tool,
+        reason=reason,
+        dest_class=dest_class,
+        path=path,
+    )
+
+
+def _canonicalize_values(
+    spec: DestinationSpec, raw: Any, *, tool: str
+) -> tuple[str, ...]:
+    if spec.dest_type == DEST_EMAIL:
+        return _emails_from_value(raw, tool=tool, path=spec.path)
+    if spec.dest_type == DEST_HTTPS_URL:
+        if isinstance(raw, (list, tuple)):
+            return tuple(
+                canonicalize_https_url(
+                    item,
+                    tool=tool,
+                    path=spec.path,
+                    reject_redirects=spec.reject_redirects,
+                )
+                for item in raw
+            )
+        return (
+            canonicalize_https_url(
+                raw,
+                tool=tool,
+                path=spec.path,
+                reject_redirects=spec.reject_redirects,
+            ),
+        )
+    if spec.dest_type == DEST_HOST:
+        if isinstance(raw, (list, tuple)):
+            return tuple(canonicalize_host(item, tool=tool, path=spec.path) for item in raw)
+        return (canonicalize_host(raw, tool=tool, path=spec.path),)
+    if isinstance(raw, (list, tuple)):
+        return tuple(canonicalize_entity_id(item, tool=tool, path=spec.path) for item in raw)
+    return (canonicalize_entity_id(raw, tool=tool, path=spec.path),)
+
+
+def _value_allowed(spec: DestinationSpec, canonical: str) -> bool:
+    if spec.dest_type == DEST_EMAIL:
+        return _email_allowed(canonical, spec.allow)
+    if spec.dest_type in {DEST_HTTPS_URL, DEST_HOST}:
+        host = _host_from_url(canonical) if spec.dest_type == DEST_HTTPS_URL else canonical
+        return _host_allowed(host, spec.allow)
+    return _entity_allowed(canonical, spec.allow)
+
+
+def _field_kind(name: str) -> str | None:
+    key = name.lower()
+    if key in _EMAIL_FIELD_NAMES:
+        return DEST_EMAIL
+    if key in _URL_FIELD_NAMES:
+        return DEST_HTTPS_URL if key != "host" else DEST_HOST
+    if key in _ID_FIELD_NAMES:
+        return DEST_ENTITY_ID
+    return None
+
+
+def _walk_undeclared(
+    value: Any,
+    *,
+    prefix: str,
+    covered: set[str],
+    payload: bool,
+) -> list[tuple[str, str]]:
+    found: list[tuple[str, str]] = []
+    if payload:
+        return found
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            name = str(key)
+            path = f"{prefix}.{name}" if prefix else name
+            kind = _field_kind(name)
+            in_payload = name.lower() in _PAYLOAD_FIELD_NAMES
+            if kind and path not in covered and not in_payload:
+                if item not in (None, "", [], {}):
+                    found.append((path, kind))
+            found.extend(
+                _walk_undeclared(
+                    item, prefix=path, covered=covered, payload=in_payload
+                )
+            )
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            found.extend(
+                _walk_undeclared(
+                    item,
+                    prefix=f"{prefix}[{index}]",
+                    covered=covered,
+                    payload=payload,
+                )
+            )
+    return found
+
+
+def enforce_entity_guard(
+    tool: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    policy: EntityGuardPolicy,
+    func: Callable[..., Any] | None = None,
+) -> tuple[tuple[Any, ...], dict[str, Any], EntityDecision]:
+    """Canonicalize and authorize destinations. Fail closed on any violation."""
+    tool_policy = policy.tools.get(tool)
+    if tool_policy is None:
+        decision = EntityDecision(
+            tool=tool,
+            destinations=(),
+            policy_version=policy.policy_version,
+            decision="allow",
+        )
+        _decision_var.set(decision)
+        return args, kwargs, decision
+
+    tool_kwargs, extra = (
+        _split_bookkeeping(func, kwargs) if func is not None else (dict(kwargs), {})
+    )
+    mapping = (
+        _bound_mapping(func, args, tool_kwargs) if func is not None else dict(tool_kwargs)
+    )
+    approved: list[ApprovedDestination] = []
+    covered: set[str] = set()
+
+    for spec in tool_policy.destinations:
+        covered.add(spec.path)
+        raw = _lookup_path(mapping, spec.path)
+        empty = raw is _MISSING or raw in (None, "", [], ())
+        if empty:
+            if spec.deny_if_present() or not spec.required:
+                continue
+            _raise(
+                tool=tool,
+                reason=REASON_MISSING,
+                dest_class=spec.dest_type,
+                path=spec.path,
+                missing_policy=policy.missing_policy,
+            )
+        values = _canonicalize_values(spec, raw, tool=tool)
+        if not values:
+            if spec.deny_if_present() or not spec.required:
+                continue
+            _raise(
+                tool=tool,
+                reason=REASON_MISSING,
+                dest_class=spec.dest_type,
+                path=spec.path,
+                missing_policy=policy.missing_policy,
+            )
+        if spec.deny_if_present():
+            _raise(
+                tool=tool,
+                reason=REASON_NOT_ALLOWED,
+                dest_class=spec.dest_type,
+                path=spec.path,
+                missing_policy=policy.missing_policy,
+            )
+        rewritten: list[str] = []
+        for canonical in values:
+            if not _value_allowed(spec, canonical):
+                _raise(
+                    tool=tool,
+                    reason=REASON_NOT_ALLOWED,
+                    dest_class=spec.dest_type,
+                    path=spec.path,
+                    missing_policy=policy.missing_policy,
+                )
+            entity = (
+                _host_from_url(canonical)
+                if spec.dest_type == DEST_HTTPS_URL
+                else canonical
+            )
+            approved.append(
+                ApprovedDestination(
+                    path=spec.path, dest_class=spec.dest_type, entity=entity
+                )
+            )
+            rewritten.append(canonical)
+        if isinstance(raw, (list, tuple)):
+            _set_path(mapping, spec.path, rewritten)
+        elif spec.dest_type == DEST_EMAIL and isinstance(raw, Mapping):
+            pass
+        else:
+            _set_path(mapping, spec.path, rewritten[0] if len(rewritten) == 1 else rewritten)
+
+    for path, kind in _walk_undeclared(mapping, prefix="", covered=covered, payload=False):
+        _raise(
+            tool=tool,
+            reason=REASON_UNDECLARED,
+            dest_class=kind,
+            path=path,
+            missing_policy=policy.missing_policy,
+        )
+
+    decision = EntityDecision(
+        tool=tool,
+        destinations=tuple(approved),
+        policy_version=policy.policy_version,
+        decision="allow",
+    )
+    _decision_var.set(decision)
+    if func is not None:
+        return (*_rebuild_call(func, args, kwargs, mapping, extra), decision)
+    merged = dict(mapping)
+    merged.update(extra)
+    return args, merged, decision
+
+
+def sanitize_entity_evidence(
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any],
+    policy: EntityGuardPolicy | None = None,
+) -> tuple[list[Any], dict[str, Any]]:
+    """Keep tool / approved entity IDs; drop sensitive payload."""
+    del policy
+    decision = get_active_entity_decision()
+    dest_by_path = {item.path: item.entity for item in decision.destinations} if decision else {}
+
+    def scrub(value: Any, *, name: str | None = None, payload: bool = False) -> Any:
+        key = (name or "").lower()
+        if key in _PAYLOAD_FIELD_NAMES or payload:
+            return PAYLOAD_OMITTED
+        if name and name in dest_by_path:
+            return dest_by_path[name]
+        if isinstance(value, Mapping):
+            return {
+                str(k): scrub(
+                    v,
+                    name=str(k),
+                    payload=str(k).lower() in _PAYLOAD_FIELD_NAMES,
+                )
+                for k, v in value.items()
+            }
+        if isinstance(value, list):
+            return [scrub(item, payload=payload) for item in value]
+        if isinstance(value, tuple):
+            return [scrub(item, payload=payload) for item in value]
+        return value
+
+    safe_kwargs = scrub(dict(kwargs)) if isinstance(kwargs, Mapping) else {}
+    assert isinstance(safe_kwargs, dict)
+    return [scrub(item) for item in args], safe_kwargs
+
+
+def destination_fingerprint(decision: EntityDecision | None) -> tuple[str, ...]:
+    if decision is None:
+        return ()
+    return tuple(sorted(f"{item.dest_class}:{item.entity}" for item in decision.destinations))
+
+
+def apply_entity_guard(
+    func: Callable[P, R],
+    policy: EntityGuardPolicy,
+    *,
+    tool_name: str | None = None,
+) -> Callable[P, R]:
+    """Wrap *func* so destinations are authorized before any inner guard or claim."""
+    name = tool_name or getattr(func, "__name__", "tool")
+
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            token = set_active_entity_policy(policy)
+            try:
+                call_args, call_kwargs, _decision = enforce_entity_guard(
+                    name, args, kwargs, policy=policy, func=func
+                )
+                return await func(*call_args, **call_kwargs)
+            except EntityGuardError as exc:
+                _decision_var.set(
+                    EntityDecision(
+                        tool=name,
+                        destinations=(),
+                        policy_version=policy.policy_version,
+                        decision="deny",
+                        reason=exc.reason,
+                    )
+                )
+                raise
+            finally:
+                reset_active_entity_policy(token)
+
+        async_wrapper._mycelium_entity_guard = True  # type: ignore[attr-defined]
+        return async_wrapper  # type: ignore[return-value]
+
+    @functools.wraps(func)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        token = set_active_entity_policy(policy)
+        try:
+            call_args, call_kwargs, _decision = enforce_entity_guard(
+                name, args, kwargs, policy=policy, func=func
+            )
+            return func(*call_args, **call_kwargs)
+        except EntityGuardError as exc:
+            _decision_var.set(
+                EntityDecision(
+                    tool=name,
+                    destinations=(),
+                    policy_version=policy.policy_version,
+                    decision="deny",
+                    reason=exc.reason,
+                )
+            )
+            raise
+        finally:
+            reset_active_entity_policy(token)
+
+    sync_wrapper._mycelium_entity_guard = True  # type: ignore[attr-defined]
+    return sync_wrapper  # type: ignore[return-value]
+
+
+def entity_guard_policy_for_tool(
+    policy: EntityGuardPolicy, tool_name: str
+) -> EntityGuardPolicy:
+    tool = policy.tools.get(tool_name)
+    if tool is None:
+        return replace(policy, tools={})
+    return replace(policy, tools={tool_name: tool})
+
+
+__all__ = [
+    "DEST_EMAIL",
+    "DEST_ENTITY_ID",
+    "DEST_HOST",
+    "DEST_HTTPS_URL",
+    "DEST_TYPES",
+    "MISSING_POLICIES",
+    "MISSING_POLICY_ERROR",
+    "MISSING_POLICY_WARN",
+    "PAYLOAD_OMITTED",
+    "ApprovedDestination",
+    "DestinationAllow",
+    "DestinationSpec",
+    "EntityDecision",
+    "EntityGuardError",
+    "EntityGuardPolicy",
+    "ToolDestinationPolicy",
+    "apply_entity_guard",
+    "canonicalize_email",
+    "canonicalize_entity_id",
+    "canonicalize_host",
+    "canonicalize_https_url",
+    "destination_fingerprint",
+    "enforce_entity_guard",
+    "entity_guard_policy_for_tool",
+    "get_active_entity_decision",
+    "get_active_entity_policy",
+    "reset_active_entity_policy",
+    "reset_entity_guard_state",
+    "sanitize_entity_evidence",
+    "set_active_entity_policy",
+]

--- a/sdk/mycelium/templates/mycelium.minimal.yaml
+++ b/sdk/mycelium/templates/mycelium.minimal.yaml
@@ -6,6 +6,7 @@
 #   and missing run_id cannot silently skip protection.
 # Optional AF-010: secret_args: {enabled: true, policy: error}
 #   Pass secret:// references instead of credentials.
+# Optional destination policy: entity_guard: {enabled: true, missing_policy: error}
 #
 # side_effect_class required only for tools listed under action_ledger.tools:
 #   read | idempotent_mutate | keyed_mutate | non_idempotent_mutate | irreversible

--- a/sdk/mycelium/templates/mycelium.template.yaml
+++ b/sdk/mycelium/templates/mycelium.template.yaml
@@ -7,7 +7,7 @@
 #   Optional:  integrations, task_ledger, state_flush, audit_receipt, outcome_emit,
 #              loop_guard, completion, state_authority, registry, runner,
 #              history_guard, message_validator, deployment, verify,
-#              secret_args — delete unused sections
+#              secret_args, entity_guard — delete unused sections
 #
 # Next steps
 #   1. Allowlist first: rename tools: / tasks: stubs, then copy those exact
@@ -81,6 +81,7 @@
 #   → completion: requires a verified terminal adapter at startup
 #   → secret_args.policy: error when secret_args is enabled and
 #     consequential tools exist (warn/redact rejected)
+#   → entity_guard.missing_policy: error when entity_guard is enabled
 #   Weaker explicit warn/derived/memory-outcome settings are rejected.
 #   unclassified_policy: warn remains an accepted product choice.
 # Verify with:
@@ -272,6 +273,36 @@ loop_guard:
 #   allow_tools: []
 #   entropy_detection: true
 # Per tool: secret_fields: [api_key]  and/or  secret_args: false
+
+# ---------------------------------------------------------------------------
+# entity_guard  (unnumbered — destination policy at the tool boundary)
+# A write may carry sensitive data only into a host-authorized destination.
+# Unknown / missing / malformed / dynamic destination → no execution.
+# The model cannot add recipients to the allowlist.
+# ---------------------------------------------------------------------------
+# entity_guard:
+#   enabled: true
+#   missing_policy: error
+#   tools:
+#     send_email:
+#       destinations:
+#         - path: recipient
+#           type: email
+#           allow:
+#             addresses: [billing@customer.com]
+#             domains: [customer.com]
+#         - path: cc
+#           type: email
+#           allow: []
+#           required: false
+#     http_post:
+#       destinations:
+#         - path: url
+#           type: https_url
+#           allow:
+#             hosts: [api.stripe.com, hooks.slack.com]
+#           reject_redirects: true
+# Per tool: entity_guard: false
 
 # ---------------------------------------------------------------------------
 # budget  (unnumbered — cost / time / step ceilings; refuse next step)

--- a/sdk/mycelium/verify/registry.py
+++ b/sdk/mycelium/verify/registry.py
@@ -18,6 +18,7 @@ SCENARIO_ORDER = (
     "ambiguous-effect",
     "reconcile",
     "secret-in-args",
+    "entity-guard",
 )
 
 ScenarioFn = Callable[["ScenarioContext"], "VerificationEvidence"]
@@ -76,6 +77,7 @@ def ensure_builtin_scenarios_registered() -> None:
     from mycelium.verify.scenarios import (  # noqa: F401
         ambiguous_effect,
         contention,
+        entity_guard,
         reconcile,
         redispatch,
         secret_in_args,

--- a/sdk/mycelium/verify/render.py
+++ b/sdk/mycelium/verify/render.py
@@ -17,6 +17,7 @@ _SCENARIO_LABELS = {
     "ambiguous-effect": "Ambiguous effect",
     "reconcile": "Reconcile",
     "secret-in-args": "Secret-in-args",
+    "entity-guard": "Entity-guard",
 }
 
 

--- a/sdk/mycelium/verify/scenarios/entity_guard.py
+++ b/sdk/mycelium/verify/scenarios/entity_guard.py
@@ -1,0 +1,232 @@
+"""Entity-guard: unauthorized destinations never reach claim or evidence."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from mycelium.action_ledger import InMemoryLedgerStorage, ledger_sync
+from mycelium.entity_guard import (
+    DEST_EMAIL,
+    DEST_HTTPS_URL,
+    DestinationAllow,
+    DestinationSpec,
+    EntityGuardError,
+    EntityGuardPolicy,
+    ToolDestinationPolicy,
+    apply_entity_guard,
+    reset_entity_guard_state,
+)
+from mycelium.transition import TransitionScope, execution_scope
+from mycelium.verify.registry import ScenarioContext, verify_scenario
+from mycelium.verify.types import VerificationEvidence, VerificationStatus
+from mycelium.verify.workers import synthetic_binding
+
+_PAYLOAD = "INTERNAL_PAYROLL_SSN_VERIFY_ONLY"
+_FORBIDDEN = "exfil@evil.example"
+
+
+def _scan_payload(value: Any) -> bool:
+    try:
+        text = json.dumps(value, default=str)
+    except TypeError:
+        text = repr(value)
+    return _PAYLOAD in text or _FORBIDDEN in text
+
+
+class _RecordingStorage(InMemoryLedgerStorage):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self.events = events
+
+    def try_claim_inflight(self, entry, *, lease_ttl: float = 3600.0):
+        self.events.append("claim")
+        if _scan_payload(entry.to_dict() if hasattr(entry, "to_dict") else entry):
+            raise RuntimeError("storage refused a payload that contained secrets")
+        return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+
+def _policy() -> EntityGuardPolicy:
+    return EntityGuardPolicy(
+        enabled=True,
+        missing_policy="error",
+        policy_version="verify",
+        tools={
+            "verify_send": ToolDestinationPolicy(
+                destinations=(
+                    DestinationSpec(
+                        path="recipient",
+                        dest_type=DEST_EMAIL,
+                        allow=DestinationAllow(
+                            addresses=frozenset({"billing@customer.com"}),
+                            domains=frozenset({"customer.com"}),
+                        ),
+                    ),
+                    DestinationSpec(
+                        path="cc",
+                        dest_type=DEST_EMAIL,
+                        allow=DestinationAllow(),
+                        required=False,
+                    ),
+                )
+            ),
+            "verify_post": ToolDestinationPolicy(
+                destinations=(
+                    DestinationSpec(
+                        path="url",
+                        dest_type=DEST_HTTPS_URL,
+                        allow=DestinationAllow(hosts=frozenset({"api.stripe.com"})),
+                        reject_redirects=True,
+                    ),
+                )
+            ),
+        },
+    )
+
+
+def _wrap(storage, *, tool: str, events: list[str], seen: list[Any]):
+    binding = synthetic_binding()
+
+    def verify_send(
+        recipient: str,
+        body: str,
+        cc: list[str] | None = None,
+    ) -> dict[str, Any]:
+        events.append("body")
+        seen.append(recipient)
+        return {"sent": True, "recipient": recipient, "body": body, "cc": cc}
+
+    def verify_post(url: str, body: str) -> dict[str, Any]:
+        events.append("body")
+        seen.append(url)
+        return {"posted": True, "url": url, "body": body}
+
+    target = verify_send if tool == "verify_send" else verify_post
+    ledgered = ledger_sync(
+        storage=storage,
+        transition_binding=binding,
+        lease_ttl=30.0,
+        lease_renew_interval=0,
+        poll_interval=0.02,
+        poll_timeout=5.0,
+    )(target)
+    return apply_entity_guard(ledgered, _policy(), tool_name=tool)
+
+
+@verify_scenario("entity-guard")
+def run_entity_guard(ctx: ScenarioContext) -> VerificationEvidence:
+    started = time.time()
+    reset_entity_guard_state()
+    iso = ctx.isolation
+    events: list[str] = []
+    seen: list[Any] = []
+    storage = _RecordingStorage(events)
+    send = _wrap(storage, tool="verify_send", events=events, seen=seen)
+    post = _wrap(storage, tool="verify_post", events=events, seen=seen)
+    dump = Path(iso.artifact_file("entity-guard-dump-"))
+    notes: list[str] = []
+    failed = False
+
+    def _record(ok: bool, note: str) -> None:
+        nonlocal failed
+        notes.append(note)
+        if not ok:
+            failed = True
+
+    with execution_scope(TransitionScope(run_id="entity-guard", thread_id="verify")):
+        rid_ok = iso.track(iso.namespace.request_id("entity-guard", "allow"))
+        send(recipient="billing@customer.com", body=_PAYLOAD, request_id=rid_ok)
+        _record("body" in events and "claim" in events, "allowed destination claimed")
+
+        before = list(events)
+        rid_deny = iso.track(iso.namespace.request_id("entity-guard", "deny"))
+        try:
+            send(recipient=_FORBIDDEN, body=_PAYLOAD, request_id=rid_deny)
+            _record(False, "forbidden recipient executed")
+        except EntityGuardError as exc:
+            _record(
+                exc.reason == "not_allowed" and events == before,
+                "forbidden recipient blocked before claim",
+            )
+
+        before = list(events)
+        rid_cc = iso.track(iso.namespace.request_id("entity-guard", "cc"))
+        try:
+            send(
+                recipient="billing@customer.com",
+                body=_PAYLOAD,
+                cc=[_FORBIDDEN],
+                request_id=rid_cc,
+            )
+            _record(False, "forbidden cc executed")
+        except EntityGuardError:
+            _record(events == before, "forbidden cc blocked before claim")
+
+        before = list(events)
+        rid_url = iso.track(iso.namespace.request_id("entity-guard", "url"))
+        try:
+            post(
+                url="https://api.stripe.com.evil.example/v1",
+                body=_PAYLOAD,
+                request_id=rid_url,
+            )
+            _record(False, "lookalike host executed")
+        except EntityGuardError:
+            _record(events == before, "lookalike host blocked before claim")
+
+        before = list(events)
+        rid_redir = iso.track(iso.namespace.request_id("entity-guard", "redir"))
+        try:
+            post(
+                url="https://api.stripe.com/redirect?next=https://evil.example",
+                body=_PAYLOAD,
+                request_id=rid_redir,
+            )
+            _record(False, "redirect URL executed")
+        except EntityGuardError:
+            _record(events == before, "embedded redirect blocked before claim")
+
+    payload = {
+        "events": events,
+        "seen": seen,
+        "notes": notes,
+        "entries": [entry.to_dict() for entry in storage._entries.values()]
+        if hasattr(storage, "_entries")
+        else [],
+    }
+    dump.write_text(json.dumps(payload, default=str), encoding="utf-8")
+    leaked = _scan_payload(payload) or _PAYLOAD in dump.read_text(encoding="utf-8")
+    _record(not leaked, "evidence omitted sensitive payload")
+
+    reset_entity_guard_state()
+    status = VerificationStatus.FAIL if failed else VerificationStatus.PASS
+    return VerificationEvidence(
+        scenario="entity-guard",
+        backend=iso.backend,
+        namespace=iso.namespace.prefix,
+        attempts=len(notes),
+        body_executions=events.count("body"),
+        ledger_decisions=notes,
+        duration=time.time() - started,
+        expected_behavior=(
+            "Unauthorized, malformed, dynamic, or undeclared destinations "
+            "fail closed before claim. Evidence omits the sensitive payload."
+        ),
+        observed_behavior="; ".join(notes),
+        artifacts=[str(dump), *iso.artifact_paths()],
+        limitations=[
+            "Synthetic destinations only; no real provider was contacted.",
+            "Allowlists are host-controlled; the model cannot add recipients.",
+        ],
+        status=status,
+        summary=(
+            "Destination policy blocked unauthorized writes before claim"
+            if not failed
+            else "Destination policy failed to block an unauthorized write"
+        ),
+        remediation=""
+        if status is VerificationStatus.PASS
+        else "Declare host-owned destinations; unknown destination means no execution.",
+    )

--- a/sdk/tests/test_entity_guard.py
+++ b/sdk/tests/test_entity_guard.py
@@ -1,0 +1,472 @@
+"""Destination-policy guard: unauthorized writes never reach claim."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from mycelium import (
+    PAYLOAD_OMITTED,
+    ConfigError,
+    EntityGuardError,
+    InMemoryLedgerStorage,
+    apply_entity_guard,
+    canonicalize_email,
+    canonicalize_https_url,
+    enforce_entity_guard,
+    ledger_sync,
+    load_config_from_string,
+)
+from mycelium.action_ledger import ARGS_DRIFT_HARD
+from mycelium.doctor.types import DoctorStatus
+from mycelium.entity_guard import (
+    DEST_EMAIL,
+    DEST_ENTITY_ID,
+    DEST_HTTPS_URL,
+    DestinationAllow,
+    DestinationSpec,
+    EntityGuardPolicy,
+    ToolDestinationPolicy,
+    reset_entity_guard_state,
+    sanitize_entity_evidence,
+)
+from mycelium.transition import (
+    SideEffectClass,
+    ToolTransitionBinding,
+    TransitionScope,
+    args_fingerprint,
+    execution_scope,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    reset_entity_guard_state()
+    yield
+    reset_entity_guard_state()
+
+
+def _policy(**tools: ToolDestinationPolicy) -> EntityGuardPolicy:
+    return EntityGuardPolicy(
+        enabled=True,
+        missing_policy="error",
+        policy_version="test",
+        tools=dict(tools),
+    )
+
+
+def _email_tool() -> ToolDestinationPolicy:
+    return ToolDestinationPolicy(
+        destinations=(
+            DestinationSpec(
+                path="recipient",
+                dest_type=DEST_EMAIL,
+                allow=DestinationAllow(
+                    addresses=frozenset({"billing@customer.com"}),
+                    domains=frozenset({"customer.com"}),
+                ),
+            ),
+            DestinationSpec(
+                path="cc",
+                dest_type=DEST_EMAIL,
+                allow=DestinationAllow(),
+                required=False,
+            ),
+        )
+    )
+
+
+def _url_tool() -> ToolDestinationPolicy:
+    return ToolDestinationPolicy(
+        destinations=(
+            DestinationSpec(
+                path="url",
+                dest_type=DEST_HTTPS_URL,
+                allow=DestinationAllow(
+                    hosts=frozenset({"api.stripe.com", "hooks.slack.com"})
+                ),
+                reject_redirects=True,
+            ),
+        )
+    )
+
+
+def _ticket_tool() -> ToolDestinationPolicy:
+    return ToolDestinationPolicy(
+        destinations=(
+            DestinationSpec(
+                path="project_id",
+                dest_type=DEST_ENTITY_ID,
+                allow=DestinationAllow(values=frozenset({"SUPPORT", "INCIDENTS"})),
+            ),
+        )
+    )
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="t",
+        policy_version="test",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def test_omitted_config_keeps_existing_behavior() -> None:
+    cfg = load_config_from_string(
+        """
+tools:
+  send_email:
+    side_effect_class: non_idempotent_mutate
+"""
+    )
+    assert cfg.entity_guard is None
+    assert cfg.entity_guard_applies("send_email") is False
+
+
+def test_canonical_email_and_https() -> None:
+    assert canonicalize_email("Billing@Customer.COM") == "billing@customer.com"
+    assert (
+        canonicalize_https_url("https://API.Stripe.com/v1")
+        == "https://api.stripe.com/v1"
+    )
+
+
+def test_allow_email_and_domain() -> None:
+    policy = _policy(send_email=_email_tool())
+
+    def send_email(recipient: str, body: str) -> str:
+        return recipient
+
+    wrapped = apply_entity_guard(send_email, policy, tool_name="send_email")
+    assert wrapped(recipient="billing@customer.com", body="secret") == "billing@customer.com"
+    assert wrapped(recipient="ops@customer.com", body="secret") == "ops@customer.com"
+
+
+def test_forbidden_and_missing_fail_closed() -> None:
+    policy = _policy(send_email=_email_tool())
+
+    def send_email(recipient: str | None = None, body: str = "") -> str:
+        return "ran"
+
+    wrapped = apply_entity_guard(send_email, policy, tool_name="send_email")
+    with pytest.raises(EntityGuardError) as denied:
+        wrapped(recipient="exfil@evil.example", body="secret")
+    assert denied.value.reason == "not_allowed"
+    with pytest.raises(EntityGuardError) as missing:
+        wrapped(body="secret")
+    assert missing.value.reason == "missing"
+
+
+def test_empty_cc_allowlist_denies_present_values() -> None:
+    policy = _policy(send_email=_email_tool())
+
+    def send_email(recipient: str, body: str, cc: list[str] | None = None) -> str:
+        return "ran"
+
+    wrapped = apply_entity_guard(send_email, policy, tool_name="send_email")
+    assert wrapped(recipient="billing@customer.com", body="x") == "ran"
+    with pytest.raises(EntityGuardError) as caught:
+        wrapped(recipient="billing@customer.com", body="x", cc=["other@customer.com"])
+    assert caught.value.reason == "not_allowed"
+
+
+def test_undeclared_bcc_fails_closed() -> None:
+    policy = _policy(send_email=_email_tool())
+
+    def send_email(recipient: str, body: str, bcc: str | None = None) -> str:
+        return "ran"
+
+    wrapped = apply_entity_guard(send_email, policy, tool_name="send_email")
+    with pytest.raises(EntityGuardError) as caught:
+        wrapped(recipient="billing@customer.com", body="x", bcc="shadow@evil.example")
+    assert caught.value.reason == "undeclared"
+
+
+def test_dynamic_and_encoded_url_rejected() -> None:
+    policy = _policy(http_post=_url_tool())
+
+    def http_post(url: str, body: str) -> str:
+        return "ran"
+
+    wrapped = apply_entity_guard(http_post, policy, tool_name="http_post")
+    with pytest.raises(EntityGuardError) as dynamic:
+        wrapped(url="https://{host}/v1", body="x")
+    assert dynamic.value.reason == "dynamic"
+    with pytest.raises(EntityGuardError):
+        wrapped(url="https://api.stripe.com.evil.example/v1", body="x")
+    with pytest.raises(EntityGuardError):
+        wrapped(url="https://evil.example@api.stripe.com/", body="x")
+    with pytest.raises(EntityGuardError):
+        wrapped(url="http://api.stripe.com/v1", body="x")
+    with pytest.raises(EntityGuardError):
+        wrapped(url="https://api.stripe.com/go?next=https://evil.example", body="x")
+    assert wrapped(url="https://API.stripe.com/v1", body="x") == "ran"
+
+
+def test_entity_id_and_ticket_project() -> None:
+    policy = _policy(create_ticket=_ticket_tool())
+
+    def create_ticket(project_id: str, body: str) -> str:
+        return project_id
+
+    wrapped = apply_entity_guard(create_ticket, policy, tool_name="create_ticket")
+    assert wrapped(project_id="support", body="x") == "support"
+    with pytest.raises(EntityGuardError):
+        wrapped(project_id="PAYROLL", body="x")
+
+
+def test_blocks_before_ledger_claim() -> None:
+    events: list[str] = []
+
+    class Recording(InMemoryLedgerStorage):
+        def try_claim_inflight(self, entry, *, lease_ttl: float = 3600.0):
+            events.append("claim")
+            return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+    def send_email(recipient: str, body: str) -> str:
+        events.append("body")
+        return "ran"
+
+    wrapped = apply_entity_guard(
+        ledger_sync(storage=Recording(), transition_binding=_binding())(send_email),
+        _policy(send_email=_email_tool()),
+        tool_name="send_email",
+    )
+    with execution_scope(TransitionScope(run_id="r", thread_id="t")):
+        with pytest.raises(EntityGuardError):
+            wrapped(recipient="exfil@evil.example", body="payroll", request_id="eg-1")
+    assert events == []
+
+
+def test_canonical_dest_bound_into_fingerprint() -> None:
+    policy = _policy(send_email=_email_tool())
+
+    def send_email(recipient: str, body: str) -> str:
+        return recipient
+
+    _args, kwargs_a, decision_a = enforce_entity_guard(
+        "send_email",
+        (),
+        {"recipient": "Billing@Customer.COM", "body": "one"},
+        policy=policy,
+        func=send_email,
+    )
+    _args, kwargs_b, decision_b = enforce_entity_guard(
+        "send_email",
+        (),
+        {"recipient": "billing@customer.com", "body": "two"},
+        policy=policy,
+        func=send_email,
+    )
+    assert kwargs_a["recipient"] == kwargs_b["recipient"] == "billing@customer.com"
+    assert args_fingerprint((), {"recipient": kwargs_a["recipient"]}) == args_fingerprint(
+        (), {"recipient": kwargs_b["recipient"]}
+    )
+    _args, kwargs_c, _dec = enforce_entity_guard(
+        "send_email",
+        (),
+        {"recipient": "ops@customer.com", "body": "three"},
+        policy=policy,
+        func=send_email,
+    )
+    assert kwargs_c["recipient"] != kwargs_a["recipient"]
+    del decision_a, decision_b
+
+
+def test_retry_cannot_change_recipient_on_same_request_id() -> None:
+    storage = InMemoryLedgerStorage()
+
+    def send_email(recipient: str, body: str) -> str:
+        return recipient
+
+    wrapped = apply_entity_guard(
+        ledger_sync(
+            storage=storage,
+            transition_binding=_binding(),
+            on_args_drift=ARGS_DRIFT_HARD,
+        )(send_email),
+        _policy(send_email=_email_tool()),
+        tool_name="send_email",
+    )
+    with execution_scope(TransitionScope(run_id="r", thread_id="t")):
+        assert (
+            wrapped(
+                recipient="billing@customer.com",
+                body="first",
+                request_id="eg-drift",
+            )
+            == "billing@customer.com"
+        )
+        with pytest.raises(Exception, match="[Dd]rift|args"):
+            wrapped(
+                recipient="ops@customer.com",
+                body="first",
+                request_id="eg-drift",
+            )
+
+
+def test_evidence_omits_payload() -> None:
+    policy = _policy(send_email=_email_tool())
+    storage = InMemoryLedgerStorage()
+
+    def send_email(recipient: str, body: str) -> str:
+        return recipient
+
+    wrapped = apply_entity_guard(
+        ledger_sync(storage=storage, transition_binding=_binding())(send_email),
+        policy,
+        tool_name="send_email",
+    )
+    with execution_scope(TransitionScope(run_id="r", thread_id="t")):
+        wrapped(
+            recipient="billing@customer.com",
+            body="INTERNAL_PAYROLL",
+            request_id="eg-ev",
+        )
+    entry = storage.get("eg-ev")
+    assert entry is not None
+    dumped = json.dumps(entry.to_dict(), default=str)
+    assert "INTERNAL_PAYROLL" not in dumped
+    assert PAYLOAD_OMITTED in dumped or "billing@customer.com" in dumped
+
+
+def test_sanitize_entity_evidence_drops_body() -> None:
+    policy = _policy(send_email=_email_tool())
+    enforce_entity_guard(
+        "send_email",
+        (),
+        {"recipient": "billing@customer.com", "body": "secret-payroll"},
+        policy=policy,
+        func=lambda recipient, body: None,
+    )
+    _args, kwargs = sanitize_entity_evidence(
+        (),
+        {"recipient": "billing@customer.com", "body": "secret-payroll"},
+    )
+    assert kwargs["body"] == PAYLOAD_OMITTED
+    assert kwargs["recipient"] == "billing@customer.com"
+    assert "secret-payroll" not in json.dumps(kwargs)
+
+
+def test_sync_and_async_wrappers_match() -> None:
+    policy = _policy(send_email=_email_tool())
+
+    def sync_send(recipient: str, body: str) -> str:
+        return recipient
+
+    async def async_send(recipient: str, body: str) -> str:
+        return recipient
+
+    sync_wrapped = apply_entity_guard(sync_send, policy, tool_name="send_email")
+    async_wrapped = apply_entity_guard(async_send, policy, tool_name="send_email")
+    assert sync_wrapped(recipient="billing@customer.com", body="x") == "billing@customer.com"
+
+    import asyncio
+
+    assert (
+        asyncio.run(async_wrapped(recipient="Billing@Customer.com", body="x"))
+        == "billing@customer.com"
+    )
+
+
+def test_yaml_example_and_production_requires_error() -> None:
+    cfg = load_config_from_string(
+        """
+entity_guard:
+  enabled: true
+  missing_policy: error
+  tools:
+    send_email:
+      destinations:
+        - path: recipient
+          type: email
+          allow:
+            addresses: [billing@customer.com]
+            domains: [customer.com]
+        - path: cc
+          type: email
+          allow: []
+          required: false
+    http_post:
+      destinations:
+        - path: url
+          type: https_url
+          allow:
+            hosts: [api.stripe.com, hooks.slack.com]
+          reject_redirects: true
+    create_ticket:
+      destinations:
+        - path: project_id
+          type: entity_id
+          allow:
+            values: [SUPPORT, INCIDENTS]
+tools:
+  send_email:
+    side_effect_class: non_idempotent_mutate
+  http_post:
+    side_effect_class: non_idempotent_mutate
+  create_ticket:
+    side_effect_class: non_idempotent_mutate
+"""
+    )
+    assert cfg.entity_guard_applies("send_email") is True
+    assert cfg.entity_guard_applies("search") is False
+
+    with pytest.raises(ConfigError, match="entity_guard.missing_policy"):
+        load_config_from_string(
+            """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [send_email]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+entity_guard:
+  enabled: true
+  missing_policy: warn
+  tools:
+    send_email:
+      destinations:
+        - path: recipient
+          type: email
+          allow:
+            addresses: [billing@customer.com]
+tools:
+  send_email:
+    side_effect_class: non_idempotent_mutate
+"""
+        )
+
+
+def test_unknown_yaml_keys_rejected() -> None:
+    with pytest.raises(ConfigError, match="unsupported"):
+        load_config_from_string("entity_guard:\n  llm_allowlist: true\n")
+
+
+def test_doctor_omitted_is_skip(tmp_path: Any) -> None:
+    from mycelium import run_doctor
+
+    path = tmp_path / "mycelium.yaml"
+    path.write_text(
+        """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [charge]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+tools:
+  charge:
+    side_effect_class: non_idempotent_mutate
+""",
+        encoding="utf-8",
+    )
+    report = run_doctor(path, connectivity=False)
+    scanning = next(c for c in report.checks if c.id == "entity.scanning")
+    assert scanning.status == DoctorStatus.SKIP

--- a/sdk/tests/test_production_profile.py
+++ b/sdk/tests/test_production_profile.py
@@ -426,6 +426,37 @@ tools:
     assert cfg.tools["charge"].secret_fields == ("api_key",)
 
 
+def test_production_accepts_entity_guard_error_policy() -> None:
+    cfg = load_config_from_string(
+        """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [send_email]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+entity_guard:
+  enabled: true
+  missing_policy: error
+  tools:
+    send_email:
+      destinations:
+        - path: recipient
+          type: email
+          allow:
+            addresses: [billing@customer.com]
+tools:
+  send_email:
+    side_effect_class: non_idempotent_mutate
+"""
+    )
+    assert cfg.entity_guard is not None
+    assert cfg.entity_guard["missing_policy"] == "error"
+    assert cfg.entity_guard_applies("send_email") is True
+
+
 def test_existing_configs_without_profile_still_load() -> None:
     cfg = load_config_from_string(
         """

--- a/sdk/tests/test_verify.py
+++ b/sdk/tests/test_verify.py
@@ -456,6 +456,7 @@ def test_cli_smoke_each_scenario(tmp_path: Path) -> None:
         "ambiguous-effect",
         "reconcile",
         "secret-in-args",
+        "entity-guard",
     ):
         code = main(
             [
@@ -666,6 +667,7 @@ def test_all_order_sqlite(tmp_path: Path, scenario: str) -> None:
         "ambiguous-effect",
         "reconcile",
         "secret-in-args",
+        "entity-guard",
     ]
     assert all(item.status == VerificationStatus.PASS for item in report.scenarios)
     assert report.empirically_verified is True


### PR DESCRIPTION
## Summary
- Optional `entity_guard:` authorizes write destinations (email, https URL, host, entity id) before ledger claim. Omitted config keeps the existing runtime.
- Each tool declares the destination argument; the host lists allowed entities. Destinations are canonicalized. Missing, malformed, dynamic, undeclared, or unapproved values fail closed.
- Canonical destinations are bound into the operation fingerprint. Evidence records tool, destination class / approved entity id, policy version, and decision — never the payload. The model cannot add allowlist entries.
- Version is **not** bumped.

## Test plan
- [x] `tests/test_entity_guard.py` plus production-profile and verify scenario coverage
- [x] Full suite (1096 passed, 6 skipped) and Ruff
- [ ] Review CHANGELOG Unreleased + destination-policy copy
- [ ] Confirm no `sdk/pyproject.toml` version bump before merge