### PR TITLE
feat: side-effect guardrails batch (AF-010–012) for 1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,60 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+## 1.33.0 (2026-08-15)
+
+MINOR: side-effect guardrails batch for unsafe / irreversible writes.
+Secret-in-args, destination policy, destructive confirm, authority-window
+expiry, and use-time currency ship together so decide-time authority
+cannot authorize a stale execute-time side effect.
+
 ### Added
+
+- **Use-time currency (AF-012):** decide-time facts (refundability, ownership,
+  inventory, policy revision, price, …) are bound at authorize and
+  revalidated at use, immediately before `mark_maybe_crossed` / provider /
+  body. Stale (`age >= max_age_seconds`), changed, missing, false, or
+  unverifiable facts raise `UseTimeCurrencyError`; no body, no provider
+  call, no `maybe_crossed`. Host `use_time_facts.capture` +
+  `register_use_time_validator` only — no prompt scanning. Ordered use
+  boundary: authority-window expiry then currency. Short-lived use-boundary
+  token avoids double validation between `body_start` and
+  `mark_maybe_crossed`. Completed ledger RETURN does not revalidate.
+  Configurable via `use_time_currency:`; omitted keeps existing behavior.
+  Production requires `missing_policy: error`. Together with
+  authority-window expiry, completes the five-item side-effect guardrails
+  batch. `mycelium doctor` / `mycelium verify --scenario use-time-currency`.
+
+- **Authority-window expiry:** time-bounded authority (destructive grants and
+  future adapters) is validated at authorize and again at use, immediately
+  before `mark_maybe_crossed` / provider invocation / tool body side effect.
+  `now >= expires_at` hard-blocks with `AuthorityExpiredError`; no body, no
+  provider call, no `maybe_crossed` marker, no auto-renew. Skew tolerance
+  only narrows validity. Completed ledger RETURN retries do not require
+  fresh authority. Configurable via `authority_window:`; omitted config
+  keeps timeless paths unchanged, while configured `destructive_confirm:`
+  still enforces use-time expiry. `mycelium doctor` reports coverage and
+  labels clock sync / host timestamps / provider auth / post-check gaps
+  `not_verifiable`. Pairs with AF-012 use-time currency for the full batch
+  guarantee. `mycelium verify --scenario authority-window`.
+
+- **Destructive confirm (AF-011):** optional `destructive_confirm:` requires
+  a host-issued grant for a specific operation on a specific canonical
+  object before a configured destructive tool can claim, execute, or
+  cross a side-effect boundary. Tool permission is not object
+  authorization. The model cannot create, widen, renew, or approve a
+  grant. Dual control is intentionally not implemented — two-person
+  approval belongs in the host workflow that calls
+  `issue_destructive_grant`. Retries with the same stable `request_id`
+  reuse the ledger result and do not consume a second use. A grant
+  authorizes an attempt; it does not prove the provider outcome or
+  replace provider idempotency. Production rejects memory grant storage
+  and, on `deployment.topology: multi_node`, file/sqlite storage.
+  Omitted `destructive_confirm:` keeps existing behavior.
+  `mycelium doctor` reports coverage and labels host minting / human
+  approval / provider outcome `not_verifiable`.
+  `mycelium verify --scenario destructive-confirm` proves ungranted
+  objects never claim.
 
 - **Entity / destination guard:** optional `entity_guard:` authorizes write
   destinations (email, https URL, host, entity id) before ledger claim.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The taxonomy **is** the product story. Each ID is a real failure class from prod
 | **AF-007** | Premature termination | Required checklist items must complete before the run can declare success |
 | **AF-008** | Cascading permission | The run tool allowlist freezes; mid-run / handoff widen is refused |
 | **AF-010** | Secret-in-args | Raw credentials are blocked before claim; pass `secret://` references |
+| **AF-011** | Destructive confirm | Tool permission is not object authorization; host-issued grants only |
 | AF-001 / AF-005 / AF-009 | Hallucination · goal misalignment · injection | Roadmap / judgment tier — not claimed as deterministic SDK guards yet |
 
 Full definitions (shipped vs roadmap): [sdk/docs/FAILURE_MODE_CATALOG.md](sdk/docs/FAILURE_MODE_CATALOG.md).
@@ -61,6 +62,9 @@ Mycelium wraps tool calls after the LLM returns `tool_calls` and returns a verdi
 - **Budget / runaway spend (unnumbered)** — `budget:` · ceilings + `@budget_guard` / `instrument_llm` (auto `check("llm")`) · `mycelium budget release`
 - **AF-010 Secret-in-args** — `secret_args:` · block raw credentials before claim · pass `secret://` references · `mycelium verify --scenario secret-in-args`
 - **Entity / destination guard (unnumbered)** — `entity_guard:` · write tools declare the destination argument · host allowlist · fail closed before claim · `mycelium verify --scenario entity-guard`
+- **AF-011 Destructive confirm** — `destructive_confirm:` · host-issued object grant · fail closed before claim · `mycelium verify --scenario destructive-confirm`
+- **Authority-window expiry** — `authority_window:` · re-check time-bounded authority at use before the side-effect boundary · `mycelium verify --scenario authority-window`
+- **Use-time currency (AF-012)** — `use_time_currency:` · revalidate decide-time facts at use · `mycelium verify --scenario use-time-currency`
 - **AF-006 Context corruption** — `@protect` / Session · optional message/history validation
 - **AF-007 Premature termination** — `completion:` host checklist · refuse or warn-and-allow
 - **AF-008 Scope escalation** — `scope_guard:` freeze allowlist · re-check every step

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -768,7 +768,7 @@ The boundary drives failure classification and only ever moves forward (`not_cro
 | `maybe_crossed` (inside the block / crash) | `UNKNOWN` | hard-block → reconcile |
 | `crossed` (clean exit, or `mark_crossed()`) | `FAILED_AFTER_EFFECT` | hard-block |
 
-Because `maybe_crossed` is written durably *before* the call, a process crash mid-call leaves the entry ambiguous and a redispatch hard-blocks instead of double-spending. For finer control use `mark_maybe_crossed()` / `mark_crossed()` directly. Works the same inside `async` tools.
+Because `maybe_crossed` is written durably *before* the call, a process crash mid-call leaves the entry ambiguous and a redispatch hard-blocks instead of double-spending. For finer control use `mark_maybe_crossed()` / `mark_crossed()` directly. Async tools use `async with side_effect_async()` so async use-time validators are awaited at the final boundary.
 
 ### Read-only `SOFT_BLOCK` (v1.9.0)
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -64,6 +64,9 @@ Mycelium sits between your agent loop and your tools (after the LLM returns `too
 | **Opt-in** | **Budget / runaway spend (unnumbered)** | `budget:` — `max_duration` / `max_steps` / `max_tokens` / `max_usd`; tools auto-wrapped; **LLM turns auto-wired** on LangGraph/LangChain; `missing_usage_policy`; operator `mycelium budget release` |
 | **Opt-in** | **AF-010 Secret-in-args** | `secret_args:` — block raw credentials before claim; pass `secret://` references; shared sanitizer on evidence. Fail-closed is primary; redaction is defense-in-depth |
 | **Opt-in** | **Entity / destination guard (unnumbered)** | `entity_guard:` — a write may carry sensitive data only into a host-authorized destination; unknown destination means no execution |
+| **Opt-in** | **AF-011 Destructive confirm** | `destructive_confirm:` — tool permission is not object authorization; a host-issued grant is required for the exact operation and canonical object |
+| **Opt-in** | **Authority-window expiry** | `authority_window:` — re-validate time-bounded authority at use (after lease/backoff, before `mark_maybe_crossed`) |
+| **Opt-in** | **AF-012 Use-time currency** | `use_time_currency:` — revalidate decide-time facts at use; stale/changed/missing/unverifiable facts cannot authorize a side effect |
 | **Opt-in** | **AF-004 Tool misuse** | `@bounded` input/output/scope checks; optional `ToolRegistry` allowlist — block before the tool runs |
 | **Opt-in** | **AF-006 Context corruption** | TTL cache (`@protect` / `Session`); optional `MessageValidator` / `HistoryGuard` before the next LLM turn |
 | **Opt-in** | **AF-007 Premature termination** | `completion:` — host checklist; unmarked **required** → refuse terminal; unmarked **optional** → warn and allow |
@@ -1106,9 +1109,9 @@ run. LangGraph's adapter copies an existing framework `run_id` into
 `execution_scope` — do not pass a duplicate when the adapter already provides
 one.
 
-Wrapper order: `@secret_args` → `@entity_guard` → `@state_authority` →
-`@scope_guard` → `@budget_guard` → `@loop_guard` → `@ledger` → `@bounded` →
-`@protect` → `func`.
+Wrapper order: `@secret_args` → `@entity_guard` → `@destructive_confirm` →
+`@state_authority` → `@scope_guard` → `@budget_guard` → `@loop_guard` →
+`@ledger` → `@bounded` → `@protect` → `func`.
 
 ### Budget guard (unnumbered)
 
@@ -1289,6 +1292,189 @@ consequential tools lack a declaration.
 `mycelium verify --scenario entity-guard` proves unauthorized destinations
 never claim.
 
+### Destructive confirm (AF-011)
+
+Tool permission is not object authorization. A configured destructive
+tool — refund, delete, cancel, settle, revoke, terminate, purge,
+overwrite — may claim or execute only when the host has granted **this
+exact operation** on **this exact canonical object**, in this scope/run
+when bound, before expiry, for at most `max_uses`. The model cannot
+create, widen, renew, or approve a grant. Dual control is intentionally
+not implemented; teams that need two-person approval must enforce it in
+the host workflow **before** grant issuance.
+
+```yaml
+destructive_confirm:
+  enabled: true
+  missing_policy: error
+
+  tools:
+    refund_payment:
+      operation: refund
+      object:
+        type: payment
+        id_from: payment_id
+      grant:
+        bind_request_id: true
+        max_uses: 1
+        ttl_seconds: 300
+    delete_file:
+      operation: delete
+      object:
+        type: file
+        id_from: file_id
+      grant:
+        bind_request_id: true
+        max_uses: 1
+        ttl_seconds: 120
+
+authority_window:
+  enabled: true
+  use_time_check: required
+  clock_skew_tolerance_seconds: 0
+```
+
+Authorization is checked again immediately before use. Expiry at or before
+the use instant (`now >= expires_at`) blocks execution; completed-result
+reads remain available. Mycelium cannot guarantee authority remains valid
+throughout an external network call. Clock synchronization is an
+operational assumption unless storage/server time is authoritative. This
+item alone does not complete use-time currency — do not release until that
+lands.
+
+```python
+from mycelium import (
+    TransitionScope,
+    destructive_grants,
+    execution_scope,
+    issue_destructive_grant,
+)
+
+grant = destructive_grants.issue(
+    operation="refund",
+    object_type="payment",
+    object_id=payment.id,
+    request_id=request.id,
+    expires_in=300,
+)
+
+with execution_scope(
+    TransitionScope(run_id=server_run.id, destructive_grants=(grant,))
+):
+    agent.run(...)
+```
+
+Do not infer destructiveness from tool names. Production protection
+depends on this explicit configuration or a trusted
+`side_effect_class: irreversible` declaration (production fails startup
+if an irreversible tool is undeclared). Grants are minted only through
+`issue_destructive_grant` / `destructive_grants.issue` — never accepted
+as a model-generated dictionary. Object type, object id, and operation
+are canonicalized before compare; custom canonicalizers register with
+`register_destructive_object_canonicalizer` and run before claim.
+
+Enforcement runs after ordinary argument validation and before ledger
+claim, lease, tool body, provider call, or any side effect. A missing,
+expired, exhausted, mismatched, or unverifiable grant raises
+`DestructiveGrantError` and does not create a claim. Canonical
+operation and object identity are bound into the ledger fingerprint so
+the same `request_id` with a changed target fails closed. A retry with
+the same stable `request_id`, operation, object, and meaningful
+arguments reuses the ledger result and does not consume a second grant
+use. If the first attempt is ambiguous after a possible provider
+crossing, a fresh grant does not authorize a second body — use
+reconcile or hard-block resolution.
+
+For `keyed_mutate` tools, reuse the same stable business `request_id` as
+the provider idempotency key where the provider supports it and the
+tool declares a safe mapping. Mycelium does not auto-inject
+provider-specific idempotency parameters. A grant authorizes an
+attempt; it does not replace provider idempotency or prove the
+provider's final outcome. Mycelium does not claim exactly-once
+external effects.
+
+Grant storage: `memory` (dev/test only), `file` / `sqlite` (single-node),
+`redis` / `postgres` (multi-worker). Production rejects memory.
+Multi-node production rejects file/sqlite. Omitted
+`destructive_confirm:` keeps existing behavior.
+
+`mycelium doctor` checks that configured tools identify an exact object,
+that production is fail-closed and durable, and labels what cannot be
+proven from configuration: host call sites actually mint grants, the
+human approval process, provider idempotency, and external side
+effects. Installed adapters are not treated as wired.
+`mycelium verify --scenario destructive-confirm` proves ungranted
+objects never claim.
+
+### Authority-window expiry
+
+Time-bounded authority must still be valid at the side-effect boundary.
+Mycelium validates at authorize and again at use (after lease / queue /
+backoff, before `mark_maybe_crossed` / provider / body). `now >=
+expires_at` raises `AuthorityExpiredError`. Skew tolerance never extends
+expired authority. Completed ledger RETURN does not need fresh
+authority. Omitted `authority_window:` keeps timeless paths unchanged;
+configured `destructive_confirm:` still enforces use-time expiry.
+Pairs with AF-012 use-time currency for the full batch guarantee.
+`mycelium verify --scenario authority-window`.
+
+### Use-time currency (AF-012)
+
+Decide-time truth is not execute-time authority. Facts the agent used to
+decide (refundability, ownership, inventory, policy revision, price) must
+still be current at the side-effect boundary. Hosts declare required facts
+and register validators; Mycelium authorizes/binds before claim and
+revalidates at use (after lease/backoff, before `mark_maybe_crossed` /
+body). Stale (`age >= max_age_seconds`), changed, missing, or unverifiable
+facts raise `UseTimeCurrencyError` — no body, no provider call, no
+`maybe_crossed`. Prompt scanning is not used. Completed ledger RETURN does
+not revalidate. Provider preconditions (ETag / If-Match) may be declared
+explicitly; local revalidation cannot eliminate a fact change during a
+remote network call. Omitted `use_time_currency:` keeps existing behavior.
+Production requires `missing_policy: error`. Together with authority-window
+expiry, this completes the five-item side-effect guardrails batch.
+`mycelium verify --scenario use-time-currency`.
+
+```yaml
+use_time_currency:
+  enabled: true
+  missing_policy: error
+  tools:
+    refund_payment:
+      facts:
+        - name: payment.refundable
+          subject: {type: payment, id_from: payment_id}
+          validator: payment_state
+          require: {value: true}
+          revision_from: payment_version
+          max_age_seconds: 30
+          bind_request_id: true
+```
+
+```python
+from mycelium import register_use_time_validator, use_time_facts, ValidatorResult
+
+def payment_state(*, fact, subject_id, **_):
+    payment = load_payment(subject_id)  # host authoritative source
+    return ValidatorResult(
+        current=payment.refundable,
+        value=payment.refundable,
+        revision=str(payment.version),
+    )
+
+register_use_time_validator("payment_state", payment_state)
+use_time_facts.capture(
+    name="payment.refundable",
+    subject_type="payment",
+    subject_id=payment.id,
+    value=True,
+    revision=payment.version,
+    max_age_seconds=30,
+    request_id=request_id,
+    require_value=True,
+)
+```
+
 ### Scope guard (AF-008): freeze run tool allowlist
 
 AF-008 is when a narrow grant **widens mid-run** (handoff, dynamic
@@ -1319,7 +1505,7 @@ with execution_scope(TransitionScope(run_id="r1", thread_id="t")):
     fetch_customer(customer_id="c1")  # ok; tools outside the freeze soft-block
 ```
 
-Wrapper order: `@secret_args` → `@entity_guard` → `@scope_guard` → `@loop_guard` → `@ledger` →
+Wrapper order: `@secret_args` → `@entity_guard` → `@destructive_confirm` → `@scope_guard` → `@loop_guard` → `@ledger` →
 `@bounded` → `@protect`. CLI: `mycelium scope status|bind`. Demo:
 `python examples/scope_guard_allowlist.py` (from `sdk/`).
 
@@ -1435,7 +1621,7 @@ def refund(amount: float, *, tool_call_id: str, state_ref: str) -> dict:
     ...
 ```
 
-Wrapper order: `@secret_args` → `@entity_guard` → `@state_authority` → `@scope_guard` →
+Wrapper order: `@secret_args` → `@entity_guard` → `@destructive_confirm` → `@state_authority` → `@scope_guard` →
 `@loop_guard` → `@ledger` → `@bounded` → `@protect` → `func`.
 
 `decision_id` / `state_ref` are bookkeeping kwargs (excluded from the args
@@ -1601,6 +1787,11 @@ policies:
   is rejected. Omitted `secret_args:` stays backward compatible.
 - `entity_guard.missing_policy: error` when `entity_guard:` is enabled.
   Omitted `entity_guard:` stays backward compatible.
+- `destructive_confirm.missing_policy: error` when `destructive_confirm:`
+  is enabled. Production grant storage must be durable (not memory).
+  Multi-node production requires redis or postgres. Irreversible tools
+  must be declared. Omitted `destructive_confirm:` stays backward
+  compatible.
 
 Explicit weaker settings (`warn`, `derived`, memory outcomes) under
 production are rejected (`ConfigError`), not silently weakened. Omit
@@ -1705,7 +1896,8 @@ $ mycelium verify --config mycelium.yaml --scenario all --strict --json
 ```
 
 Scenarios: `redispatch`, `contention`, `storage-outage`, `worker-crash`,
-`ambiguous-effect`, `reconcile`, `secret-in-args`, `entity-guard`, or `all` (that order). Verify never executes
+`ambiguous-effect`, `reconcile`, `secret-in-args`, `entity-guard`,
+`destructive-confirm`, `authority-window`, or `all` (that order). Verify never executes
 application tools, never calls an LLM, never contacts a real business provider,
 and never inspects or alters existing production transitions. Test data uses a
 unique `mycelium:verify:<uuid>:` namespace and is deleted unless

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -221,6 +221,35 @@ section; the tests are concrete `file::test_name` entries.
     payload. Omitted `entity_guard:` keeps existing behavior.
     *Where:* [Entity / destination guard](../README.md#entity--destination-guard-unnumbered).
 
+19. **Destructive confirm (when `destructive_confirm:` is enabled).** A
+    destructive tool may execute only with a host-issued grant for this
+    exact operation and canonical object, before expiry, for at most
+    `max_uses`. Tool permission is not object authorization. The model
+    cannot mint or widen grants. Dual control is not implemented.
+    Omitted `destructive_confirm:` keeps existing behavior.
+    *Where:* [Destructive confirm (AF-011)](../README.md#destructive-confirm-af-011).
+
+20. **Authority-window expiry (when time-bounded authority is in play).**
+    An authorize-phase check is not enough. Mycelium re-validates expiry
+    at use — after lease/queue/backoff waits, immediately before
+    `mark_maybe_crossed` / provider / consequential body. `now >=
+    expires_at` raises `AuthorityExpiredError` without executing the body
+    or marking the boundary crossed. Completed ledger RETURN still works
+    without fresh authority. Mycelium does not guarantee authority remains
+    valid during a remote network call. Clock sync across machines is an
+    operational assumption unless storage time is authoritative. Pairs with
+    AF-012 use-time currency for fact freshness beyond expiry.
+    *Where:* `authority_window:` / `validate_authority_at_use`.
+
+21. **Use-time currency (when `use_time_currency:` is enabled).** A
+    decide-time fact that is stale, changed, missing, or unverifiable at
+    execute cannot authorize a consequential side effect.
+    `UseTimeCurrencyError` hard-blocks before the side-effect boundary.
+    Host facts and validators only — no prompt scanning. Completed RETURN
+    does not revalidate. Local revalidation cannot eliminate a fact change
+    during a remote network call.
+    *Where:* [Use-time currency (AF-012)](../README.md#use-time-currency-af-012).
+
 ---
 
 ## D. What we do not protect
@@ -340,6 +369,9 @@ are cited once. "Where documented" links the README section.
 | Task-level idempotency | README § [Quickstart: task-level idempotency](../README.md#quickstart-task-level-idempotency) | `test_cli_run.py::test_run_instruments_sync_tool_and_task_across_processes` |
 | Secret-in-args (when enabled) | README § [Secret-in-args (AF-010)](../README.md#secret-in-args-af-010) | `test_secret_protection.py` · `test_verify.py::test_cli_smoke_each_scenario` (`secret-in-args`) |
 | Destination policy (when enabled) | README § [Entity / destination guard](../README.md#entity--destination-guard-unnumbered) | `test_entity_guard.py` · `test_verify.py::test_cli_smoke_each_scenario` (`entity-guard`) |
+| Destructive confirm (when enabled) | README § [Destructive confirm (AF-011)](../README.md#destructive-confirm-af-011) | `test_destructive_confirm.py` · `test_verify.py::test_cli_smoke_each_scenario` (`destructive-confirm`) |
+| Authority-window expiry (when enabled) | README § [Authority-window expiry](../README.md#authority-window-expiry) | `test_authority_window.py` · `test_verify.py::test_cli_smoke_each_scenario` (`authority-window`) |
+| Use-time currency (when enabled) | README § [Use-time currency (AF-012)](../README.md#use-time-currency-af-012) | `test_use_time_currency.py` · `test_verify.py::test_cli_smoke_each_scenario` (`use-time-currency`) |
 | Single-key state machine invariants (executions ≤ 1 + not-executed verdicts; COMPLETED terminal; CAS out of IN_FLIGHT) | this doc, § C / [NOT_EXECUTED reset CAS](../README.md#not_executed-reset-cas-v118) | `test_property_transitions.py::test_transition_key_invariants` (Hypothesis, file + Redis) · `test_payment_provider_mock.py::test_redispatch_storm_never_double_charges` |
 
 <sup>1</sup> `test_postgres_storage_atomic_claim` runs when `psycopg` is

--- a/sdk/docs/FAILURE_MODE_CATALOG.md
+++ b/sdk/docs/FAILURE_MODE_CATALOG.md
@@ -1,4 +1,4 @@
-# Failure-mode catalog (AF-001…AF-010)
+# Failure-mode catalog (AF-001…AF-011)
 
 **The taxonomy is the product story.** Mycelium is the reliability layer for AI
 agents; these IDs are the public promise. Stable across the SDK README,
@@ -17,6 +17,8 @@ LangGraph, CrewAI, AutoGen, Cline, OpenHands, and related stacks.
 | AF-008 | Cascading permission | `scope_guard:` / `@scope_guard` |
 | AF-009 | Instruction injection | (MCP gateway revisit; not in SDK) |
 | AF-010 | Secret-in-args | `secret_args:` / `SecretInArgsError` · `secret://` references · shared sanitizer |
+| AF-011 | Destructive confirm | `destructive_confirm:` / `DestructiveGrantError` · host-issued object grant · fail closed before claim |
+| AF-012 | Use-time currency | `use_time_currency:` / `UseTimeCurrencyError` · revalidate decide-time facts at use · fail closed before side effect |
 | — | Exfil via write / destination policy | `entity_guard:` / `EntityGuardError` · host allowlist · fail closed before claim |
 
 ---
@@ -218,6 +220,75 @@ provider code; Doctor labels those paths `not_verifiable`.
 
 ---
 
+## AF-011 Destructive confirm
+
+**Class:** Unauthorized irreversible mutation
+
+**One line:** Tool permission is not object authorization. A delete, refund,
+cancel, settle, revoke, terminate, purge, or overwrite executes only when
+the host has granted that exact operation on that exact canonical object.
+
+**What users hit:** a model with `refund_payment` permission refunds the
+wrong payment, or retries a refund after an ambiguous crash because a
+second grant existed.
+
+**Guard:** optional `destructive_confirm:`. Listed tools declare the
+canonical operation, object type, and argument path for the object id.
+The host mints a `DestructiveGrant` through `issue_destructive_grant` /
+`destructive_grants.issue` and places it on `TransitionScope`. Enforcement
+runs after ordinary argument validation and before ledger claim, lease,
+tool body, or any side effect. Missing, expired, exhausted, mismatched,
+or unverifiable grants raise `DestructiveGrantError` and do not claim.
+Retries with the same stable `request_id` reuse the ledger result and do
+not consume a second use. Dual control is intentionally not implemented
+— two-person approval belongs in the host workflow that issues the grant.
+A grant authorizes an attempt; it does not prove the provider outcome.
+Omitted `destructive_confirm:` keeps existing behavior.
+
+---
+
+## Authority-window expiry (unnumbered; batch with AF-011)
+
+**Class:** Authorization timing / side-effect boundary
+
+**One line:** No consequential operation may cross its side-effect boundary
+using authority that expired after authorization but before use.
+
+**What users hit:** a host grant was valid when the tool was claimed, but
+expired while waiting for a lease, queue, backoff, or confirmation — and
+the body still ran.
+
+**Guard:** `authority_window:` plus use-time checks on registered
+`BoundAuthority` (including AF-011 destructive grants). Validate at
+authorize and again immediately before `mark_maybe_crossed` / provider /
+body. `AuthorityExpiredError` hard-blocks; no auto-renew. Completed
+ledger RETURN does not require fresh authority. Pairs with AF-012
+use-time currency for fact freshness beyond expiry.
+
+---
+
+## AF-012 Use-time currency
+
+**Class:** Authorization freshness / side-effect boundary
+
+**One line:** A decide-time fact that is stale, changed, missing,
+unverifiable, or outside its freshness window at execute cannot authorize
+a consequential side effect.
+
+**What users hit:** an account was refundable when the agent planned the
+refund, but ownership, inventory, policy, or refundability changed while
+waiting for a lease — and the body still ran on decide-time truth.
+
+**Guard:** `use_time_currency:` / `use_time_facts.capture` /
+`register_use_time_validator`. Authorize binds host facts; use revalidates
+immediately before the side-effect boundary (after authority-window
+expiry). `UseTimeCurrencyError` hard-blocks. `age >= max_age_seconds` is
+stale. No prompt scanning. Completed RETURN does not revalidate. Does not
+eliminate the remote-call race; provider preconditions narrow it when
+declared.
+
+---
+
 ## Budget enforcement (unnumbered)
 
 **Class:** Run-level reliability / blast-radius
@@ -253,3 +324,5 @@ Budget is intentionally **not** given an AF-00N id. See
   intentionally **not** given an AF-00N id. AF-010 is secret-in-args.
 - **Destination policy** ships as `entity_guard:` and is also unnumbered:
   a write may carry sensitive data only into a host-authorized destination.
+- **AF-011** is destructive confirm: tool permission is not object
+  authorization.

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -35,9 +35,11 @@ from mycelium.action_ledger import (
     ledger_sync,
     mark_crossed,
     mark_maybe_crossed,
+    mark_maybe_crossed_async,
     record_external_operation,
     renew_lease,
     side_effect,
+    side_effect_async,
 )
 from mycelium.audit_receipt import (
     AuditReceiptEmitter,
@@ -379,7 +381,9 @@ __all__ = [
     "ledger",
     "ledger_sync",
     "side_effect",
+    "side_effect_async",
     "mark_maybe_crossed",
+    "mark_maybe_crossed_async",
     "mark_crossed",
     "record_external_operation",
     "renew_lease",

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -47,6 +47,13 @@ from mycelium.audit_receipt import (
     InMemoryAuditReceiptStorage,
     verify_receipt,
 )
+from mycelium.authority_window import (
+    AuthorityExpiredError,
+    AuthorityValidation,
+    AuthorityValidationPhase,
+    BoundAuthority,
+    validate_authority_at_use,
+)
 from mycelium.budget_guard import (
     KIND_LLM,
     KIND_TOOL,
@@ -125,6 +132,15 @@ from mycelium.config import (
     TransitionConfig,
     load_config,
     load_config_from_string,
+)
+from mycelium.destructive_confirm import (
+    DestructiveGrant,
+    DestructiveGrantError,
+    apply_destructive_confirm,
+    destructive_grants,
+    enforce_destructive_confirm,
+    issue_destructive_grant,
+    register_destructive_object_canonicalizer,
 )
 from mycelium.doctor import (
     EVIDENCE_CONNECTIVITY,
@@ -294,6 +310,16 @@ from mycelium.transition_resolution import (
     TransitionGate,
     repair_transition_fields,
     transition_needs_repair,
+)
+from mycelium.use_time_currency import (
+    UseTimeCurrencyError,
+    UseTimeFact,
+    UseTimeValidation,
+    ValidatorResult,
+    apply_use_time_currency,
+    enforce_use_boundary,
+    register_use_time_validator,
+    use_time_facts,
 )
 from mycelium.verify import (
     IsolationRefused,
@@ -480,6 +506,26 @@ __all__ = [
     "protect",
     "protect_sync",
     "PAYLOAD_OMITTED",
+    "AuthorityExpiredError",
+    "AuthorityValidation",
+    "AuthorityValidationPhase",
+    "BoundAuthority",
+    "validate_authority_at_use",
+    "UseTimeCurrencyError",
+    "UseTimeFact",
+    "UseTimeValidation",
+    "ValidatorResult",
+    "apply_use_time_currency",
+    "enforce_use_boundary",
+    "register_use_time_validator",
+    "use_time_facts",
+    "DestructiveGrant",
+    "DestructiveGrantError",
+    "apply_destructive_confirm",
+    "destructive_grants",
+    "enforce_destructive_confirm",
+    "issue_destructive_grant",
+    "register_destructive_object_canonicalizer",
     "EntityGuardError",
     "apply_entity_guard",
     "canonicalize_email",

--- a/sdk/mycelium/__main__.py
+++ b/sdk/mycelium/__main__.py
@@ -1127,7 +1127,8 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Scenario to run (repeatable): redispatch, contention, "
             "worker-crash, storage-outage, ambiguous-effect, reconcile, "
-            "secret-in-args, entity-guard, or all"
+            "secret-in-args, entity-guard, destructive-confirm, "
+            "authority-window, use-time-currency, or all"
         ),
     )
     verify_parser.add_argument(

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -14,12 +14,12 @@ import threading
 import time
 import uuid
 import warnings
-from collections.abc import Awaitable, Callable, Iterator, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncIterator, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
 from mycelium.reconcile import Reconciler, ReconcileResult, ReconcileStatus
 from mycelium.session import Session, _session_var
@@ -3478,6 +3478,13 @@ def _use_boundary_call_mapping(
     clean_kwargs: Mapping[str, Any],
     dispatch_kwargs: Mapping[str, Any],
 ) -> dict[str, Any]:
+    """Canonical tool args for use-boundary validation.
+
+    Authorize-time ``request_id`` is retained for call comparisons / validators.
+    Configured request bindings at USE compare against the current trusted
+    ``dispatch_scope`` (see use_time_currency._current_context_ids), not this
+    frozen authorize-time copy.
+    """
     mapping = _canonical_call_mapping(func, args, clean_kwargs)
     request_id = dispatch_kwargs.get("request_id")
     if isinstance(request_id, str) and request_id.strip():

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -3472,6 +3472,19 @@ def _canonical_call_mapping(
     return mapping
 
 
+def _use_boundary_call_mapping(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    clean_kwargs: Mapping[str, Any],
+    dispatch_kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    mapping = _canonical_call_mapping(func, args, clean_kwargs)
+    request_id = dispatch_kwargs.get("request_id")
+    if isinstance(request_id, str) and request_id.strip():
+        mapping["request_id"] = request_id
+    return mapping
+
+
 def _claim_kwargs(kwargs: dict[str, Any], clean_kwargs: dict[str, Any]) -> dict[str, Any]:
     """Kwargs for claim: tool args plus optional bookkeeping pass-through.
 
@@ -3727,7 +3740,7 @@ def _run_ledgered(
         owner=owner,
     )
 
-    call_mapping = _canonical_call_mapping(func, args, clean_kwargs)
+    call_mapping = _use_boundary_call_mapping(func, args, clean_kwargs, kwargs)
     token = _active_transition_var.set(
         _ActiveTransition(
             ledger,
@@ -4037,7 +4050,7 @@ async def _run_ledgered_async(
         owner=owner,
     )
 
-    call_mapping = _canonical_call_mapping(func, args, clean_kwargs)
+    call_mapping = _use_boundary_call_mapping(func, args, clean_kwargs, kwargs)
     token = _active_transition_var.set(
         _ActiveTransition(
             ledger,

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -14,7 +14,7 @@ import threading
 import time
 import uuid
 import warnings
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import Awaitable, Callable, Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
@@ -318,6 +318,7 @@ class _ActiveTransition:
     ledger: ActionLedger
     request_id: str
     binding: ToolTransitionBinding | None
+    call_kwargs: Mapping[str, Any]
 
 
 _active_transition_var: ContextVar[_ActiveTransition | None] = ContextVar(
@@ -372,7 +373,8 @@ def mark_maybe_crossed() -> None:
     """
     from mycelium.use_time_currency import enforce_use_boundary
 
-    enforce_use_boundary(skip_if_token_valid=True)
+    active = _active_transition_var.get()
+    enforce_use_boundary(kwargs=active.call_kwargs if active is not None else {})
     _advance_active_boundary(SideEffectBoundary.MAYBE_CROSSED)
 
 
@@ -3438,6 +3440,19 @@ def _args_drift_scopes_match(
     return incoming == stored
 
 
+def _canonical_call_mapping(
+    func: Callable[..., Any], args: tuple[Any, ...], kwargs: Mapping[str, Any]
+) -> dict[str, Any]:
+    mapping = dict(kwargs)
+    try:
+        bound = inspect.signature(func).bind_partial(*args, **kwargs)
+        bound.apply_defaults()
+        mapping.update(bound.arguments)
+    except (TypeError, ValueError):
+        pass
+    return mapping
+
+
 def _claim_kwargs(kwargs: dict[str, Any], clean_kwargs: dict[str, Any]) -> dict[str, Any]:
     """Kwargs for claim: tool args plus optional bookkeeping pass-through.
 
@@ -3694,7 +3709,12 @@ def _run_ledgered(
     )
 
     token = _active_transition_var.set(
-        _ActiveTransition(ledger, request_id, transition_binding)
+        _ActiveTransition(
+            ledger,
+            request_id,
+            transition_binding,
+            _canonical_call_mapping(func, args, clean_kwargs),
+        )
     )
     try:
         from mycelium.authority_window import AuthorityExpiredError
@@ -4000,7 +4020,12 @@ async def _run_ledgered_async(
     )
 
     token = _active_transition_var.set(
-        _ActiveTransition(ledger, request_id, transition_binding)
+        _ActiveTransition(
+            ledger,
+            request_id,
+            transition_binding,
+            _canonical_call_mapping(func, args, clean_kwargs),
+        )
     )
     try:
         from mycelium.authority_window import AuthorityExpiredError

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -365,7 +365,14 @@ def mark_maybe_crossed() -> None:
     raises or the process crashes after this point, the durable entry retains
     ``maybe_crossed`` so a redispatch hard-blocks instead of re-executing a
     possibly-already-applied side effect.
+
+    Time-bounded authority and use-time currency are re-validated here
+    (use phase) before the boundary advances. Expired authority or a
+    stale/changed fact hard-blocks and never marks ``maybe_crossed``.
     """
+    from mycelium.use_time_currency import enforce_use_boundary
+
+    enforce_use_boundary(skip_if_token_valid=True)
     _advance_active_boundary(SideEffectBoundary.MAYBE_CROSSED)
 
 
@@ -498,6 +505,10 @@ def side_effect() -> Iterator[None]:
         def send_payment(amount, recipient):
             with side_effect():
                 return gateway.charge(amount, recipient)
+
+    Use-time authority expiry is enforced inside :func:`mark_maybe_crossed`
+    immediately before the boundary advances — after leases, queues, and
+    backoff, and before any provider call.
     """
     mark_maybe_crossed()
     yield
@@ -3291,6 +3302,10 @@ def _args_drift_exclude_keys(
 
 
 def _evidence_value(value: Any) -> Any:
+    from mycelium.destructive_confirm import (
+        get_active_destructive_policy,
+        sanitize_destructive_evidence,
+    )
     from mycelium.entity_guard import get_active_entity_policy, sanitize_entity_evidence
     from mycelium.secret_protection import get_active_secret_policy, sanitize_for_evidence
 
@@ -3302,11 +3317,19 @@ def _evidence_value(value: Any) -> Any:
         if isinstance(result, dict):
             _args, scrubbed = sanitize_entity_evidence((), result)
             del _args
-            return scrubbed
+            result = scrubbed
+    if get_active_destructive_policy() is not None and isinstance(result, dict):
+        _args, scrubbed = sanitize_destructive_evidence((), result)
+        del _args
+        return scrubbed
     return result
 
 
 def _evidence_args(args: Any, kwargs: Any) -> tuple[list[Any], dict[str, Any]]:
+    from mycelium.destructive_confirm import (
+        get_active_destructive_policy,
+        sanitize_destructive_evidence,
+    )
     from mycelium.entity_guard import get_active_entity_policy, sanitize_entity_evidence
     from mycelium.secret_protection import get_active_secret_policy, sanitize_secrets
 
@@ -3322,6 +3345,8 @@ def _evidence_args(args: Any, kwargs: Any) -> tuple[list[Any], dict[str, Any]]:
         out_args, out_kwargs = list(safe["args"]), dict(safe["kwargs"])
     if get_active_entity_policy() is not None:
         out_args, out_kwargs = sanitize_entity_evidence(out_args, out_kwargs)
+    if get_active_destructive_policy() is not None:
+        out_args, out_kwargs = sanitize_destructive_evidence(out_args, out_kwargs)
     return out_args, out_kwargs
 
 
@@ -3361,11 +3386,33 @@ def _args_drift_fingerprint(
     from mycelium.entity_guard import destination_fingerprint, get_active_entity_decision
 
     dests = destination_fingerprint(get_active_entity_decision())
-    if not dests:
+    from mycelium.destructive_confirm import (
+        destructive_fingerprint,
+        get_active_destructive_decision,
+        get_active_destructive_policy,
+        sanitize_destructive_evidence,
+    )
+
+    if get_active_destructive_policy() is not None:
+        scrubbed_args, scrubbed_kwargs = sanitize_destructive_evidence(args, filtered)
+        digest = (
+            fingerprint_args(tuple(scrubbed_args), scrubbed_kwargs)
+            if policy is not None and policy.enabled
+            else args_fingerprint(tuple(scrubbed_args), scrubbed_kwargs)
+        )
+    destructive = destructive_fingerprint(get_active_destructive_decision())
+    from mycelium.use_time_currency import (
+        get_pending_use_time_facts,
+        use_time_fingerprint,
+    )
+
+    currency = use_time_fingerprint(get_pending_use_time_facts())
+    extra = tuple(dests) + tuple(destructive) + tuple(currency)
+    if not extra:
         return digest
     import hashlib
 
-    return hashlib.sha256(f"{digest}|{'|'.join(dests)}".encode()).hexdigest()
+    return hashlib.sha256(f"{digest}|{'|'.join(extra)}".encode()).hexdigest()
 
 
 def _args_drift_scope_key(kwargs: dict[str, Any]) -> str | None:
@@ -3645,21 +3692,115 @@ def _run_ledgered(
         authorized_reexec=authorized_reexec,
         owner=owner,
     )
-    ledger._emit_outcome(
-        request_id=request_id,
-        tool=tool_name,
-        event="body_start",
-        terminal_outcome=TerminalOutcome.IN_FLIGHT,
-        side_effect_class=side_effect_class,
-        tool_body_executed=True,
-        authorized_reexec=authorized_reexec,
-        owner=owner,
-    )
 
     token = _active_transition_var.set(
         _ActiveTransition(ledger, request_id, transition_binding)
     )
     try:
+        from mycelium.authority_window import AuthorityExpiredError
+        from mycelium.use_time_currency import (
+            UseTimeCurrencyError,
+            enforce_use_boundary,
+        )
+
+        # Use-phase authority + currency after claim/lease wait, before body_start.
+        try:
+            auth_decision, currency_decision = enforce_use_boundary(
+                kwargs=clean_kwargs
+            )
+        except (AuthorityExpiredError, UseTimeCurrencyError) as blocked:
+            event = (
+                "use_time_currency"
+                if isinstance(blocked, UseTimeCurrencyError)
+                else "authority_window"
+            )
+            try:
+                ledger._emit_outcome(
+                    request_id=request_id,
+                    tool=tool_name,
+                    event=event,
+                    gate="DENY",
+                    terminal_outcome=TerminalOutcome.FAILED_BEFORE_EFFECT,
+                    side_effect_class=side_effect_class,
+                    tool_body_executed=False,
+                    authorized_reexec=authorized_reexec,
+                    owner=owner,
+                    error_class=type(blocked).__name__,
+                    policy_version=(
+                        transition_binding.policy_version
+                        if transition_binding is not None
+                        else None
+                    ),
+                )
+            except Exception:
+                _logger.exception(
+                    "could not emit %s denial for %s",
+                    event,
+                    request_id,
+                )
+            raise
+
+        if getattr(auth_decision, "decision", "skipped") != "skipped":
+            try:
+                ledger._emit_outcome(
+                    request_id=request_id,
+                    tool=tool_name,
+                    event="authority_window",
+                    gate="ALLOW",
+                    terminal_outcome=TerminalOutcome.IN_FLIGHT,
+                    side_effect_class=side_effect_class,
+                    tool_body_executed=False,
+                    authorized_reexec=authorized_reexec,
+                    owner=owner,
+                    policy_version=getattr(auth_decision, "policy_version", None)
+                    or (
+                        transition_binding.policy_version
+                        if transition_binding is not None
+                        else None
+                    ),
+                )
+            except Exception:
+                _logger.exception(
+                    "could not emit authority_window allow for %s",
+                    request_id,
+                )
+
+        if currency_decision.decision != "skipped":
+            try:
+                ledger._emit_outcome(
+                    request_id=request_id,
+                    tool=tool_name,
+                    event="use_time_currency",
+                    gate="ALLOW",
+                    terminal_outcome=TerminalOutcome.IN_FLIGHT,
+                    side_effect_class=side_effect_class,
+                    tool_body_executed=False,
+                    authorized_reexec=authorized_reexec,
+                    owner=owner,
+                    policy_version=currency_decision.policy_version
+                    or (
+                        transition_binding.policy_version
+                        if transition_binding is not None
+                        else None
+                    ),
+                )
+            except Exception:
+                _logger.exception(
+                    "could not emit use_time_currency allow for %s",
+                    request_id,
+                )
+
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="body_start",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT,
+            side_effect_class=side_effect_class,
+            tool_body_executed=True,
+            authorized_reexec=authorized_reexec,
+            owner=owner,
+        )
+
         from mycelium.secret_protection import (
             get_active_secret_policy,
             resolve_declared_secret_fields,
@@ -3672,6 +3813,18 @@ def _run_ledgered(
         )
         with _lease_auto_renew(ledger, request_id):
             result = func(*exec_args, **exec_kwargs)
+    except (AuthorityExpiredError, UseTimeCurrencyError) as blocked:
+        try:
+            _record_failure(ledger, request_id, blocked, _expected_owner=owner)
+            _emit_tool_receipt(audit_emitter, ledger, request_id)
+        except LedgerOutcomeAlreadySetError:
+            pass
+        except Exception:
+            _logger.exception(
+                "could not record use-boundary denial for %s",
+                request_id,
+            )
+        raise
     except Exception as exc:
         from mycelium.secret_protection import (
             get_active_secret_policy,
@@ -3845,21 +3998,114 @@ async def _run_ledgered_async(
         authorized_reexec=authorized_reexec,
         owner=owner,
     )
-    ledger._emit_outcome(
-        request_id=request_id,
-        tool=tool_name,
-        event="body_start",
-        terminal_outcome=TerminalOutcome.IN_FLIGHT,
-        side_effect_class=side_effect_class,
-        tool_body_executed=True,
-        authorized_reexec=authorized_reexec,
-        owner=owner,
-    )
 
     token = _active_transition_var.set(
         _ActiveTransition(ledger, request_id, transition_binding)
     )
     try:
+        from mycelium.authority_window import AuthorityExpiredError
+        from mycelium.use_time_currency import (
+            UseTimeCurrencyError,
+            enforce_use_boundary_async,
+        )
+
+        try:
+            auth_decision, currency_decision = await enforce_use_boundary_async(
+                kwargs=clean_kwargs
+            )
+        except (AuthorityExpiredError, UseTimeCurrencyError) as blocked:
+            event = (
+                "use_time_currency"
+                if isinstance(blocked, UseTimeCurrencyError)
+                else "authority_window"
+            )
+            try:
+                ledger._emit_outcome(
+                    request_id=request_id,
+                    tool=tool_name,
+                    event=event,
+                    gate="DENY",
+                    terminal_outcome=TerminalOutcome.FAILED_BEFORE_EFFECT,
+                    side_effect_class=side_effect_class,
+                    tool_body_executed=False,
+                    authorized_reexec=authorized_reexec,
+                    owner=owner,
+                    error_class=type(blocked).__name__,
+                    policy_version=(
+                        transition_binding.policy_version
+                        if transition_binding is not None
+                        else None
+                    ),
+                )
+            except Exception:
+                _logger.exception(
+                    "could not emit %s denial for %s",
+                    event,
+                    request_id,
+                )
+            raise
+
+        if getattr(auth_decision, "decision", "skipped") != "skipped":
+            try:
+                ledger._emit_outcome(
+                    request_id=request_id,
+                    tool=tool_name,
+                    event="authority_window",
+                    gate="ALLOW",
+                    terminal_outcome=TerminalOutcome.IN_FLIGHT,
+                    side_effect_class=side_effect_class,
+                    tool_body_executed=False,
+                    authorized_reexec=authorized_reexec,
+                    owner=owner,
+                    policy_version=getattr(auth_decision, "policy_version", None)
+                    or (
+                        transition_binding.policy_version
+                        if transition_binding is not None
+                        else None
+                    ),
+                )
+            except Exception:
+                _logger.exception(
+                    "could not emit authority_window allow for %s",
+                    request_id,
+                )
+
+        if currency_decision.decision != "skipped":
+            try:
+                ledger._emit_outcome(
+                    request_id=request_id,
+                    tool=tool_name,
+                    event="use_time_currency",
+                    gate="ALLOW",
+                    terminal_outcome=TerminalOutcome.IN_FLIGHT,
+                    side_effect_class=side_effect_class,
+                    tool_body_executed=False,
+                    authorized_reexec=authorized_reexec,
+                    owner=owner,
+                    policy_version=currency_decision.policy_version
+                    or (
+                        transition_binding.policy_version
+                        if transition_binding is not None
+                        else None
+                    ),
+                )
+            except Exception:
+                _logger.exception(
+                    "could not emit use_time_currency allow for %s",
+                    request_id,
+                )
+
+        ledger._emit_outcome(
+            request_id=request_id,
+            tool=tool_name,
+            event="body_start",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT,
+            side_effect_class=side_effect_class,
+            tool_body_executed=True,
+            authorized_reexec=authorized_reexec,
+            owner=owner,
+        )
+
         from mycelium.secret_protection import (
             get_active_secret_policy,
             resolve_declared_secret_fields,
@@ -3872,6 +4118,18 @@ async def _run_ledgered_async(
         )
         with _lease_auto_renew(ledger, request_id):
             result = await func(*exec_args, **exec_kwargs)
+    except (AuthorityExpiredError, UseTimeCurrencyError) as blocked:
+        try:
+            _record_failure(ledger, request_id, blocked, _expected_owner=owner)
+            _emit_tool_receipt(audit_emitter, ledger, request_id)
+        except LedgerOutcomeAlreadySetError:
+            pass
+        except Exception:
+            _logger.exception(
+                "could not record use-boundary denial for %s",
+                request_id,
+            )
+        raise
     except Exception as exc:
         from mycelium.secret_protection import (
             get_active_secret_policy,

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -15,11 +15,11 @@ import time
 import uuid
 import warnings
 from collections.abc import Awaitable, Callable, Iterator, Mapping
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, AsyncIterator, ParamSpec, TypeVar
 
 from mycelium.reconcile import Reconciler, ReconcileResult, ReconcileStatus
 from mycelium.session import Session, _session_var
@@ -378,6 +378,17 @@ def mark_maybe_crossed() -> None:
     _advance_active_boundary(SideEffectBoundary.MAYBE_CROSSED)
 
 
+async def mark_maybe_crossed_async() -> None:
+    """Asynchronously validate and mark the active transition as ``maybe_crossed``."""
+    from mycelium.use_time_currency import enforce_use_boundary_async
+
+    active = _active_transition_var.get()
+    await enforce_use_boundary_async(
+        kwargs=active.call_kwargs if active is not None else {}
+    )
+    _advance_active_boundary(SideEffectBoundary.MAYBE_CROSSED)
+
+
 def mark_crossed() -> None:
     """Mark the active transition as ``crossed`` (effect definitely happened)."""
     _advance_active_boundary(SideEffectBoundary.CROSSED)
@@ -513,6 +524,14 @@ def side_effect() -> Iterator[None]:
     backoff, and before any provider call.
     """
     mark_maybe_crossed()
+    yield
+    mark_crossed()
+
+
+@asynccontextmanager
+async def side_effect_async() -> AsyncIterator[None]:
+    """Wrap an async tool's external operation with async final validation."""
+    await mark_maybe_crossed_async()
     yield
     mark_crossed()
 
@@ -4430,7 +4449,9 @@ __all__ = [
     "ledger_sync",
     "mark_crossed",
     "mark_maybe_crossed",
+    "mark_maybe_crossed_async",
     "record_external_operation",
     "renew_lease",
     "side_effect",
+    "side_effect_async",
 ]

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -3727,12 +3727,13 @@ def _run_ledgered(
         owner=owner,
     )
 
+    call_mapping = _canonical_call_mapping(func, args, clean_kwargs)
     token = _active_transition_var.set(
         _ActiveTransition(
             ledger,
             request_id,
             transition_binding,
-            _canonical_call_mapping(func, args, clean_kwargs),
+            call_mapping,
         )
     )
     try:
@@ -3744,9 +3745,7 @@ def _run_ledgered(
 
         # Use-phase authority + currency after claim/lease wait, before body_start.
         try:
-            auth_decision, currency_decision = enforce_use_boundary(
-                kwargs=clean_kwargs
-            )
+            auth_decision, currency_decision = enforce_use_boundary(kwargs=call_mapping)
         except (AuthorityExpiredError, UseTimeCurrencyError) as blocked:
             event = (
                 "use_time_currency"
@@ -4038,12 +4037,13 @@ async def _run_ledgered_async(
         owner=owner,
     )
 
+    call_mapping = _canonical_call_mapping(func, args, clean_kwargs)
     token = _active_transition_var.set(
         _ActiveTransition(
             ledger,
             request_id,
             transition_binding,
-            _canonical_call_mapping(func, args, clean_kwargs),
+            call_mapping,
         )
     )
     try:
@@ -4055,7 +4055,7 @@ async def _run_ledgered_async(
 
         try:
             auth_decision, currency_decision = await enforce_use_boundary_async(
-                kwargs=clean_kwargs
+                kwargs=call_mapping
             )
         except (AuthorityExpiredError, UseTimeCurrencyError) as blocked:
             event = (

--- a/sdk/mycelium/authority_window.py
+++ b/sdk/mycelium/authority_window.py
@@ -16,7 +16,7 @@ from collections.abc import Callable, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from enum import StrEnum
+from mycelium._compat import StrEnum
 from typing import Any
 
 from mycelium.tool_boundary import ToolBoundaryError

--- a/sdk/mycelium/authority_window.py
+++ b/sdk/mycelium/authority_window.py
@@ -1,0 +1,576 @@
+"""Authority-window expiry: re-validate time-bounded authority at use.
+
+Authorization earlier in the run is not enough. Consequential operations
+must not cross a side-effect boundary on authority that expired after
+authorization but before use.
+
+This module is the shared primitive for destructive-confirm (AF-011) and
+for batch item 5 (use-time currency). It does **not** complete use-time
+currency by itself — policy/state freshness beyond expiry lands in item 5.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Mapping
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Any
+
+from mycelium.tool_boundary import ToolBoundaryError
+
+USE_TIME_CHECK_REQUIRED = "required"
+USE_TIME_CHECK_OPTIONAL = "optional"
+USE_TIME_CHECKS = frozenset({USE_TIME_CHECK_REQUIRED, USE_TIME_CHECK_OPTIONAL})
+
+PHASE_AUTHORIZE = "authorize"
+PHASE_USE = "use"
+
+
+class AuthorityValidationPhase(StrEnum):
+    """When an authority check ran."""
+
+    AUTHORIZE = PHASE_AUTHORIZE
+    USE = PHASE_USE
+
+
+DECISION_ALLOWED = "allowed"
+DECISION_EXPIRED = "expired"
+DECISION_DENIED = "denied"
+DECISION_SKIPPED = "skipped"
+
+REASON_VALID = "valid"
+REASON_EXPIRED = "expired"
+REASON_POLICY_MISMATCH = "policy_mismatch"
+REASON_TIMELESS = "timeless"
+REASON_DISABLED = "disabled"
+
+
+class AuthorityExpiredError(ToolBoundaryError):
+    """Authority was valid at authorize but expired before use."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tool: str | None = None,
+        authority_ref: str | None = None,
+        expires_at: datetime | None = None,
+        observed_at: datetime | None = None,
+        phase: str = PHASE_USE,
+        operation: str | None = None,
+        object_ref: str | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            violation="authority_window",
+            tool_name=tool or "tool",
+            llm_message=(
+                f"Authority expired before use for {(tool or 'tool')!r}. "
+                "Re-authorize with a fresh host grant. The tool body was not "
+                "executed and the side-effect boundary was not crossed."
+            ),
+            field=phase,
+            expected="valid_authority",
+            recovery_hint=(
+                "Issue a new host authorization with a future expires_at. "
+                "Mycelium does not renew, extend, or substitute expired authority."
+            ),
+        )
+        self.tool = tool
+        self.authority_ref = authority_ref
+        self.expires_at = expires_at
+        self.observed_at = observed_at
+        self.phase = phase
+        self.operation = operation
+        self.object_ref = object_ref
+
+
+@dataclass(frozen=True)
+class AuthorityValidation:
+    """Payload-free result of an authorize- or use-phase check."""
+
+    decision: str
+    reason: str
+    phase: str
+    authority_ref: str | None = None
+    authority_kind: str | None = None
+    tool: str | None = None
+    operation: str | None = None
+    object_ref: str | None = None
+    policy_version: str | None = None
+    expires_at: datetime | None = None
+    observed_at: datetime | None = None
+    request_id: str | None = None
+    run_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision,
+            "reason": self.reason,
+            "phase": self.phase,
+            "authority_ref": self.authority_ref,
+            "authority_kind": self.authority_kind,
+            "tool": self.tool,
+            "operation": self.operation,
+            "object_ref": self.object_ref,
+            "policy_version": self.policy_version,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "observed_at": self.observed_at.isoformat() if self.observed_at else None,
+            "request_id": self.request_id,
+            "run_id": self.run_id,
+        }
+
+
+@dataclass(frozen=True)
+class BoundAuthority:
+    """Time-bounded authority registered for a mandatory use-phase check.
+
+    Timeless authority is never registered here. Only host/infrastructure
+    clocks supply ``now`` — never model-provided time.
+    """
+
+    authority_id: str
+    authority_kind: str
+    expires_at: datetime
+    tool: str
+    operation: str | None = None
+    object_ref: str | None = None
+    policy_version: str | None = None
+    request_id: str | None = None
+    run_id: str | None = None
+    issued_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        ensure_aware_utc(self.expires_at, field="expires_at")
+        if self.issued_at is not None:
+            ensure_aware_utc(self.issued_at, field="issued_at")
+
+    @property
+    def authority_ref(self) -> str:
+        return authority_digest(self.authority_id)
+
+
+@dataclass(frozen=True)
+class AuthorityWindowPolicy:
+    """Host-owned authority-window configuration."""
+
+    enabled: bool = True
+    use_time_check: str = USE_TIME_CHECK_REQUIRED
+    clock_skew_tolerance_seconds: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.use_time_check not in USE_TIME_CHECKS:
+            raise ValueError(
+                "authority_window.use_time_check must be one of "
+                f"{sorted(USE_TIME_CHECKS)}, got {self.use_time_check!r}"
+            )
+        if self.clock_skew_tolerance_seconds < 0:
+            raise ValueError(
+                "authority_window.clock_skew_tolerance_seconds must be >= 0"
+            )
+
+
+_clock_var: ContextVar[Callable[[], float] | None] = ContextVar(
+    "mycelium_authority_clock", default=None
+)
+_policy_var: ContextVar[AuthorityWindowPolicy | None] = ContextVar(
+    "mycelium_authority_window_policy", default=None
+)
+_pending_var: ContextVar[tuple[BoundAuthority, ...]] = ContextVar(
+    "mycelium_pending_authorities", default=()
+)
+_decision_var: ContextVar[tuple[AuthorityValidation, ...]] = ContextVar(
+    "mycelium_authority_decisions", default=()
+)
+_adapters: dict[str, Callable[..., AuthorityValidation]] = {}
+
+
+def authority_digest(authority_id: str) -> str:
+    return hashlib.sha256(authority_id.encode()).hexdigest()[:16]
+
+
+def ensure_aware_utc(value: datetime, *, field: str) -> datetime:
+    """Require a timezone-aware UTC instant. Reject naive timestamps."""
+    if not isinstance(value, datetime):
+        raise ValueError(f"{field} must be a datetime")
+    if value.tzinfo is None:
+        raise ValueError(
+            f"{field} must be timezone-aware UTC (naive timestamps are rejected)"
+        )
+    return value.astimezone(UTC)
+
+
+def as_utc_datetime(value: Any, *, field: str = "expires_at") -> datetime:
+    """Parse a trusted host expiry into aware UTC.
+
+    Accepts aware ``datetime`` or a numeric UTC epoch seconds. Rejects naive
+    datetimes, invalid values, and non-finite numbers.
+    """
+    if isinstance(value, datetime):
+        return ensure_aware_utc(value, field=field)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        try:
+            ts = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field} is not a valid timestamp") from exc
+        if ts != ts or ts in (float("inf"), float("-inf")):  # noqa: PLR0124
+            raise ValueError(f"{field} is not a finite timestamp")
+        return datetime.fromtimestamp(ts, tz=UTC)
+    raise ValueError(f"{field} must be an aware datetime or UTC epoch seconds")
+
+
+def utc_now() -> datetime:
+    """Host/infrastructure clock. Never accepts model-provided time."""
+    clock = _clock_var.get()
+    if clock is not None:
+        return datetime.fromtimestamp(float(clock()), tz=UTC)
+    return datetime.now(UTC)
+
+
+def set_authority_clock(
+    clock: Callable[[], float] | None,
+) -> Token[Callable[[], float] | None]:
+    """Install an injectable clock for host setup and tests only."""
+    return _clock_var.set(clock)
+
+
+def reset_authority_clock(token: Token[Callable[[], float] | None]) -> None:
+    _clock_var.reset(token)
+
+
+def get_authority_window_policy() -> AuthorityWindowPolicy | None:
+    return _policy_var.get()
+
+
+def set_authority_window_policy(
+    policy: AuthorityWindowPolicy | None,
+) -> Token[AuthorityWindowPolicy | None]:
+    return _policy_var.set(policy)
+
+
+def reset_authority_window_policy(token: Token[AuthorityWindowPolicy | None]) -> None:
+    _policy_var.reset(token)
+
+
+def get_pending_authorities() -> tuple[BoundAuthority, ...]:
+    return _pending_var.get()
+
+
+def get_authority_decisions() -> tuple[AuthorityValidation, ...]:
+    return _decision_var.get()
+
+
+def reset_authority_window_state() -> None:
+    _clock_var.set(None)
+    _policy_var.set(None)
+    _pending_var.set(())
+    _decision_var.set(())
+    _adapters.clear()
+
+
+def register_authority_use_adapter(
+    kind: str, fn: Callable[..., AuthorityValidation]
+) -> None:
+    """Register a host adapter that participates in use-time checks."""
+    if not isinstance(kind, str) or not kind.strip():
+        raise ValueError("authority adapter kind must be a non-empty string")
+    _adapters[kind.strip()] = fn
+
+
+def registered_authority_use_adapters() -> frozenset[str]:
+    return frozenset(_adapters)
+
+
+def _append_decision(decision: AuthorityValidation) -> AuthorityValidation:
+    current = _decision_var.get()
+    _decision_var.set((*current, decision))
+    return decision
+
+
+def _effective_expires_at(
+    expires_at: datetime,
+    *,
+    skew_seconds: float,
+) -> datetime:
+    """Skew narrows validity only — never extends expired authority."""
+    if skew_seconds <= 0:
+        return expires_at
+    return expires_at - timedelta(seconds=float(skew_seconds))
+
+
+def validate_authority(
+    authority: BoundAuthority | Mapping[str, Any] | None,
+    *,
+    now: datetime | None = None,
+    expected_policy_version: str | None = None,
+    phase: AuthorityValidationPhase | str = AuthorityValidationPhase.AUTHORIZE,
+    skew_seconds: float = 0.0,
+    context: Mapping[str, Any] | None = None,
+) -> AuthorityValidation:
+    """Validate a time-bounded authority at authorize or use.
+
+    ``now`` may only be supplied by host/test code via the injectable clock
+    or an explicit host call. Production tool paths must not pass model time.
+    """
+    del context  # reserved for item 5 / adapters
+    phase_value = (
+        phase.value if isinstance(phase, AuthorityValidationPhase) else str(phase)
+    )
+    if authority is None:
+        decision = AuthorityValidation(
+            decision=DECISION_SKIPPED,
+            reason=REASON_TIMELESS,
+            phase=phase_value,
+            observed_at=utc_now() if now is None else ensure_aware_utc(now, field="now"),
+        )
+        return _append_decision(decision)
+
+    if isinstance(authority, Mapping):
+        raise AuthorityExpiredError(
+            "authority must be a host BoundAuthority, not a model-controlled mapping",
+            phase=phase_value,
+        )
+
+    observed = utc_now() if now is None else ensure_aware_utc(now, field="now")
+    expires = ensure_aware_utc(authority.expires_at, field="expires_at")
+    effective = _effective_expires_at(expires, skew_seconds=skew_seconds)
+
+    if (
+        expected_policy_version is not None
+        and authority.policy_version is not None
+        and authority.policy_version != expected_policy_version
+        and expected_policy_version != "unspecified"
+        and authority.policy_version != "unspecified"
+    ):
+        decision = AuthorityValidation(
+            decision=DECISION_DENIED,
+            reason=REASON_POLICY_MISMATCH,
+            phase=phase_value,
+            authority_ref=authority.authority_ref,
+            authority_kind=authority.authority_kind,
+            tool=authority.tool,
+            operation=authority.operation,
+            object_ref=authority.object_ref,
+            policy_version=authority.policy_version,
+            expires_at=expires,
+            observed_at=observed,
+            request_id=authority.request_id,
+            run_id=authority.run_id,
+        )
+        _append_decision(decision)
+        raise AuthorityExpiredError(
+            f"authority policy version mismatch for tool {authority.tool!r}",
+            tool=authority.tool,
+            authority_ref=authority.authority_ref,
+            expires_at=expires,
+            observed_at=observed,
+            phase=phase_value,
+            operation=authority.operation,
+            object_ref=authority.object_ref,
+        )
+
+    if observed >= effective:
+        decision = AuthorityValidation(
+            decision=DECISION_EXPIRED,
+            reason=REASON_EXPIRED,
+            phase=phase_value,
+            authority_ref=authority.authority_ref,
+            authority_kind=authority.authority_kind,
+            tool=authority.tool,
+            operation=authority.operation,
+            object_ref=authority.object_ref,
+            policy_version=authority.policy_version,
+            expires_at=expires,
+            observed_at=observed,
+            request_id=authority.request_id,
+            run_id=authority.run_id,
+        )
+        _append_decision(decision)
+        raise AuthorityExpiredError(
+            f"authority expired before {phase_value} for tool {authority.tool!r} "
+            f"(expires_at={expires.isoformat()}, observed_at={observed.isoformat()})",
+            tool=authority.tool,
+            authority_ref=authority.authority_ref,
+            expires_at=expires,
+            observed_at=observed,
+            phase=phase_value,
+            operation=authority.operation,
+            object_ref=authority.object_ref,
+        )
+
+    decision = AuthorityValidation(
+        decision=DECISION_ALLOWED,
+        reason=REASON_VALID,
+        phase=phase_value,
+        authority_ref=authority.authority_ref,
+        authority_kind=authority.authority_kind,
+        tool=authority.tool,
+        operation=authority.operation,
+        object_ref=authority.object_ref,
+        policy_version=authority.policy_version,
+        expires_at=expires,
+        observed_at=observed,
+        request_id=authority.request_id,
+        run_id=authority.run_id,
+    )
+    return _append_decision(decision)
+
+
+def validate_authority_at_use(
+    authority: BoundAuthority | Mapping[str, Any] | None = None,
+    *,
+    now: datetime | None = None,
+    expected_policy_version: str | None = None,
+    context: Mapping[str, Any] | None = None,
+) -> AuthorityValidation:
+    """Mandatory use-phase check immediately before the side-effect boundary."""
+    policy = _policy_var.get()
+    skew = float(policy.clock_skew_tolerance_seconds) if policy is not None else 0.0
+    if authority is not None:
+        kind = (
+            authority.authority_kind
+            if isinstance(authority, BoundAuthority)
+            else str((authority or {}).get("authority_kind") or "")
+        )
+        adapter = _adapters.get(kind)
+        if adapter is not None:
+            return adapter(
+                authority,
+                now=now,
+                expected_policy_version=expected_policy_version,
+                context=context,
+                phase=AuthorityValidationPhase.USE,
+            )
+        return validate_authority(
+            authority,
+            now=now,
+            expected_policy_version=expected_policy_version,
+            phase=AuthorityValidationPhase.USE,
+            skew_seconds=skew,
+            context=context,
+        )
+    return enforce_pending_authorities_at_use(
+        now=now,
+        expected_policy_version=expected_policy_version,
+    )
+
+
+def register_authority_for_use(authority: BoundAuthority) -> BoundAuthority:
+    """Bind host authority so the use-phase check can find it later."""
+    ensure_aware_utc(authority.expires_at, field="expires_at")
+    current = _pending_var.get()
+    kept = tuple(item for item in current if item.authority_id != authority.authority_id)
+    _pending_var.set((*kept, authority))
+    return authority
+
+
+def clear_pending_authorities() -> None:
+    _pending_var.set(())
+
+
+def enforce_pending_authorities_at_use(
+    *,
+    now: datetime | None = None,
+    expected_policy_version: str | None = None,
+) -> AuthorityValidation:
+    """Validate every registered time-bounded authority at the use boundary.
+
+    No-op (skipped) when nothing is pending — timeless paths stay unchanged.
+    """
+    pending = _pending_var.get()
+    if not pending:
+        decision = AuthorityValidation(
+            decision=DECISION_SKIPPED,
+            reason=REASON_TIMELESS,
+            phase=PHASE_USE,
+            observed_at=utc_now() if now is None else ensure_aware_utc(now, field="now"),
+        )
+        return _append_decision(decision)
+
+    policy = _policy_var.get()
+    # Destructive-confirm registers authorities even when authority_window is
+    # omitted; use-time remains mandatory for those bindings.
+    if (
+        policy is not None
+        and not policy.enabled
+        and not any(item.authority_kind == "destructive_grant" for item in pending)
+    ):
+        decision = AuthorityValidation(
+            decision=DECISION_SKIPPED,
+            reason=REASON_DISABLED,
+            phase=PHASE_USE,
+            observed_at=utc_now() if now is None else ensure_aware_utc(now, field="now"),
+        )
+        return _append_decision(decision)
+
+    last: AuthorityValidation | None = None
+    for item in pending:
+        last = validate_authority_at_use(
+            item,
+            now=now,
+            expected_policy_version=expected_policy_version or item.policy_version,
+        )
+    assert last is not None
+    return last
+
+
+def bound_authority_from_destructive_grant(
+    grant: Any,
+    *,
+    tool: str,
+    object_ref: str | None = None,
+    request_id: str | None = None,
+    run_id: str | None = None,
+) -> BoundAuthority:
+    """Build a BoundAuthority from a host DestructiveGrant."""
+    expires = as_utc_datetime(grant.expires_at, field="expires_at")
+    issued = as_utc_datetime(grant.issued_at, field="issued_at")
+    return BoundAuthority(
+        authority_id=str(grant.grant_id),
+        authority_kind="destructive_grant",
+        expires_at=expires,
+        tool=tool,
+        operation=str(getattr(grant, "operation", "") or "") or None,
+        object_ref=object_ref,
+        policy_version=str(getattr(grant, "policy_version", "") or "") or None,
+        request_id=request_id or getattr(grant, "request_id", None),
+        run_id=run_id or getattr(grant, "run_id", None),
+        issued_at=issued,
+    )
+
+
+__all__ = [
+    "PHASE_AUTHORIZE",
+    "PHASE_USE",
+    "USE_TIME_CHECK_OPTIONAL",
+    "USE_TIME_CHECK_REQUIRED",
+    "USE_TIME_CHECKS",
+    "AuthorityExpiredError",
+    "AuthorityValidation",
+    "AuthorityValidationPhase",
+    "AuthorityWindowPolicy",
+    "BoundAuthority",
+    "as_utc_datetime",
+    "authority_digest",
+    "bound_authority_from_destructive_grant",
+    "clear_pending_authorities",
+    "enforce_pending_authorities_at_use",
+    "ensure_aware_utc",
+    "get_authority_decisions",
+    "get_authority_window_policy",
+    "get_pending_authorities",
+    "register_authority_for_use",
+    "register_authority_use_adapter",
+    "registered_authority_use_adapters",
+    "reset_authority_clock",
+    "reset_authority_window_policy",
+    "reset_authority_window_state",
+    "set_authority_clock",
+    "set_authority_window_policy",
+    "utc_now",
+    "validate_authority",
+    "validate_authority_at_use",
+]

--- a/sdk/mycelium/authority_window.py
+++ b/sdk/mycelium/authority_window.py
@@ -15,7 +15,7 @@ import hashlib
 from collections.abc import Callable, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import StrEnum
 from typing import Any
 
@@ -200,7 +200,7 @@ def ensure_aware_utc(value: datetime, *, field: str) -> datetime:
         raise ValueError(
             f"{field} must be timezone-aware UTC (naive timestamps are rejected)"
         )
-    return value.astimezone(UTC)
+    return value.astimezone(timezone.utc)
 
 
 def as_utc_datetime(value: Any, *, field: str = "expires_at") -> datetime:
@@ -218,7 +218,7 @@ def as_utc_datetime(value: Any, *, field: str = "expires_at") -> datetime:
             raise ValueError(f"{field} is not a valid timestamp") from exc
         if ts != ts or ts in (float("inf"), float("-inf")):  # noqa: PLR0124
             raise ValueError(f"{field} is not a finite timestamp")
-        return datetime.fromtimestamp(ts, tz=UTC)
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
     raise ValueError(f"{field} must be an aware datetime or UTC epoch seconds")
 
 
@@ -226,8 +226,8 @@ def utc_now() -> datetime:
     """Host/infrastructure clock. Never accepts model-provided time."""
     clock = _clock_var.get()
     if clock is not None:
-        return datetime.fromtimestamp(float(clock()), tz=UTC)
-    return datetime.now(UTC)
+        return datetime.fromtimestamp(float(clock()), tz=timezone.utc)
+    return datetime.now(timezone.utc)
 
 
 def set_authority_clock(

--- a/sdk/mycelium/authority_window.py
+++ b/sdk/mycelium/authority_window.py
@@ -16,9 +16,9 @@ from collections.abc import Callable, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from mycelium._compat import StrEnum
 from typing import Any
 
+from mycelium._compat import StrEnum
 from mycelium.tool_boundary import ToolBoundaryError
 
 USE_TIME_CHECK_REQUIRED = "required"

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -32,6 +32,12 @@ from mycelium.audit_receipt import (
     InMemoryAuditReceiptStorage,
     resolve_signing_key,
 )
+from mycelium.authority_window import (
+    USE_TIME_CHECK_REQUIRED,
+    USE_TIME_CHECKS,
+    AuthorityWindowPolicy,
+    set_authority_window_policy,
+)
 from mycelium.budget_guard import (
     MISSING_USAGE_POLICIES,
     MISSING_USAGE_POLICY_ERROR,
@@ -56,6 +62,31 @@ from mycelium.completion_contract import (
     InMemoryCompletionStorage,
     registered_terminal_adapters,
     set_active_completion_contract,
+)
+from mycelium.destructive_confirm import (
+    MISSING_POLICIES as DESTRUCTIVE_MISSING_POLICIES,
+)
+from mycelium.destructive_confirm import (
+    MISSING_POLICY_ERROR as DESTRUCTIVE_MISSING_POLICY_ERROR,
+)
+from mycelium.destructive_confirm import (
+    SHARED_GRANT_STORAGES,
+    STORAGE_FILE,
+    STORAGE_MEMORY,
+    STORAGE_POSTGRES,
+    STORAGE_REDIS,
+    STORAGE_SQLITE,
+    DestructiveConfirmPolicy,
+    DestructiveGrantSpec,
+    DestructiveObjectSpec,
+    DestructiveToolPolicy,
+    FileDestructiveGrantStore,
+    InMemoryDestructiveGrantStore,
+    PostgresDestructiveGrantStore,
+    RedisDestructiveGrantStore,
+    SqliteDestructiveGrantStore,
+    apply_destructive_confirm,
+    destructive_confirm_policy_for_tool,
 )
 from mycelium.entity_guard import (
     DEST_TYPES,
@@ -157,6 +188,20 @@ from mycelium.transition import (
     parse_side_effect_boundary,
     parse_side_effect_class,
     parse_spendability,
+)
+from mycelium.use_time_currency import (
+    MISSING_POLICIES as USE_TIME_MISSING_POLICIES,
+)
+from mycelium.use_time_currency import (
+    MISSING_POLICY_ERROR as USE_TIME_MISSING_POLICY_ERROR,
+)
+from mycelium.use_time_currency import (
+    UseTimeCurrencyPolicy,
+    UseTimeFactSpec,
+    UseTimeToolPolicy,
+    apply_use_time_currency,
+    set_use_time_currency_policy,
+    use_time_currency_policy_for_tool,
 )
 
 
@@ -324,6 +369,10 @@ class ToolConfig:
     secret_args: bool | None = None
     # Per-tool entity_guard: None=inherit global, False=disable
     entity_guard: bool | None = None
+    # Per-tool destructive_confirm: None=inherit global, False=disable
+    destructive_confirm: bool | None = None
+    # Per-tool use_time_currency: None=inherit global, False=disable
+    use_time_currency: bool | None = None
 
     def is_noop(self) -> bool:
         return (
@@ -338,6 +387,8 @@ class ToolConfig:
             and not self.secret_fields
             and self.secret_args is None
             and self.entity_guard is None
+            and self.destructive_confirm is None
+            and self.use_time_currency is None
         )
 
 
@@ -389,6 +440,9 @@ class MyceliumConfig:
     verify: dict[str, Any] | None = None
     secret_args: dict[str, Any] | None = None
     entity_guard: dict[str, Any] | None = None
+    destructive_confirm: dict[str, Any] | None = None
+    authority_window: dict[str, Any] | None = None
+    use_time_currency: dict[str, Any] | None = None
     profile: str = PROFILE_DEVELOPMENT
     _audit_emitter: AuditReceiptEmitter | None = None
     _outcome_emitter: OutcomeEmitter | None = None
@@ -398,6 +452,7 @@ class MyceliumConfig:
     _state_authority: StateAuthority | None = None
     _completion: CompletionContract | None = None
     _state_flush: StateFlush | None = None
+    _destructive_store: Any | None = None
     _audit_auto: bool = False
     _terminal_adapters: frozenset[str] = frozenset()
     _llm_adapters: frozenset[str] = frozenset()
@@ -410,9 +465,10 @@ class MyceliumConfig:
         function is returned unchanged.
 
         Guard order (outermost first, after optional LangGraph instrument):
-        ``@secret_args`` -> ``@entity_guard`` -> ``@state_authority`` ->
-        ``@scope_guard`` -> ``@budget_guard`` -> ``@loop_guard`` ->
-        ``@ledger`` -> ``@bounded`` -> ``@protect`` -> ``func``
+        ``@secret_args`` -> ``@entity_guard`` -> ``@destructive_confirm`` ->
+        ``@use_time_currency`` -> ``@state_authority`` -> ``@scope_guard`` ->
+        ``@budget_guard`` -> ``@loop_guard`` -> ``@ledger`` -> ``@bounded`` ->
+        ``@protect`` -> ``func``
         """
         return self.apply_tool(func.__name__, func)
 
@@ -516,6 +572,109 @@ class MyceliumConfig:
             return False
         return name in policy.tools
 
+    def destructive_confirm_applies(
+        self, name: str, tool_config: ToolConfig | None = None
+    ) -> bool:
+        """Whether destructive-confirm should wrap this tool."""
+        if self.destructive_confirm is None:
+            return False
+        policy = destructive_confirm_policy_from_mapping(self.destructive_confirm)
+        if not policy.enabled:
+            return False
+        cfg = tool_config if tool_config is not None else self.tools.get(name)
+        if cfg is not None and cfg.destructive_confirm is False:
+            return False
+        return name in policy.tools
+
+    def use_time_currency_applies(
+        self, name: str, tool_config: ToolConfig | None = None
+    ) -> bool:
+        """Whether use-time currency should wrap this tool."""
+        if self.use_time_currency is None:
+            return False
+        policy = use_time_currency_policy_from_mapping(self.use_time_currency)
+        if not policy.enabled:
+            return False
+        cfg = tool_config if tool_config is not None else self.tools.get(name)
+        if cfg is not None and cfg.use_time_currency is False:
+            return False
+        return name in policy.tools
+
+    def build_destructive_grant_store(self) -> Any:
+        """Build (once) the grant store declared by ``destructive_confirm:``."""
+        if self._destructive_store is not None:
+            return self._destructive_store
+        raw = self.destructive_confirm or {}
+        self._destructive_store = self._build_destructive_grant_store(raw)
+        return self._destructive_store
+
+    @staticmethod
+    def _build_destructive_grant_store(raw: dict[str, Any]) -> Any:
+        storage_type = raw.get("storage", STORAGE_MEMORY)
+        if storage_type == STORAGE_MEMORY:
+            return InMemoryDestructiveGrantStore()
+        if storage_type == STORAGE_FILE:
+            path = raw.get("path")
+            if not path:
+                raise ConfigError("destructive_confirm storage 'file' requires a 'path'")
+            return FileDestructiveGrantStore(path)
+        if storage_type == STORAGE_SQLITE:
+            path = raw.get("path")
+            if not path:
+                raise ConfigError("destructive_confirm storage 'sqlite' requires a 'path'")
+            return SqliteDestructiveGrantStore(
+                path,
+                table=str(raw.get("table", "mycelium_destructive_grants")),
+            )
+        if storage_type == STORAGE_REDIS:
+            from mycelium.storage._helpers import resolve_storage_url
+
+            try:
+                url = resolve_storage_url(raw)
+            except ValueError as exc:
+                raise ConfigError(str(exc)) from exc
+            return RedisDestructiveGrantStore(
+                url,
+                prefix=str(raw.get("prefix", "mycelium:destructive:")),
+            )
+        if storage_type == STORAGE_POSTGRES:
+            from mycelium.storage._helpers import resolve_storage_url
+
+            try:
+                dsn = resolve_storage_url(raw, url_key="dsn")
+            except ValueError as exc:
+                raise ConfigError(str(exc)) from exc
+            return PostgresDestructiveGrantStore(
+                dsn,
+                table=str(raw.get("table", "mycelium_destructive_grants")),
+            )
+        raise ConfigError(f"unknown destructive_confirm storage type: {storage_type!r}")
+
+    def _activate_authority_window(self) -> None:
+        """Bind process policy for use-time expiry checks."""
+        raw = self.authority_window
+        if raw is None and self.destructive_confirm is not None:
+            # AF-011 already promises expiry; enable use-time even when
+            # authority_window: is omitted.
+            set_authority_window_policy(
+                AuthorityWindowPolicy(
+                    enabled=True,
+                    use_time_check=USE_TIME_CHECK_REQUIRED,
+                    clock_skew_tolerance_seconds=0.0,
+                )
+            )
+            return
+        if raw is None:
+            return
+        set_authority_window_policy(authority_window_policy_from_mapping(raw))
+
+    def _activate_use_time_currency(self) -> None:
+        """Bind process policy for use-time currency checks."""
+        raw = self.use_time_currency
+        if raw is None:
+            return
+        set_use_time_currency_policy(use_time_currency_policy_from_mapping(raw))
+
     def apply_tool(
         self,
         name: str,
@@ -531,6 +690,8 @@ class MyceliumConfig:
         applies_state = self.state_authority_applies(name, tool_config)
         applies_secret = self.secret_args_applies(name, tool_config)
         applies_entity = self.entity_guard_applies(name, tool_config)
+        applies_destructive = self.destructive_confirm_applies(name, tool_config)
+        applies_use_time = self.use_time_currency_applies(name, tool_config)
         if tool_config.secret_fields:
             setattr(func, "_mycelium_secret_fields", tool_config.secret_fields)
         if (
@@ -541,6 +702,8 @@ class MyceliumConfig:
             and not applies_state
             and not applies_secret
             and not applies_entity
+            and not applies_destructive
+            and not applies_use_time
         ):
             return func
         if _check_existing_config_wrapper(func, kind="tool", name=name):
@@ -643,6 +806,48 @@ class MyceliumConfig:
                 side_effect_class=tool_config.side_effect_class,
             )
 
+        # Use-time currency outside claim: authorize before claim, use inside ledger.
+        if applies_use_time:
+            self._activate_use_time_currency()
+            policy = use_time_currency_policy_from_mapping(self.use_time_currency or {})
+            if (
+                self.profile == PROFILE_PRODUCTION
+                and policy.missing_policy != USE_TIME_MISSING_POLICY_ERROR
+            ):
+                raise ConfigError(
+                    f"profile is {PROFILE_PRODUCTION!r} but "
+                    f"use_time_currency.missing_policy is {policy.missing_policy!r}; "
+                    "production requires 'error'"
+                )
+            func = apply_use_time_currency(
+                func,
+                use_time_currency_policy_for_tool(policy, name),
+                tool_name=name,
+                outcome_emitter=self.build_outcome_emitter(),
+            )
+
+        # Destructive confirm outside claim: ungranted objects never execute.
+        if applies_destructive:
+            self._activate_authority_window()
+            policy = destructive_confirm_policy_from_mapping(self.destructive_confirm or {})
+            if (
+                self.profile == PROFILE_PRODUCTION
+                and policy.missing_policy != DESTRUCTIVE_MISSING_POLICY_ERROR
+            ):
+                raise ConfigError(
+                    f"profile is {PROFILE_PRODUCTION!r} but "
+                    f"destructive_confirm.missing_policy is {policy.missing_policy!r}; "
+                    "production requires 'error'"
+                )
+            store = self.build_destructive_grant_store()
+            func = apply_destructive_confirm(
+                func,
+                destructive_confirm_policy_for_tool(policy, name),
+                tool_name=name,
+                store=store,
+                outcome_emitter=self.build_outcome_emitter(),
+            )
+
         # Destination policy outside claim: unauthorized recipients never execute.
         if applies_entity:
             from dataclasses import replace as _replace_policy
@@ -706,6 +911,7 @@ class MyceliumConfig:
             or applies_state
             or applies_secret
             or applies_entity
+            or applies_destructive
         ):
             try:
                 func = instrument_langgraph_tool(func)
@@ -2086,6 +2292,24 @@ def _parse_tool_config(
     else:
         raise ConfigError(f"tool '{name}'.entity_guard must be a bool")
 
+    destructive_raw = raw.get("destructive_confirm")
+    destructive_cfg: bool | None
+    if destructive_raw is None:
+        destructive_cfg = None
+    elif isinstance(destructive_raw, bool):
+        destructive_cfg = destructive_raw
+    else:
+        raise ConfigError(f"tool '{name}'.destructive_confirm must be a bool")
+
+    use_time_raw = raw.get("use_time_currency")
+    use_time_cfg: bool | None
+    if use_time_raw is None:
+        use_time_cfg = None
+    elif isinstance(use_time_raw, bool):
+        use_time_cfg = use_time_raw
+    else:
+        raise ConfigError(f"tool '{name}'.use_time_currency must be a bool")
+
     return ToolConfig(
         name=name,
         protect=protect,
@@ -2107,6 +2331,8 @@ def _parse_tool_config(
         secret_fields=secret_fields,
         secret_args=secret_args_cfg,
         entity_guard=entity_guard_cfg,
+        destructive_confirm=destructive_cfg,
+        use_time_currency=use_time_cfg,
     )
 
 
@@ -2214,6 +2440,8 @@ def _apply_action_ledger_tools(
             secret_fields=existing.secret_fields,
             secret_args=existing.secret_args,
             entity_guard=existing.entity_guard,
+            destructive_confirm=existing.destructive_confirm,
+            use_time_currency=existing.use_time_currency,
         )
 
 
@@ -2995,6 +3223,305 @@ def _parse_destination_spec(raw: Any, *, tool: str) -> dict[str, Any]:
     }
 
 
+_AUTHORITY_WINDOW_KEYS = frozenset(
+    {"enabled", "use_time_check", "clock_skew_tolerance_seconds"}
+)
+
+
+def authority_window_policy_from_mapping(raw: dict[str, Any]) -> AuthorityWindowPolicy:
+    return AuthorityWindowPolicy(
+        enabled=bool(raw.get("enabled", True)),
+        use_time_check=str(raw.get("use_time_check", USE_TIME_CHECK_REQUIRED)),
+        clock_skew_tolerance_seconds=float(
+            raw.get("clock_skew_tolerance_seconds", 0.0)
+        ),
+    )
+
+
+def _parse_authority_window(
+    data: dict[str, Any],
+    *,
+    profile: str,
+    destructive_confirm: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    raw = data.get("authority_window")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError("'authority_window' must be a mapping")
+    extra = set(raw) - _AUTHORITY_WINDOW_KEYS
+    if extra:
+        names = ", ".join(sorted(str(item) for item in extra))
+        raise ConfigError(f"unsupported 'authority_window' option(s): {names}")
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise ConfigError("'authority_window.enabled' must be a boolean")
+    use_time = raw.get("use_time_check", USE_TIME_CHECK_REQUIRED)
+    if use_time not in USE_TIME_CHECKS:
+        raise ConfigError(
+            "'authority_window.use_time_check' must be one of "
+            f"{sorted(USE_TIME_CHECKS)}"
+        )
+    skew = raw.get("clock_skew_tolerance_seconds", 0)
+    if not isinstance(skew, (int, float)) or isinstance(skew, bool) or skew < 0:
+        raise ConfigError(
+            "'authority_window.clock_skew_tolerance_seconds' must be a number >= 0"
+        )
+    if profile == PROFILE_PRODUCTION and destructive_confirm is not None:
+        if not enabled or use_time != USE_TIME_CHECK_REQUIRED:
+            raise ConfigError(
+                "profile is 'production' with time-bounded destructive_confirm "
+                "but authority_window does not require use-time expiry "
+                "(enabled: true, use_time_check: required)"
+            )
+    return {
+        "enabled": enabled,
+        "use_time_check": str(use_time),
+        "clock_skew_tolerance_seconds": float(skew),
+    }
+
+
+_USE_TIME_TOP_KEYS = frozenset({"enabled", "missing_policy", "policy_version", "tools"})
+_USE_TIME_FACT_KEYS = frozenset(
+    {
+        "name",
+        "subject",
+        "validator",
+        "require",
+        "revision_from",
+        "max_age_seconds",
+        "bind_request_id",
+        "bind_run_id",
+        "bind_thread_id",
+        "compare_to_arg",
+        "provider_precondition",
+    }
+)
+_USE_TIME_SUBJECT_KEYS = frozenset(
+    {"type", "id_from", "tenant_from", "account_from"}
+)
+
+
+def use_time_currency_policy_from_mapping(raw: dict[str, Any]) -> UseTimeCurrencyPolicy:
+    tools: dict[str, UseTimeToolPolicy] = {}
+    for name, tool_raw in (raw.get("tools") or {}).items():
+        facts_raw = tool_raw.get("facts") or []
+        facts: list[UseTimeFactSpec] = []
+        for item in facts_raw:
+            subject = item.get("subject") or {}
+            require = item.get("require")
+            facts.append(
+                UseTimeFactSpec(
+                    name=str(item["name"]),
+                    subject_type=str(subject["type"]),
+                    id_from=str(subject["id_from"]),
+                    validator=str(item["validator"]),
+                    tenant_from=subject.get("tenant_from"),
+                    account_from=subject.get("account_from"),
+                    require=dict(require) if isinstance(require, dict) else None,
+                    revision_from=item.get("revision_from"),
+                    max_age_seconds=(
+                        float(item["max_age_seconds"])
+                        if item.get("max_age_seconds") is not None
+                        else None
+                    ),
+                    bind_request_id=bool(item.get("bind_request_id", False)),
+                    bind_run_id=bool(item.get("bind_run_id", False)),
+                    bind_thread_id=bool(item.get("bind_thread_id", False)),
+                    compare_to_arg=item.get("compare_to_arg"),
+                    provider_precondition=item.get("provider_precondition"),
+                )
+            )
+        tools[str(name)] = UseTimeToolPolicy(facts=tuple(facts))
+    return UseTimeCurrencyPolicy(
+        enabled=bool(raw.get("enabled", True)),
+        missing_policy=str(raw.get("missing_policy", USE_TIME_MISSING_POLICY_ERROR)),
+        policy_version=str(raw.get("policy_version") or "unspecified"),
+        tools=tools,
+    )
+
+
+def _parse_use_time_fact(raw: Any, *, tool: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ConfigError(f"use_time_currency.tools.{tool}.facts items must be mappings")
+    extra = set(raw) - _USE_TIME_FACT_KEYS
+    if extra:
+        names = ", ".join(sorted(str(item) for item in extra))
+        raise ConfigError(
+            f"unsupported use_time_currency.tools.{tool}.facts option(s): {names}"
+        )
+    name = raw.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ConfigError(
+            f"use_time_currency.tools.{tool}.facts[].name must be a non-empty string"
+        )
+    subject = raw.get("subject")
+    if not isinstance(subject, dict):
+        raise ConfigError(
+            f"use_time_currency.tools.{tool}.facts[].subject must be a mapping"
+        )
+    subject_extra = set(subject) - _USE_TIME_SUBJECT_KEYS
+    if subject_extra:
+        names = ", ".join(sorted(str(item) for item in subject_extra))
+        raise ConfigError(
+            f"unsupported use_time_currency.tools.{tool}.facts[].subject "
+            f"option(s): {names}"
+        )
+    subject_type = subject.get("type")
+    id_from = subject.get("id_from")
+    if not isinstance(subject_type, str) or not subject_type.strip():
+        raise ConfigError(
+            f"use_time_currency.tools.{tool}.facts[].subject.type is required"
+        )
+    if not isinstance(id_from, str) or not id_from.strip():
+        raise ConfigError(
+            f"use_time_currency.tools.{tool}.facts[].subject.id_from is required"
+        )
+    validator = raw.get("validator")
+    if not isinstance(validator, str) or not validator.strip():
+        raise ConfigError(
+            f"use_time_currency.tools.{tool}.facts[].validator is required"
+        )
+    max_age = raw.get("max_age_seconds")
+    if max_age is not None and (
+        not isinstance(max_age, (int, float))
+        or isinstance(max_age, bool)
+        or max_age < 0
+    ):
+        raise ConfigError(
+            f"use_time_currency.tools.{tool}.facts[].max_age_seconds must be >= 0"
+        )
+    require = raw.get("require")
+    if require is not None and not isinstance(require, dict):
+        raise ConfigError(
+            f"use_time_currency.tools.{tool}.facts[].require must be a mapping"
+        )
+    for key in ("bind_request_id", "bind_run_id", "bind_thread_id"):
+        if key in raw and not isinstance(raw[key], bool):
+            raise ConfigError(
+                f"use_time_currency.tools.{tool}.facts[].{key} must be a bool"
+            )
+    for key in ("revision_from", "compare_to_arg", "provider_precondition"):
+        if key in raw and raw[key] is not None:
+            if not isinstance(raw[key], str) or not str(raw[key]).strip():
+                raise ConfigError(
+                    f"use_time_currency.tools.{tool}.facts[].{key} must be a "
+                    "non-empty string"
+                )
+    for key in ("tenant_from", "account_from"):
+        if key in subject and subject[key] is not None:
+            if not isinstance(subject[key], str) or not str(subject[key]).strip():
+                raise ConfigError(
+                    f"use_time_currency.tools.{tool}.facts[].subject.{key} must be "
+                    "a non-empty string"
+                )
+    parsed: dict[str, Any] = {
+        "name": name.strip(),
+        "subject": {
+            "type": subject_type.strip(),
+            "id_from": id_from.strip(),
+        },
+        "validator": validator.strip(),
+    }
+    if subject.get("tenant_from"):
+        parsed["subject"]["tenant_from"] = str(subject["tenant_from"]).strip()
+    if subject.get("account_from"):
+        parsed["subject"]["account_from"] = str(subject["account_from"]).strip()
+    if require is not None:
+        parsed["require"] = dict(require)
+    if raw.get("revision_from"):
+        parsed["revision_from"] = str(raw["revision_from"]).strip()
+    if max_age is not None:
+        parsed["max_age_seconds"] = float(max_age)
+    for key in ("bind_request_id", "bind_run_id", "bind_thread_id"):
+        if key in raw:
+            parsed[key] = bool(raw[key])
+    if raw.get("compare_to_arg"):
+        parsed["compare_to_arg"] = str(raw["compare_to_arg"]).strip()
+    if raw.get("provider_precondition"):
+        parsed["provider_precondition"] = str(raw["provider_precondition"]).strip()
+    return parsed
+
+
+def _parse_use_time_currency(
+    data: dict[str, Any],
+    *,
+    profile: str,
+    tools: dict[str, ToolConfig],
+) -> dict[str, Any] | None:
+    raw = data.get("use_time_currency")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError("'use_time_currency' must be a mapping")
+    extra = set(raw) - _USE_TIME_TOP_KEYS
+    if extra:
+        names = ", ".join(sorted(str(item) for item in extra))
+        raise ConfigError(f"unsupported 'use_time_currency' option(s): {names}")
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise ConfigError("'use_time_currency.enabled' must be a boolean")
+    missing_policy = raw.get("missing_policy", USE_TIME_MISSING_POLICY_ERROR)
+    if missing_policy not in USE_TIME_MISSING_POLICIES:
+        raise ConfigError(
+            "'use_time_currency.missing_policy' must be one of "
+            f"{sorted(USE_TIME_MISSING_POLICIES)}, got {missing_policy!r}"
+        )
+    policy_version = raw.get("policy_version")
+    if policy_version is not None and (
+        not isinstance(policy_version, str) or not policy_version.strip()
+    ):
+        raise ConfigError("'use_time_currency.policy_version' must be a non-empty string")
+    tools_raw = raw.get("tools", {})
+    if not isinstance(tools_raw, dict):
+        raise ConfigError("'use_time_currency.tools' must be a mapping of tool names")
+
+    parsed_tools: dict[str, Any] = {}
+    for name, tool_raw in tools_raw.items():
+        if not isinstance(name, str) or not name.strip():
+            raise ConfigError(
+                "'use_time_currency.tools' keys must be non-empty tool names"
+            )
+        if not isinstance(tool_raw, dict):
+            raise ConfigError(f"use_time_currency.tools.{name} must be a mapping")
+        tool_extra = set(tool_raw) - {"facts"}
+        if tool_extra:
+            names = ", ".join(sorted(str(item) for item in tool_extra))
+            raise ConfigError(
+                f"unsupported use_time_currency.tools.{name} option(s): {names}"
+            )
+        facts_raw = tool_raw.get("facts")
+        if not isinstance(facts_raw, list) or not facts_raw:
+            raise ConfigError(
+                f"use_time_currency.tools.{name}.facts must be a non-empty list"
+            )
+        parsed_tools[name.strip()] = {
+            "facts": [
+                _parse_use_time_fact(item, tool=name.strip()) for item in facts_raw
+            ]
+        }
+
+    if enabled and profile == PROFILE_PRODUCTION:
+        if missing_policy != USE_TIME_MISSING_POLICY_ERROR:
+            _reject_weaker_production_policy(
+                "use_time_currency.missing_policy", str(missing_policy)
+            )
+        for name, tool in tools.items():
+            if tool.use_time_currency is False or name not in parsed_tools:
+                continue
+            # Consequential tools with use_time enabled must declare facts —
+            # already enforced by requiring non-empty facts above.
+
+    parsed: dict[str, Any] = {
+        "enabled": enabled,
+        "missing_policy": str(missing_policy),
+        "tools": parsed_tools,
+    }
+    if policy_version is not None:
+        parsed["policy_version"] = str(policy_version).strip()
+    return parsed
+
+
 def _parse_entity_guard(data: dict[str, Any], *, profile: str) -> dict[str, Any] | None:
     """Optional destination-policy section. Omitted keeps existing behavior."""
     raw = data.get("entity_guard")
@@ -3059,6 +3586,283 @@ def _parse_entity_guard(data: dict[str, Any], *, profile: str) -> dict[str, Any]
     }
     if policy_version is not None:
         parsed["policy_version"] = str(policy_version).strip()
+    return parsed
+
+
+_DESTRUCTIVE_TOP_KEYS = frozenset(
+    {
+        "enabled",
+        "missing_policy",
+        "policy_version",
+        "storage",
+        "path",
+        "table",
+        "url",
+        "url_env",
+        "dsn",
+        "dsn_env",
+        "prefix",
+        "tools",
+    }
+)
+_DESTRUCTIVE_TOOL_KEYS = frozenset({"operation", "object", "grant"})
+_DESTRUCTIVE_OBJECT_KEYS = frozenset(
+    {
+        "type",
+        "id_from",
+        "tenant_from",
+        "account_from",
+        "case_sensitive",
+        "require_canonicalizer",
+    }
+)
+_DESTRUCTIVE_GRANT_KEYS = frozenset(
+    {
+        "bind_request_id",
+        "bind_run_id",
+        "bind_thread_id",
+        "max_uses",
+        "ttl_seconds",
+    }
+)
+def destructive_confirm_policy_from_mapping(raw: dict[str, Any]) -> DestructiveConfirmPolicy:
+    tools: dict[str, DestructiveToolPolicy] = {}
+    for name, tool_raw in (raw.get("tools") or {}).items():
+        object_raw = tool_raw.get("object") or {}
+        grant_raw = tool_raw.get("grant") or {}
+        tools[str(name)] = DestructiveToolPolicy(
+            operation=str(tool_raw["operation"]),
+            object=DestructiveObjectSpec(
+                object_type=str(object_raw["type"]),
+                id_from=str(object_raw["id_from"]),
+                tenant_from=object_raw.get("tenant_from"),
+                account_from=object_raw.get("account_from"),
+                case_sensitive=bool(object_raw.get("case_sensitive", True)),
+                require_canonicalizer=bool(object_raw.get("require_canonicalizer", False)),
+            ),
+            grant=DestructiveGrantSpec(
+                bind_request_id=bool(grant_raw.get("bind_request_id", False)),
+                bind_run_id=bool(grant_raw.get("bind_run_id", False)),
+                bind_thread_id=bool(grant_raw.get("bind_thread_id", False)),
+                max_uses=int(grant_raw.get("max_uses", 1)),
+                ttl_seconds=float(grant_raw.get("ttl_seconds", 300)),
+            ),
+        )
+    return DestructiveConfirmPolicy(
+        enabled=bool(raw.get("enabled", True)),
+        missing_policy=str(raw.get("missing_policy", DESTRUCTIVE_MISSING_POLICY_ERROR)),
+        policy_version=str(raw.get("policy_version") or "unspecified"),
+        storage=str(raw.get("storage") or STORAGE_MEMORY),
+        tools=tools,
+    )
+
+
+def _parse_destructive_object(raw: Any, *, tool: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ConfigError(f"destructive_confirm.tools.{tool}.object must be a mapping")
+    extra = set(raw) - _DESTRUCTIVE_OBJECT_KEYS
+    if extra:
+        names = ", ".join(sorted(str(item) for item in extra))
+        raise ConfigError(
+            f"unsupported destructive_confirm.tools.{tool}.object option(s): {names}"
+        )
+    object_type = raw.get("type")
+    id_from = raw.get("id_from")
+    if not isinstance(object_type, str) or not object_type.strip():
+        raise ConfigError(
+            f"destructive_confirm.tools.{tool}.object.type is required"
+        )
+    if not isinstance(id_from, str) or not id_from.strip():
+        raise ConfigError(
+            f"destructive_confirm.tools.{tool}.object.id_from is required"
+        )
+    parsed: dict[str, Any] = {
+        "type": object_type.strip(),
+        "id_from": id_from.strip(),
+        "case_sensitive": True,
+        "require_canonicalizer": False,
+    }
+    if "case_sensitive" in raw:
+        if not isinstance(raw["case_sensitive"], bool):
+            raise ConfigError(
+                f"destructive_confirm.tools.{tool}.object.case_sensitive must be a bool"
+            )
+        parsed["case_sensitive"] = raw["case_sensitive"]
+    if "require_canonicalizer" in raw:
+        if not isinstance(raw["require_canonicalizer"], bool):
+            raise ConfigError(
+                f"destructive_confirm.tools.{tool}.object.require_canonicalizer "
+                "must be a bool"
+            )
+        parsed["require_canonicalizer"] = raw["require_canonicalizer"]
+    for key in ("tenant_from", "account_from"):
+        if key not in raw:
+            continue
+        value = raw[key]
+        if not isinstance(value, str) or not value.strip():
+            raise ConfigError(
+                f"destructive_confirm.tools.{tool}.object.{key} must be a non-empty string"
+            )
+        parsed[key] = value.strip()
+    return parsed
+
+
+def _parse_destructive_grant(raw: Any, *, tool: str) -> dict[str, Any]:
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, dict):
+        raise ConfigError(f"destructive_confirm.tools.{tool}.grant must be a mapping")
+    extra = set(raw) - _DESTRUCTIVE_GRANT_KEYS
+    if extra:
+        names = ", ".join(sorted(str(item) for item in extra))
+        raise ConfigError(
+            f"unsupported destructive_confirm.tools.{tool}.grant option(s): {names}"
+        )
+    parsed: dict[str, Any] = {
+        "bind_request_id": False,
+        "bind_run_id": False,
+        "bind_thread_id": False,
+        "max_uses": 1,
+        "ttl_seconds": 300.0,
+    }
+    for key in ("bind_request_id", "bind_run_id", "bind_thread_id"):
+        if key not in raw:
+            continue
+        if not isinstance(raw[key], bool):
+            raise ConfigError(
+                f"destructive_confirm.tools.{tool}.grant.{key} must be a bool"
+            )
+        parsed[key] = raw[key]
+    if "max_uses" in raw:
+        value = raw["max_uses"]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ConfigError(
+                f"destructive_confirm.tools.{tool}.grant.max_uses must be an integer >= 1"
+            )
+        parsed["max_uses"] = value
+    if "ttl_seconds" in raw:
+        value = raw["ttl_seconds"]
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+            raise ConfigError(
+                f"destructive_confirm.tools.{tool}.grant.ttl_seconds must be > 0"
+            )
+        parsed["ttl_seconds"] = float(value)
+    return parsed
+
+
+def _parse_destructive_confirm(
+    data: dict[str, Any],
+    *,
+    profile: str,
+    tools: dict[str, ToolConfig],
+    deployment: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    raw = data.get("destructive_confirm")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError("'destructive_confirm' must be a mapping")
+    extra = set(raw) - _DESTRUCTIVE_TOP_KEYS
+    if extra:
+        names = ", ".join(sorted(str(item) for item in extra))
+        raise ConfigError(f"unsupported 'destructive_confirm' option(s): {names}")
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise ConfigError("'destructive_confirm.enabled' must be a boolean")
+    missing_policy = raw.get("missing_policy", DESTRUCTIVE_MISSING_POLICY_ERROR)
+    if missing_policy not in DESTRUCTIVE_MISSING_POLICIES:
+        raise ConfigError(
+            "'destructive_confirm.missing_policy' must be one of "
+            f"{sorted(DESTRUCTIVE_MISSING_POLICIES)}"
+        )
+    policy_version = raw.get("policy_version")
+    if policy_version is not None and (
+        not isinstance(policy_version, str) or not policy_version.strip()
+    ):
+        raise ConfigError("'destructive_confirm.policy_version' must be a non-empty string")
+    storage = raw.get("storage", STORAGE_MEMORY)
+    if storage not in {
+        STORAGE_MEMORY,
+        STORAGE_FILE,
+        STORAGE_SQLITE,
+        STORAGE_REDIS,
+        STORAGE_POSTGRES,
+    }:
+        raise ConfigError(
+            "'destructive_confirm.storage' must be one of "
+            "memory, file, sqlite, redis, postgres"
+        )
+    tools_raw = raw.get("tools", {})
+    if not isinstance(tools_raw, dict):
+        raise ConfigError("'destructive_confirm.tools' must be a mapping of tool names")
+    parsed_tools: dict[str, Any] = {}
+    for name, tool_raw in tools_raw.items():
+        if not isinstance(name, str) or not name.strip():
+            raise ConfigError(
+                "'destructive_confirm.tools' keys must be non-empty tool names"
+            )
+        if not isinstance(tool_raw, dict):
+            raise ConfigError(f"destructive_confirm.tools.{name} must be a mapping")
+        extra_tool = set(tool_raw) - _DESTRUCTIVE_TOOL_KEYS
+        if extra_tool:
+            names = ", ".join(sorted(str(item) for item in extra_tool))
+            raise ConfigError(
+                f"unsupported destructive_confirm.tools.{name} option(s): {names}"
+            )
+        operation = tool_raw.get("operation")
+        if not isinstance(operation, str) or not operation.strip():
+            raise ConfigError(
+                f"destructive_confirm.tools.{name}.operation is required"
+            )
+        object_spec = _parse_destructive_object(tool_raw.get("object"), tool=name.strip())
+        grant_spec = _parse_destructive_grant(tool_raw.get("grant"), tool=name.strip())
+        parsed_tools[name.strip()] = {
+            "operation": operation.strip(),
+            "object": object_spec,
+            "grant": grant_spec,
+        }
+
+    if enabled and profile == PROFILE_PRODUCTION:
+        if missing_policy != DESTRUCTIVE_MISSING_POLICY_ERROR:
+            _reject_weaker_production_policy(
+                "destructive_confirm.missing_policy", str(missing_policy)
+            )
+        if storage == STORAGE_MEMORY:
+            raise ConfigError(
+                "profile is 'production' but destructive_confirm.storage is "
+                "'memory'; production requires durable grant storage "
+                "(file, sqlite, redis, or postgres)"
+            )
+        topology = (deployment or {}).get("topology")
+        if topology == "multi_node" and storage not in SHARED_GRANT_STORAGES:
+            raise ConfigError(
+                "profile is 'production' and deployment.topology is 'multi_node' "
+                "but destructive_confirm.storage is "
+                f"{storage!r}; multi-node production requires redis or postgres"
+            )
+        for name, tool in tools.items():
+            if tool.side_effect_class != SideEffectClass.IRREVERSIBLE:
+                continue
+            if tool.destructive_confirm is False or name not in parsed_tools:
+                raise ConfigError(
+                    f"profile is 'production' and tool {name!r} is "
+                    "side_effect_class: irreversible but has no "
+                    "destructive_confirm.tools declaration. Do not infer "
+                    "destructiveness from the tool name; list the tool with "
+                    "operation, object type, and id_from."
+                )
+
+    parsed: dict[str, Any] = {
+        "enabled": enabled,
+        "missing_policy": str(missing_policy),
+        "storage": storage,
+        "tools": parsed_tools,
+    }
+    if policy_version is not None:
+        parsed["policy_version"] = str(policy_version).strip()
+    for key in ("path", "table", "url", "url_env", "dsn", "dsn_env", "prefix"):
+        if key in raw:
+            parsed[key] = raw[key]
     return parsed
 
 
@@ -3301,6 +4105,7 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
 
     secret_args_raw = _parse_secret_args(data, profile=profile, tools=tools)
     entity_guard_raw = _parse_entity_guard(data, profile=profile)
+    # destructive_confirm is parsed after deployment so topology can be checked.
 
     message_validator_raw = data.get("message_validator", False)
     if isinstance(message_validator_raw, dict):
@@ -3315,6 +4120,15 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
     integrations = _parse_integrations(data)
     deployment = _parse_deployment(data)
     verify = _parse_verify(data)
+    destructive_confirm_raw = _parse_destructive_confirm(
+        data, profile=profile, tools=tools, deployment=deployment
+    )
+    authority_window_raw = _parse_authority_window(
+        data, profile=profile, destructive_confirm=destructive_confirm_raw
+    )
+    use_time_currency_raw = _parse_use_time_currency(
+        data, profile=profile, tools=tools
+    )
 
     cfg = MyceliumConfig(
         tools=tools,
@@ -3339,11 +4153,18 @@ def _parse_config(data: dict[str, Any]) -> MyceliumConfig:
         verify=verify,
         secret_args=secret_args_raw,
         entity_guard=entity_guard_raw,
+        destructive_confirm=destructive_confirm_raw,
+        authority_window=authority_window_raw,
+        use_time_currency=use_time_currency_raw,
         profile=profile,
         _audit_auto=audit_auto,
     )
     cfg._activate_completion_terminal()
     cfg._activate_llm_budget()
+    if authority_window_raw is not None or destructive_confirm_raw is not None:
+        cfg._activate_authority_window()
+    if use_time_currency_raw is not None:
+        cfg._activate_use_time_currency()
     return cfg
 
 

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -912,6 +912,7 @@ class MyceliumConfig:
             or applies_secret
             or applies_entity
             or applies_destructive
+            or applies_use_time
         ):
             try:
                 func = instrument_langgraph_tool(func)

--- a/sdk/mycelium/destructive_confirm.py
+++ b/sdk/mycelium/destructive_confirm.py
@@ -1,0 +1,1755 @@
+"""Host-issued object grants for destructive / irreversible tool calls.
+
+Tool permission is not object authorization. A configured destructive tool
+may claim, execute, or cross a side-effect boundary only when the host has
+minted an exact grant: this operation, this canonical object, this scope
+when bound, before expiry, for at most ``max_uses``. The model cannot
+create, widen, renew, or approve a grant. Dual control is intentionally
+not implemented — two-person approval belongs in the host workflow that
+calls :func:`issue_destructive_grant`.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import inspect
+import json
+import re
+import secrets
+import threading
+import time
+from collections.abc import Callable, Mapping, Sequence
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, ParamSpec, Protocol, TypeVar
+
+from mycelium.entity_guard import PAYLOAD_OMITTED
+from mycelium.storage.json_file import LockedJsonDictFile
+from mycelium.tool_boundary import ToolBoundaryError
+from mycelium.transition import LEDGER_KWARG_KEYS, get_active_execution_scope
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+MISSING_POLICY_ERROR = "error"
+MISSING_POLICY_WARN = "warn"
+MISSING_POLICIES = frozenset({MISSING_POLICY_ERROR, MISSING_POLICY_WARN})
+
+DECISION_ALLOWED = "allowed"
+DECISION_DENIED = "denied"
+DECISION_EXPIRED = "expired"
+DECISION_EXHAUSTED = "exhausted"
+DECISION_MISMATCHED = "mismatched"
+DECISION_AMBIGUOUS = "ambiguous"
+DECISIONS = frozenset(
+    {
+        DECISION_ALLOWED,
+        DECISION_DENIED,
+        DECISION_EXPIRED,
+        DECISION_EXHAUSTED,
+        DECISION_MISMATCHED,
+        DECISION_AMBIGUOUS,
+    }
+)
+
+REASON_MISSING = "missing"
+REASON_EXPIRED = "expired"
+REASON_EXHAUSTED = "exhausted"
+REASON_MISMATCHED = "mismatched"
+REASON_MALFORMED = "malformed"
+REASON_UNVERIFIABLE = "unverifiable"
+REASON_STORAGE = "storage"
+REASON_RETRY = "retry"
+REASON_IDENTITY_DRIFT = "identity_drift"
+
+PROVENANCE_HOST = "host"
+STORAGE_MEMORY = "memory"
+STORAGE_FILE = "file"
+STORAGE_SQLITE = "sqlite"
+STORAGE_REDIS = "redis"
+STORAGE_POSTGRES = "postgres"
+DURABLE_STORAGES = frozenset({STORAGE_FILE, STORAGE_SQLITE, STORAGE_REDIS, STORAGE_POSTGRES})
+SINGLE_NODE_GRANT_STORAGES = frozenset({STORAGE_FILE, STORAGE_SQLITE, STORAGE_MEMORY})
+SHARED_GRANT_STORAGES = frozenset({STORAGE_REDIS, STORAGE_POSTGRES})
+
+_HOMOGLYPH_DOTS = ("\u3002", "\uff0e", "\uff61", "\u2024")
+_DYNAMIC_MARKERS = ("{", "}", "{{", "}}", "${")
+_SCHEME_PREFIXES = ("http:", "https:", "file:", "ftp:", "data:")
+_TABLE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_MISSING = object()
+_PAYLOAD_FIELD_NAMES = frozenset(
+    {
+        "body",
+        "content",
+        "text",
+        "html",
+        "message",
+        "payload",
+        "file",
+        "data",
+        "attachments",
+        "subject",
+        "title",
+        "description",
+        "markdown",
+        "bytes",
+        "amount",
+        "reason",
+        "notes",
+        "secret",
+        "token",
+        "password",
+        "api_key",
+    }
+)
+
+_clock_var: ContextVar[Callable[[], float] | None] = ContextVar(
+    "mycelium_destructive_clock", default=None
+)
+_store_var: ContextVar[DestructiveGrantStore | None] = ContextVar(
+    "mycelium_destructive_grant_store", default=None
+)
+_policy_var: ContextVar[DestructiveConfirmPolicy | None] = ContextVar(
+    "mycelium_destructive_policy", default=None
+)
+_decision_var: ContextVar[DestructiveDecision | None] = ContextVar(
+    "mycelium_destructive_decision", default=None
+)
+_canonicalizers: dict[str, Callable[[Any], str]] = {}
+_default_store: DestructiveGrantStore | None = None
+
+
+class DestructiveGrantError(ToolBoundaryError):
+    """Grant missing, expired, exhausted, mismatched, or unverifiable."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tool: str,
+        operation: str | None = None,
+        object_type: str | None = None,
+        object_ref: str | None = None,
+        reason: str = REASON_MISSING,
+    ) -> None:
+        super().__init__(
+            message,
+            violation="destructive_confirm",
+            tool_name=tool,
+            llm_message=(
+                f"Destructive confirmation blocked {tool!r}: {message}. "
+                "The host must issue an exact grant for this operation and "
+                "object. The tool body was not executed."
+            ),
+            field=operation,
+            expected=object_type,
+            recovery_hint=(
+                "Ask the host to mint a DestructiveGrant for this exact "
+                "operation and canonical object. The model cannot approve "
+                "or renew grants."
+            ),
+        )
+        self.tool = tool
+        self.operation = operation
+        self.object_type = object_type
+        self.object_ref = object_ref
+        self.reason = reason
+
+
+class DestructiveCanonicalizeError(ValueError):
+    """Object type, object id, or operation cannot be canonicalized."""
+
+
+@dataclass(frozen=True)
+class DestructiveGrant:
+    """Immutable host-issued authorization for one destructive attempt."""
+
+    grant_id: str
+    operation: str
+    object_type: str
+    object_id: str
+    issued_at: float
+    expires_at: float
+    max_uses: int
+    request_id: str | None = None
+    run_id: str | None = None
+    thread_id: str | None = None
+    tenant: str | None = None
+    account: str | None = None
+    policy_version: str = "unspecified"
+    policy_hash: str = ""
+    provenance: str = PROVENANCE_HOST
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "grant_id": self.grant_id,
+            "operation": self.operation,
+            "object_type": self.object_type,
+            "object_id": self.object_id,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "max_uses": self.max_uses,
+            "request_id": self.request_id,
+            "run_id": self.run_id,
+            "thread_id": self.thread_id,
+            "tenant": self.tenant,
+            "account": self.account,
+            "policy_version": self.policy_version,
+            "policy_hash": self.policy_hash,
+            "provenance": self.provenance,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> DestructiveGrant:
+        required = (
+            "grant_id",
+            "operation",
+            "object_type",
+            "object_id",
+            "issued_at",
+            "expires_at",
+            "max_uses",
+        )
+        missing = [key for key in required if key not in raw]
+        if missing:
+            raise DestructiveCanonicalizeError(
+                f"grant record missing field(s): {missing}"
+            )
+        return cls(
+            grant_id=str(raw["grant_id"]),
+            operation=str(raw["operation"]),
+            object_type=str(raw["object_type"]),
+            object_id=str(raw["object_id"]),
+            issued_at=float(raw["issued_at"]),
+            expires_at=float(raw["expires_at"]),
+            max_uses=int(raw["max_uses"]),
+            request_id=_optional_str(raw.get("request_id")),
+            run_id=_optional_str(raw.get("run_id")),
+            thread_id=_optional_str(raw.get("thread_id")),
+            tenant=_optional_str(raw.get("tenant")),
+            account=_optional_str(raw.get("account")),
+            policy_version=str(raw.get("policy_version") or "unspecified"),
+            policy_hash=str(raw.get("policy_hash") or ""),
+            provenance=str(raw.get("provenance") or PROVENANCE_HOST),
+        )
+
+
+@dataclass(frozen=True)
+class DestructiveObjectSpec:
+    object_type: str
+    id_from: str
+    tenant_from: str | None = None
+    account_from: str | None = None
+    case_sensitive: bool = True
+    require_canonicalizer: bool = False
+
+
+@dataclass(frozen=True)
+class DestructiveGrantSpec:
+    bind_request_id: bool = False
+    bind_run_id: bool = False
+    bind_thread_id: bool = False
+    max_uses: int = 1
+    ttl_seconds: float = 300.0
+
+
+@dataclass(frozen=True)
+class DestructiveToolPolicy:
+    operation: str
+    object: DestructiveObjectSpec
+    grant: DestructiveGrantSpec = field(default_factory=DestructiveGrantSpec)
+
+
+@dataclass(frozen=True)
+class DestructiveConfirmPolicy:
+    """Host-owned destructive-confirm policy. The model cannot mint grants."""
+
+    enabled: bool = True
+    missing_policy: str = MISSING_POLICY_ERROR
+    policy_version: str = "unspecified"
+    storage: str = STORAGE_MEMORY
+    tools: dict[str, DestructiveToolPolicy] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.missing_policy not in MISSING_POLICIES:
+            raise ValueError(
+                "destructive_confirm.missing_policy must be one of "
+                f"{sorted(MISSING_POLICIES)}, got {self.missing_policy!r}"
+            )
+
+
+@dataclass(frozen=True)
+class DestructiveDecision:
+    tool: str
+    operation: str
+    object_type: str
+    object_ref: str
+    tenant: str | None
+    account: str | None
+    grant_ref: str | None
+    policy_version: str
+    decision: str
+    reason: str
+    request_id: str | None
+    run_id: str | None
+    timestamp: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "operation": self.operation,
+            "object_type": self.object_type,
+            "object_ref": self.object_ref,
+            "tenant": self.tenant,
+            "account": self.account,
+            "grant_ref": self.grant_ref,
+            "policy_version": self.policy_version,
+            "decision": self.decision,
+            "reason": self.reason,
+            "request_id": self.request_id,
+            "run_id": self.run_id,
+            "timestamp": self.timestamp,
+        }
+
+
+@dataclass(frozen=True)
+class ConsumeResult:
+    status: str
+    grant: DestructiveGrant | None = None
+    uses_remaining: int | None = None
+
+
+class DestructiveGrantStore(Protocol):
+    kind: str
+
+    def put(self, grant: DestructiveGrant) -> None: ...
+
+    def get(self, grant_id: str) -> dict[str, Any] | None: ...
+
+    def try_consume(
+        self, grant_id: str, request_id: str, now: float
+    ) -> ConsumeResult: ...
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _now() -> float:
+    clock = _clock_var.get()
+    return float(clock()) if clock is not None else time.time()
+
+
+def set_destructive_clock(clock: Callable[[], float] | None) -> Token[Callable[[], float] | None]:
+    """Install an injectable clock for expiry tests. ``None`` restores wall time.
+
+    Also binds the shared authority-window clock so authorize and use phases
+    observe the same host/test time.
+    """
+    from mycelium.authority_window import set_authority_clock
+
+    set_authority_clock(clock)
+    return _clock_var.set(clock)
+
+
+def reset_destructive_clock(token: Token[Callable[[], float] | None]) -> None:
+    from mycelium.authority_window import set_authority_clock
+
+    set_authority_clock(None)
+    _clock_var.reset(token)
+
+
+def get_destructive_grant_store() -> DestructiveGrantStore | None:
+    return _store_var.get() or _default_store
+
+
+def set_destructive_grant_store(
+    store: DestructiveGrantStore | None,
+) -> Token[DestructiveGrantStore | None]:
+    """Bind the process-wide grant store used by :func:`issue_destructive_grant`."""
+    global _default_store
+    _default_store = store
+    return _store_var.set(store)
+
+
+def reset_destructive_grant_store(token: Token[DestructiveGrantStore | None]) -> None:
+    _store_var.reset(token)
+
+
+def get_active_destructive_policy() -> DestructiveConfirmPolicy | None:
+    return _policy_var.get()
+
+
+def set_active_destructive_policy(
+    policy: DestructiveConfirmPolicy | None,
+) -> Token[DestructiveConfirmPolicy | None]:
+    return _policy_var.set(policy)
+
+
+def reset_active_destructive_policy(token: Token[DestructiveConfirmPolicy | None]) -> None:
+    _policy_var.reset(token)
+
+
+def get_active_destructive_decision() -> DestructiveDecision | None:
+    return _decision_var.get()
+
+
+def reset_destructive_confirm_state() -> None:
+    """Clear process-local grant, policy, decision, clock, and canonicalizers."""
+    global _default_store
+    from mycelium.authority_window import reset_authority_window_state
+
+    _store_var.set(None)
+    _policy_var.set(None)
+    _decision_var.set(None)
+    _clock_var.set(None)
+    _default_store = None
+    _canonicalizers.clear()
+    reset_authority_window_state()
+
+
+def register_destructive_object_canonicalizer(
+    object_type: str, fn: Callable[[Any], str]
+) -> None:
+    """Register a host canonicalizer that runs before claim and side effect."""
+    if not isinstance(object_type, str) or not object_type.strip():
+        raise ValueError("object_type must be a non-empty string")
+    key = canonicalize_object_type(object_type)
+    _canonicalizers[key] = fn
+
+
+def registered_destructive_canonicalizers() -> frozenset[str]:
+    return frozenset(_canonicalizers)
+
+
+def canonicalize_operation(value: Any) -> str:
+    if not isinstance(value, str):
+        raise DestructiveCanonicalizeError("operation must be a string")
+    text = value.strip()
+    if not text or text != value.strip():
+        if value != value.strip() or not text:
+            raise DestructiveCanonicalizeError("operation is empty or whitespace")
+    if any(marker in text for marker in _DYNAMIC_MARKERS):
+        raise DestructiveCanonicalizeError("operation is dynamic")
+    return text.casefold()
+
+
+def canonicalize_object_type(value: Any) -> str:
+    if not isinstance(value, str):
+        raise DestructiveCanonicalizeError("object type must be a string")
+    text = value.strip()
+    if not text:
+        raise DestructiveCanonicalizeError("object type is empty or whitespace")
+    if value != value.strip():
+        raise DestructiveCanonicalizeError("object type has surrounding whitespace")
+    if any(marker in text for marker in _DYNAMIC_MARKERS):
+        raise DestructiveCanonicalizeError("object type is dynamic")
+    return text.casefold()
+
+
+def canonicalize_scope_id(value: Any, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise DestructiveCanonicalizeError(f"{field} must be a string")
+    if value != value.strip() or not value.strip():
+        raise DestructiveCanonicalizeError(f"{field} is empty, whitespace, or padded")
+    if any(ord(char) < 32 or char == "\x7f" for char in value):
+        raise DestructiveCanonicalizeError(f"{field} contains control characters")
+    return value
+
+
+def canonicalize_object_id(
+    value: Any,
+    *,
+    object_type: str,
+    case_sensitive: bool = True,
+) -> str:
+    """Deterministic object-id canonicalization. Rejects ambiguous encodings."""
+    custom = _canonicalizers.get(object_type)
+    if custom is not None:
+        value = custom(value)
+    if not isinstance(value, str):
+        raise DestructiveCanonicalizeError("object id must be a string")
+    if value != value.strip() or not value.strip():
+        raise DestructiveCanonicalizeError(
+            "object id is empty, whitespace-only, or has surrounding whitespace"
+        )
+    if any(ord(char) < 32 or char == "\x7f" for char in value):
+        raise DestructiveCanonicalizeError("object id contains control characters")
+    if ".." in value or "\\" in value or "%" in value or "@" in value:
+        raise DestructiveCanonicalizeError("object id uses a path, encoding, or userinfo form")
+    if any(dot in value for dot in _HOMOGLYPH_DOTS):
+        raise DestructiveCanonicalizeError("object id uses an ambiguous Unicode dot")
+    folded = value.casefold()
+    if any(folded.startswith(prefix) for prefix in _SCHEME_PREFIXES):
+        raise DestructiveCanonicalizeError("object id looks like a URL or data URI")
+    if value.startswith("/") or value.startswith("\\"):
+        raise DestructiveCanonicalizeError("object id looks like an absolute path")
+    if any(marker in value for marker in _DYNAMIC_MARKERS):
+        raise DestructiveCanonicalizeError("object id is dynamic")
+    return value if case_sensitive else folded
+
+
+def object_digest(object_type: str, object_id: str) -> str:
+    payload = f"{object_type}\0{object_id}".encode()
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def grant_digest(grant_id: str) -> str:
+    return hashlib.sha256(grant_id.encode()).hexdigest()[:16]
+
+
+def policy_hash_for(
+    *,
+    operation: str,
+    object_type: str,
+    object_id: str,
+    tenant: str | None,
+    account: str | None,
+    max_uses: int,
+    bind_request_id: bool,
+    bind_run_id: bool,
+    bind_thread_id: bool,
+    policy_version: str,
+) -> str:
+    payload = "|".join(
+        [
+            operation,
+            object_type,
+            object_id,
+            tenant or "",
+            account or "",
+            str(max_uses),
+            "1" if bind_request_id else "0",
+            "1" if bind_run_id else "0",
+            "1" if bind_thread_id else "0",
+            policy_version,
+        ]
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _record_dict(grant: DestructiveGrant) -> dict[str, Any]:
+    return {
+        "grant": grant.to_dict(),
+        "uses_remaining": grant.max_uses,
+        "consumed_request_ids": [],
+    }
+
+
+def _consume_record(
+    rec: dict[str, Any] | None, request_id: str, now: float
+) -> ConsumeResult:
+    if rec is None:
+        return ConsumeResult(status=REASON_MISSING)
+    try:
+        grant = DestructiveGrant.from_dict(rec["grant"])
+        uses_remaining = int(rec.get("uses_remaining", 0))
+        consumed = [str(item) for item in rec.get("consumed_request_ids") or []]
+    except (KeyError, TypeError, ValueError, DestructiveCanonicalizeError):
+        return ConsumeResult(status=DECISION_AMBIGUOUS)
+    if request_id and request_id in consumed:
+        return ConsumeResult(status=REASON_RETRY, grant=grant, uses_remaining=uses_remaining)
+    if now >= float(grant.expires_at):
+        return ConsumeResult(status=REASON_EXPIRED, grant=grant, uses_remaining=uses_remaining)
+    if uses_remaining <= 0:
+        return ConsumeResult(status=REASON_EXHAUSTED, grant=grant, uses_remaining=0)
+    rec["uses_remaining"] = uses_remaining - 1
+    consumed.append(request_id)
+    rec["consumed_request_ids"] = consumed
+    return ConsumeResult(
+        status=DECISION_ALLOWED,
+        grant=grant,
+        uses_remaining=uses_remaining - 1,
+    )
+
+
+class InMemoryDestructiveGrantStore:
+    """Process-local grant store. Development and tests only."""
+
+    kind = STORAGE_MEMORY
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._records: dict[str, dict[str, Any]] = {}
+
+    def put(self, grant: DestructiveGrant) -> None:
+        with self._lock:
+            self._records[grant.grant_id] = _record_dict(grant)
+
+    def get(self, grant_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            rec = self._records.get(grant_id)
+            return json.loads(json.dumps(rec)) if rec is not None else None
+
+    def try_consume(self, grant_id: str, request_id: str, now: float) -> ConsumeResult:
+        with self._lock:
+            rec = self._records.get(grant_id)
+            result = _consume_record(rec, request_id, now)
+            return result
+
+
+class FileDestructiveGrantStore:
+    """Locked JSON file store for single-node deployments."""
+
+    kind = STORAGE_FILE
+
+    def __init__(self, path: str | Path) -> None:
+        self._file = LockedJsonDictFile(path)
+
+    def put(self, grant: DestructiveGrant) -> None:
+        def mutate(data: dict[str, dict[str, Any]]) -> None:
+            data[grant.grant_id] = _record_dict(grant)
+
+        self._file.read_modify_write(mutate)
+
+    def get(self, grant_id: str) -> dict[str, Any] | None:
+        data = self._file.load()
+        rec = data.get(grant_id)
+        return dict(rec) if rec is not None else None
+
+    def try_consume(self, grant_id: str, request_id: str, now: float) -> ConsumeResult:
+        def mutate(data: dict[str, dict[str, Any]]) -> ConsumeResult:
+            rec = data.get(grant_id)
+            result = _consume_record(rec, request_id, now)
+            return result
+
+        return self._file.read_modify_write(mutate)
+
+
+class SqliteDestructiveGrantStore:
+    """SQLite JSON-blob store with ``BEGIN IMMEDIATE`` consume."""
+
+    kind = STORAGE_SQLITE
+
+    def __init__(self, path: str | Path, *, table: str = "mycelium_destructive_grants") -> None:
+        import sqlite3
+
+        if not _TABLE_RE.fullmatch(table):
+            raise ValueError(f"invalid SQLite table name {table!r}")
+        self._path = Path(path)
+        self._table = table
+        self._lock = threading.Lock()
+        self._sqlite3 = sqlite3
+        self._schema_ready = False
+
+    def _connect(self) -> Any:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        conn = self._sqlite3.connect(
+            str(self._path), timeout=30.0, check_same_thread=False
+        )
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=30000")
+        conn.row_factory = self._sqlite3.Row
+        return conn
+
+    def _ensure_schema(self, conn: Any) -> None:
+        if self._schema_ready:
+            return
+        conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {self._table} ("
+            "grant_id TEXT PRIMARY KEY, payload TEXT NOT NULL)"
+        )
+        conn.commit()
+        self._schema_ready = True
+
+    def put(self, grant: DestructiveGrant) -> None:
+        payload = json.dumps(_record_dict(grant), default=str)
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                conn.execute(
+                    f"INSERT INTO {self._table} (grant_id, payload) VALUES (?, ?) "
+                    "ON CONFLICT(grant_id) DO UPDATE SET payload = excluded.payload",
+                    (grant.grant_id, payload),
+                )
+                conn.commit()
+
+    def get(self, grant_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                row = conn.execute(
+                    f"SELECT payload FROM {self._table} WHERE grant_id = ?",
+                    (grant_id,),
+                ).fetchone()
+        if row is None:
+            return None
+        return json.loads(row["payload"])
+
+    def try_consume(self, grant_id: str, request_id: str, now: float) -> ConsumeResult:
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    f"SELECT payload FROM {self._table} WHERE grant_id = ?",
+                    (grant_id,),
+                ).fetchone()
+                rec = json.loads(row["payload"]) if row is not None else None
+                result = _consume_record(rec, request_id, now)
+                if rec is not None and result.status == DECISION_ALLOWED:
+                    conn.execute(
+                        f"UPDATE {self._table} SET payload = ? WHERE grant_id = ?",
+                        (json.dumps(rec, default=str), grant_id),
+                    )
+                conn.commit()
+                return result
+
+
+class RedisDestructiveGrantStore:
+    """Redis JSON-blob store with WATCH/MULTI atomic consume."""
+
+    kind = STORAGE_REDIS
+
+    def __init__(self, url: str, *, prefix: str = "mycelium:destructive:") -> None:
+        import redis
+        from redis.exceptions import WatchError
+
+        self._redis = redis.Redis.from_url(url, decode_responses=True)
+        self._watch_error = WatchError
+        self._prefix = prefix
+        self._lock = threading.Lock()
+
+    def _key(self, grant_id: str) -> str:
+        return f"{self._prefix}{grant_id}"
+
+    def put(self, grant: DestructiveGrant) -> None:
+        self._redis.set(self._key(grant.grant_id), json.dumps(_record_dict(grant), default=str))
+
+    def get(self, grant_id: str) -> dict[str, Any] | None:
+        raw = self._redis.get(self._key(grant_id))
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    def try_consume(self, grant_id: str, request_id: str, now: float) -> ConsumeResult:
+        key = self._key(grant_id)
+        with self._lock:
+            while True:
+                with self._redis.pipeline() as pipe:
+                    try:
+                        pipe.watch(key)
+                        raw = pipe.get(key)
+                        rec = json.loads(raw) if raw is not None else None
+                        result = _consume_record(rec, request_id, now)
+                        if rec is not None and result.status == DECISION_ALLOWED:
+                            pipe.multi()
+                            pipe.set(key, json.dumps(rec, default=str))
+                            pipe.execute()
+                        else:
+                            pipe.reset()
+                        return result
+                    except self._watch_error:
+                        continue
+
+
+class PostgresDestructiveGrantStore:
+    """Postgres JSONB store with ``SELECT … FOR UPDATE`` consume."""
+
+    kind = STORAGE_POSTGRES
+
+    def __init__(self, dsn: str, *, table: str = "mycelium_destructive_grants") -> None:
+        import psycopg
+
+        if not _TABLE_RE.fullmatch(table):
+            raise ValueError(f"invalid Postgres table name {table!r}")
+        self._dsn = dsn
+        self._table = table
+        self._psycopg = psycopg
+        self._lock = threading.Lock()
+        self._schema_ready = False
+
+    def _ensure_schema(self, conn: Any) -> None:
+        if self._schema_ready:
+            return
+        conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {self._table} ("
+            "grant_id TEXT PRIMARY KEY, payload JSONB NOT NULL)"
+        )
+        conn.commit()
+        self._schema_ready = True
+
+    def put(self, grant: DestructiveGrant) -> None:
+        payload = json.dumps(_record_dict(grant), default=str)
+        with self._lock:
+            with self._psycopg.connect(self._dsn) as conn:
+                self._ensure_schema(conn)
+                conn.execute(
+                    f"INSERT INTO {self._table} (grant_id, payload) VALUES (%s, %s::jsonb) "
+                    "ON CONFLICT (grant_id) DO UPDATE SET payload = EXCLUDED.payload",
+                    (grant.grant_id, payload),
+                )
+                conn.commit()
+
+    def get(self, grant_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            with self._psycopg.connect(self._dsn) as conn:
+                self._ensure_schema(conn)
+                row = conn.execute(
+                    f"SELECT payload FROM {self._table} WHERE grant_id = %s",
+                    (grant_id,),
+                ).fetchone()
+        if row is None:
+            return None
+        payload = row[0]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return dict(payload)
+
+    def try_consume(self, grant_id: str, request_id: str, now: float) -> ConsumeResult:
+        with self._lock:
+            with self._psycopg.connect(self._dsn) as conn:
+                self._ensure_schema(conn)
+                with conn.transaction():
+                    row = conn.execute(
+                        f"SELECT payload FROM {self._table} "
+                        "WHERE grant_id = %s FOR UPDATE",
+                        (grant_id,),
+                    ).fetchone()
+                    if row is None:
+                        rec = None
+                    else:
+                        payload = row[0]
+                        if isinstance(payload, str):
+                            payload = json.loads(payload)
+                        rec = dict(payload)
+                    result = _consume_record(rec, request_id, now)
+                    if rec is not None and result.status == DECISION_ALLOWED:
+                        conn.execute(
+                            f"UPDATE {self._table} SET payload = %s::jsonb "
+                            "WHERE grant_id = %s",
+                            (json.dumps(rec, default=str), grant_id),
+                        )
+                    return result
+
+
+def issue_destructive_grant(
+    *,
+    operation: str,
+    object_type: str,
+    object_id: str,
+    request_id: str | None = None,
+    run_id: str | None = None,
+    thread_id: str | None = None,
+    tenant: str | None = None,
+    account: str | None = None,
+    expires_in: float = 300.0,
+    max_uses: int = 1,
+    policy_version: str = "unspecified",
+    store: DestructiveGrantStore | None = None,
+    case_sensitive: bool = True,
+    bind_request_id: bool = False,
+    bind_run_id: bool = False,
+    bind_thread_id: bool = False,
+) -> DestructiveGrant:
+    """Mint a host-controlled grant. Never call this from model-controlled code."""
+    if not isinstance(expires_in, (int, float)) or expires_in <= 0:
+        raise ValueError("expires_in must be a positive number of seconds")
+    if not isinstance(max_uses, int) or isinstance(max_uses, bool) or max_uses < 1:
+        raise ValueError("max_uses must be an integer >= 1")
+    op = canonicalize_operation(operation)
+    otype = canonicalize_object_type(object_type)
+    oid = canonicalize_object_id(object_id, object_type=otype, case_sensitive=case_sensitive)
+    tenant_id = canonicalize_scope_id(tenant, field="tenant") if tenant is not None else None
+    account_id = canonicalize_scope_id(account, field="account") if account is not None else None
+    req = canonicalize_scope_id(request_id, field="request_id") if request_id is not None else None
+    run = canonicalize_scope_id(run_id, field="run_id") if run_id is not None else None
+    thread = (
+        canonicalize_scope_id(thread_id, field="thread_id") if thread_id is not None else None
+    )
+    now = _now()
+    version = str(policy_version).strip() or "unspecified"
+    grant = DestructiveGrant(
+        grant_id=secrets.token_urlsafe(18),
+        operation=op,
+        object_type=otype,
+        object_id=oid,
+        issued_at=now,
+        expires_at=now + float(expires_in),
+        max_uses=max_uses,
+        request_id=req,
+        run_id=run,
+        thread_id=thread,
+        tenant=tenant_id,
+        account=account_id,
+        policy_version=version,
+        policy_hash=policy_hash_for(
+            operation=op,
+            object_type=otype,
+            object_id=oid,
+            tenant=tenant_id,
+            account=account_id,
+            max_uses=max_uses,
+            bind_request_id=bind_request_id,
+            bind_run_id=bind_run_id,
+            bind_thread_id=bind_thread_id,
+            policy_version=version,
+        ),
+        provenance=PROVENANCE_HOST,
+    )
+    target = store if store is not None else get_destructive_grant_store()
+    if target is None:
+        raise RuntimeError(
+            "No destructive grant store is bound. Call "
+            "set_destructive_grant_store(...) or destructive_grants.bind(config) "
+            "before issue_destructive_grant()."
+        )
+    target.put(grant)
+    return grant
+
+
+class DestructiveGrantIssuer:
+    """Host-facing issuer. There is no model-facing approve/renew API."""
+
+    def issue(self, **kwargs: Any) -> DestructiveGrant:
+        return issue_destructive_grant(**kwargs)
+
+    def bind(self, store_or_config: Any) -> DestructiveGrantStore:
+        if hasattr(store_or_config, "build_destructive_grant_store"):
+            store = store_or_config.build_destructive_grant_store()
+        else:
+            store = store_or_config
+        set_destructive_grant_store(store)
+        return store
+
+
+destructive_grants = DestructiveGrantIssuer()
+
+
+def _lookup_path(mapping: Mapping[str, Any], path: str) -> Any:
+    current: Any = mapping
+    for part in path.split("."):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return _MISSING
+    return current
+
+
+def _split_bookkeeping(
+    func: Callable[..., Any], kwargs: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    extra = {key: value for key, value in kwargs.items() if key in LEDGER_KWARG_KEYS}
+    known = {key: value for key, value in kwargs.items() if key not in LEDGER_KWARG_KEYS}
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return known, extra
+    if any(
+        param.kind is inspect.Parameter.VAR_KEYWORD
+        for param in signature.parameters.values()
+    ):
+        return known, extra
+    names = set(signature.parameters)
+    for key, value in list(known.items()):
+        if key not in names:
+            extra[key] = value
+            del known[key]
+    return known, extra
+
+
+def _bound_mapping(
+    func: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    try:
+        signature = inspect.signature(func)
+        bound = signature.bind_partial(*args, **kwargs)
+        return dict(bound.arguments)
+    except (TypeError, ValueError):
+        return dict(kwargs)
+
+
+def _rebuild_call(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    mapping: dict[str, Any],
+    extra: dict[str, Any],
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    new_args = list(args)
+    new_kwargs = dict(extra)
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        new_kwargs.update(mapping)
+        return tuple(new_args), new_kwargs
+    positional = [
+        param
+        for param in signature.parameters.values()
+        if param.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    for index, param in enumerate(positional):
+        if param.name in mapping and index < len(new_args):
+            new_args[index] = mapping[param.name]
+        elif param.name in mapping:
+            new_kwargs[param.name] = mapping[param.name]
+    for key, value in mapping.items():
+        if key not in {param.name for param in positional}:
+            new_kwargs[key] = value
+    return tuple(new_args), new_kwargs
+
+
+def _scope_grants() -> tuple[DestructiveGrant, ...]:
+    scope = get_active_execution_scope()
+    if scope is None:
+        return ()
+    raw = getattr(scope, "destructive_grants", ()) or ()
+    grants: list[DestructiveGrant] = []
+    for item in raw:
+        if isinstance(item, DestructiveGrant):
+            grants.append(item)
+    return tuple(grants)
+
+
+def _call_request_id(kwargs: Mapping[str, Any]) -> str | None:
+    value = kwargs.get("request_id")
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value
+
+
+def _call_run_thread() -> tuple[str | None, str | None]:
+    scope = get_active_execution_scope()
+    if scope is None:
+        return None, None
+    run_id = scope.run_id or None
+    thread_id = scope.thread_id or None
+    return run_id, thread_id
+
+
+def _safe_message(
+    *,
+    tool: str,
+    operation: str,
+    object_type: str,
+    object_ref: str,
+    reason: str,
+) -> str:
+    return (
+        f"destructive grant {reason} for tool {tool!r} "
+        f"operation={operation!r} object={object_type}/{object_ref}"
+    )
+
+
+def _set_decision(decision: DestructiveDecision) -> DestructiveDecision:
+    _decision_var.set(decision)
+    return decision
+
+
+def _raise(
+    *,
+    tool: str,
+    operation: str,
+    object_type: str,
+    object_ref: str,
+    reason: str,
+    decision: str,
+    tenant: str | None,
+    account: str | None,
+    grant_ref: str | None,
+    policy_version: str,
+    request_id: str | None,
+    run_id: str | None,
+) -> None:
+    _set_decision(
+        DestructiveDecision(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            tenant=tenant,
+            account=account,
+            grant_ref=grant_ref,
+            policy_version=policy_version,
+            decision=decision,
+            reason=reason,
+            request_id=request_id,
+            run_id=run_id,
+            timestamp=_now(),
+        )
+    )
+    raise DestructiveGrantError(
+        _safe_message(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            reason=reason,
+        ),
+        tool=tool,
+        operation=operation,
+        object_type=object_type,
+        object_ref=object_ref,
+        reason=reason,
+    )
+
+
+def _grant_matches(
+    grant: DestructiveGrant,
+    *,
+    operation: str,
+    object_type: str,
+    object_id: str,
+    tenant: str | None,
+    account: str | None,
+    check_tenant: bool,
+    check_account: bool,
+    request_id: str | None,
+    run_id: str | None,
+    thread_id: str | None,
+    spec: DestructiveGrantSpec,
+    policy_version: str,
+    now: float,
+) -> str | None:
+    """Return a mismatch reason, or None if the grant matches."""
+    if grant.provenance != PROVENANCE_HOST:
+        return REASON_UNVERIFIABLE
+    if grant.operation != operation or grant.object_type != object_type:
+        return REASON_MISMATCHED
+    if grant.object_id != object_id:
+        return REASON_MISMATCHED
+    if check_tenant and (grant.tenant or None) != (tenant or None):
+        return REASON_MISMATCHED
+    if check_account and (grant.account or None) != (account or None):
+        return REASON_MISMATCHED
+    if policy_version != "unspecified" and grant.policy_version != policy_version:
+        return REASON_MISMATCHED
+    if spec.bind_request_id:
+        if not request_id or grant.request_id != request_id:
+            return REASON_MISMATCHED
+    if spec.bind_run_id:
+        if not run_id or grant.run_id != run_id:
+            return REASON_MISMATCHED
+    if spec.bind_thread_id:
+        if not thread_id or grant.thread_id != thread_id:
+            return REASON_MISMATCHED
+    if now >= grant.expires_at:
+        return REASON_EXPIRED
+    return None
+
+
+def enforce_destructive_confirm(
+    tool: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    policy: DestructiveConfirmPolicy,
+    func: Callable[..., Any] | None = None,
+    store: DestructiveGrantStore | None = None,
+) -> tuple[tuple[Any, ...], dict[str, Any], DestructiveDecision]:
+    """Authorize a destructive call. Fail closed before any side effect."""
+    tool_policy = policy.tools.get(tool)
+    request_id = _call_request_id(kwargs)
+    run_id, thread_id = _call_run_thread()
+    if "run_id" in kwargs and isinstance(kwargs.get("run_id"), str) and kwargs["run_id"]:
+        run_id = str(kwargs["run_id"])
+    if "thread_id" in kwargs and isinstance(kwargs.get("thread_id"), str) and kwargs["thread_id"]:
+        thread_id = str(kwargs["thread_id"])
+
+    if tool_policy is None:
+        decision = DestructiveDecision(
+            tool=tool,
+            operation="",
+            object_type="",
+            object_ref="",
+            tenant=None,
+            account=None,
+            grant_ref=None,
+            policy_version=policy.policy_version,
+            decision=DECISION_ALLOWED,
+            reason="undeclared",
+            request_id=request_id,
+            run_id=run_id,
+            timestamp=_now(),
+        )
+        _set_decision(decision)
+        return args, kwargs, decision
+
+    tool_kwargs, extra = (
+        _split_bookkeeping(func, kwargs) if func is not None else (dict(kwargs), {})
+    )
+    mapping = (
+        _bound_mapping(func, args, tool_kwargs) if func is not None else dict(tool_kwargs)
+    )
+    spec = tool_policy.object
+    try:
+        operation = canonicalize_operation(tool_policy.operation)
+        object_type = canonicalize_object_type(spec.object_type)
+    except DestructiveCanonicalizeError as exc:
+        _raise(
+            tool=tool,
+            operation=str(tool_policy.operation),
+            object_type=str(spec.object_type),
+            object_ref="",
+            reason=REASON_MALFORMED,
+            decision=DECISION_DENIED,
+            tenant=None,
+            account=None,
+            grant_ref=None,
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+        raise exc
+
+    raw_id = _lookup_path(mapping, spec.id_from)
+    tenant_raw = _lookup_path(mapping, spec.tenant_from) if spec.tenant_from else None
+    account_raw = _lookup_path(mapping, spec.account_from) if spec.account_from else None
+    if raw_id is _MISSING or raw_id in (None, "", [], ()):
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref="",
+            reason=REASON_MISSING,
+            decision=DECISION_DENIED,
+            tenant=None,
+            account=None,
+            grant_ref=None,
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+
+    try:
+        object_id = canonicalize_object_id(
+            raw_id, object_type=object_type, case_sensitive=spec.case_sensitive
+        )
+        tenant = (
+            canonicalize_scope_id(tenant_raw, field="tenant")
+            if spec.tenant_from and tenant_raw not in (_MISSING, None)
+            else None
+        )
+        account = (
+            canonicalize_scope_id(account_raw, field="account")
+            if spec.account_from and account_raw not in (_MISSING, None)
+            else None
+        )
+        if spec.tenant_from and tenant is None:
+            raise DestructiveCanonicalizeError("tenant is missing")
+        if spec.account_from and account is None:
+            raise DestructiveCanonicalizeError("account is missing")
+    except DestructiveCanonicalizeError:
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref="",
+            reason=REASON_MALFORMED,
+            decision=DECISION_DENIED,
+            tenant=None,
+            account=None,
+            grant_ref=None,
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+
+    object_ref = object_digest(object_type, object_id)
+    now = _now()
+    candidates = _scope_grants()
+    matching: list[DestructiveGrant] = []
+    drift = False
+    expired_match = False
+    for grant in candidates:
+        reason = _grant_matches(
+            grant,
+            operation=operation,
+            object_type=object_type,
+            object_id=object_id,
+            tenant=tenant,
+            account=account,
+            check_tenant=bool(spec.tenant_from),
+            check_account=bool(spec.account_from),
+            request_id=request_id,
+            run_id=run_id,
+            thread_id=thread_id,
+            spec=tool_policy.grant,
+            policy_version=policy.policy_version,
+            now=now,
+        )
+        if reason is None:
+            matching.append(grant)
+        elif reason == REASON_EXPIRED and grant.object_id == object_id:
+            expired_match = True
+            # Already-consumed request_id may still RETURN a completed ledger
+            # result without fresh authority (dedupe); include for try_consume.
+            target_probe = store if store is not None else get_destructive_grant_store()
+            if (
+                request_id
+                and target_probe is not None
+                and tool_policy.grant.bind_request_id
+            ):
+                try:
+                    rec = target_probe.get(grant.grant_id)
+                except Exception:
+                    rec = None
+                consumed = (
+                    [str(item) for item in (rec or {}).get("consumed_request_ids") or []]
+                    if isinstance(rec, dict)
+                    else []
+                )
+                if request_id in consumed:
+                    matching.append(grant)
+        elif (
+            tool_policy.grant.bind_request_id
+            and request_id
+            and grant.request_id == request_id
+            and (grant.object_id != object_id or grant.operation != operation)
+        ):
+            drift = True
+
+    if not matching:
+        if drift:
+            _raise(
+                tool=tool,
+                operation=operation,
+                object_type=object_type,
+                object_ref=object_ref,
+                reason=REASON_IDENTITY_DRIFT,
+                decision=DECISION_MISMATCHED,
+                tenant=tenant,
+                account=account,
+                grant_ref=None,
+                policy_version=policy.policy_version,
+                request_id=request_id,
+                run_id=run_id,
+            )
+        if expired_match:
+            _raise(
+                tool=tool,
+                operation=operation,
+                object_type=object_type,
+                object_ref=object_ref,
+                reason=REASON_EXPIRED,
+                decision=DECISION_EXPIRED,
+                tenant=tenant,
+                account=account,
+                grant_ref=None,
+                policy_version=policy.policy_version,
+                request_id=request_id,
+                run_id=run_id,
+            )
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            reason=REASON_MISSING if not candidates else REASON_MISMATCHED,
+            decision=DECISION_DENIED if not candidates else DECISION_MISMATCHED,
+            tenant=tenant,
+            account=account,
+            grant_ref=None,
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+
+    target = store if store is not None else get_destructive_grant_store()
+    if target is None:
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            reason=REASON_UNVERIFIABLE,
+            decision=DECISION_AMBIGUOUS,
+            tenant=tenant,
+            account=account,
+            grant_ref=grant_digest(matching[0].grant_id),
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+
+    consume_id = request_id or matching[0].grant_id
+    try:
+        result = target.try_consume(matching[0].grant_id, consume_id, now)
+    except Exception:
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            reason=REASON_STORAGE,
+            decision=DECISION_DENIED,
+            tenant=tenant,
+            account=account,
+            grant_ref=grant_digest(matching[0].grant_id),
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+
+    grant_ref = grant_digest(matching[0].grant_id)
+    if result.status == REASON_MISSING:
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            reason=REASON_UNVERIFIABLE,
+            decision=DECISION_AMBIGUOUS,
+            tenant=tenant,
+            account=account,
+            grant_ref=grant_ref,
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+    if result.status == REASON_EXPIRED:
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            reason=REASON_EXPIRED,
+            decision=DECISION_EXPIRED,
+            tenant=tenant,
+            account=account,
+            grant_ref=grant_ref,
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+    if result.status == REASON_EXHAUSTED:
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            reason=REASON_EXHAUSTED,
+            decision=DECISION_EXHAUSTED,
+            tenant=tenant,
+            account=account,
+            grant_ref=grant_ref,
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+    if result.status == DECISION_AMBIGUOUS:
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            reason=REASON_UNVERIFIABLE,
+            decision=DECISION_AMBIGUOUS,
+            tenant=tenant,
+            account=account,
+            grant_ref=grant_ref,
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+    if result.status not in {DECISION_ALLOWED, REASON_RETRY}:
+        _raise(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            reason=REASON_MISMATCHED,
+            decision=DECISION_MISMATCHED,
+            tenant=tenant,
+            account=account,
+            grant_ref=grant_ref,
+            policy_version=policy.policy_version,
+            request_id=request_id,
+            run_id=run_id,
+        )
+
+    decision = _set_decision(
+        DestructiveDecision(
+            tool=tool,
+            operation=operation,
+            object_type=object_type,
+            object_ref=object_ref,
+            tenant=tenant,
+            account=account,
+            grant_ref=grant_ref,
+            policy_version=policy.policy_version,
+            decision=DECISION_ALLOWED,
+            reason=REASON_RETRY if result.status == REASON_RETRY else DECISION_ALLOWED,
+            request_id=request_id,
+            run_id=run_id,
+            timestamp=now,
+        )
+    )
+    # Register for mandatory use-phase expiry only when this call may still
+    # execute. Ledger RETURN retries must not require fresh authority.
+    if result.status != REASON_RETRY:
+        grant_obj = result.grant or matching[0]
+        from mycelium.authority_window import (
+            AuthorityValidationPhase,
+            bound_authority_from_destructive_grant,
+            register_authority_for_use,
+            validate_authority,
+        )
+
+        bound = bound_authority_from_destructive_grant(
+            grant_obj,
+            tool=tool,
+            object_ref=object_ref,
+            request_id=request_id,
+            run_id=run_id,
+        )
+        validate_authority(
+            bound,
+            phase=AuthorityValidationPhase.AUTHORIZE,
+            expected_policy_version=policy.policy_version,
+        )
+        register_authority_for_use(bound)
+    if func is not None:
+        return (*_rebuild_call(func, args, kwargs, mapping, extra), decision)
+    merged = dict(mapping)
+    merged.update(extra)
+    return args, merged, decision
+
+
+def sanitize_destructive_evidence(
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any],
+) -> tuple[list[Any], dict[str, Any]]:
+    """Keep tool / operation / object type; drop destructive payload."""
+    decision = get_active_destructive_decision()
+
+    def scrub(value: Any, *, name: str | None = None, payload: bool = False) -> Any:
+        key = (name or "").lower()
+        if key in _PAYLOAD_FIELD_NAMES or payload:
+            return PAYLOAD_OMITTED
+        if decision is not None and name in {"object_id", "payment_id", "file_id"}:
+            return decision.object_ref
+        if isinstance(value, Mapping):
+            return {
+                str(k): scrub(
+                    v,
+                    name=str(k),
+                    payload=str(k).lower() in _PAYLOAD_FIELD_NAMES,
+                )
+                for k, v in value.items()
+            }
+        if isinstance(value, list):
+            return [scrub(item, payload=payload) for item in value]
+        if isinstance(value, tuple):
+            return [scrub(item, payload=payload) for item in value]
+        return value
+
+    safe_kwargs = scrub(dict(kwargs)) if isinstance(kwargs, Mapping) else {}
+    assert isinstance(safe_kwargs, dict)
+    return [scrub(item) for item in args], safe_kwargs
+
+
+def destructive_fingerprint(decision: DestructiveDecision | None) -> tuple[str, ...]:
+    if decision is None or decision.decision != DECISION_ALLOWED:
+        return ()
+    return (
+        ":".join(
+            [
+                decision.operation,
+                decision.object_type,
+                decision.object_ref,
+                decision.tenant or "",
+                decision.account or "",
+            ]
+        ),
+    )
+
+
+def apply_destructive_confirm(
+    func: Callable[P, R],
+    policy: DestructiveConfirmPolicy,
+    *,
+    tool_name: str | None = None,
+    store: DestructiveGrantStore | None = None,
+    outcome_emitter: Any | None = None,
+) -> Callable[P, R]:
+    """Wrap *func* so a host grant is consumed before any inner guard or claim."""
+    name = tool_name or getattr(func, "__name__", "tool")
+
+    def _emit(decision: DestructiveDecision) -> None:
+        if outcome_emitter is None:
+            return
+        try:
+            outcome_emitter.emit_event(
+                tool=decision.tool,
+                request_id=decision.request_id or "",
+                event="destructive_confirm",
+                gate=decision.decision,
+                resolution_reason=decision.reason,
+                run_id=decision.run_id,
+                policy_version=decision.policy_version,
+                tool_body_executed=False,
+            )
+        except Exception:
+            return
+
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            token = set_active_destructive_policy(policy)
+            store_token = set_destructive_grant_store(store) if store is not None else None
+            from mycelium.authority_window import clear_pending_authorities
+
+            try:
+                call_args, call_kwargs, decision = enforce_destructive_confirm(
+                    name, args, kwargs, policy=policy, func=func, store=store
+                )
+                _emit(decision)
+                if not getattr(func, "_mycelium_ledger", False):
+                    from mycelium.authority_window import enforce_pending_authorities_at_use
+
+                    enforce_pending_authorities_at_use()
+                return await func(*call_args, **call_kwargs)
+            except DestructiveGrantError as exc:
+                current = get_active_destructive_decision()
+                if current is not None:
+                    _emit(current)
+                else:
+                    _emit(
+                        DestructiveDecision(
+                            tool=name,
+                            operation=exc.operation or "",
+                            object_type=exc.object_type or "",
+                            object_ref=exc.object_ref or "",
+                            tenant=None,
+                            account=None,
+                            grant_ref=None,
+                            policy_version=policy.policy_version,
+                            decision=DECISION_DENIED,
+                            reason=exc.reason,
+                            request_id=_call_request_id(kwargs),
+                            run_id=_call_run_thread()[0],
+                            timestamp=_now(),
+                        )
+                    )
+                raise
+            finally:
+                clear_pending_authorities()
+                reset_active_destructive_policy(token)
+                if store_token is not None:
+                    reset_destructive_grant_store(store_token)
+
+        async_wrapper._mycelium_destructive_confirm = True  # type: ignore[attr-defined]
+        return async_wrapper  # type: ignore[return-value]
+
+    @functools.wraps(func)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        token = set_active_destructive_policy(policy)
+        store_token = set_destructive_grant_store(store) if store is not None else None
+        from mycelium.authority_window import clear_pending_authorities
+
+        try:
+            call_args, call_kwargs, decision = enforce_destructive_confirm(
+                name, args, kwargs, policy=policy, func=func, store=store
+            )
+            _emit(decision)
+            if not getattr(func, "_mycelium_ledger", False):
+                from mycelium.authority_window import enforce_pending_authorities_at_use
+
+                enforce_pending_authorities_at_use()
+            return func(*call_args, **call_kwargs)
+        except DestructiveGrantError as exc:
+            current = get_active_destructive_decision()
+            if current is not None:
+                _emit(current)
+            else:
+                _emit(
+                    DestructiveDecision(
+                        tool=name,
+                        operation=exc.operation or "",
+                        object_type=exc.object_type or "",
+                        object_ref=exc.object_ref or "",
+                        tenant=None,
+                        account=None,
+                        grant_ref=None,
+                        policy_version=policy.policy_version,
+                        decision=DECISION_DENIED,
+                        reason=exc.reason,
+                        request_id=_call_request_id(kwargs),
+                        run_id=_call_run_thread()[0],
+                        timestamp=_now(),
+                    )
+                )
+            raise
+        finally:
+            clear_pending_authorities()
+            reset_active_destructive_policy(token)
+            if store_token is not None:
+                reset_destructive_grant_store(store_token)
+
+    sync_wrapper._mycelium_destructive_confirm = True  # type: ignore[attr-defined]
+    return sync_wrapper  # type: ignore[return-value]
+
+
+def destructive_confirm_policy_for_tool(
+    policy: DestructiveConfirmPolicy, tool_name: str
+) -> DestructiveConfirmPolicy:
+    tool = policy.tools.get(tool_name)
+    if tool is None:
+        return replace(policy, tools={})
+    return replace(policy, tools={tool_name: tool})
+
+
+__all__ = [
+    "DECISIONS",
+    "DECISION_ALLOWED",
+    "DECISION_AMBIGUOUS",
+    "DECISION_DENIED",
+    "DECISION_EXHAUSTED",
+    "DECISION_EXPIRED",
+    "DECISION_MISMATCHED",
+    "DURABLE_STORAGES",
+    "MISSING_POLICIES",
+    "MISSING_POLICY_ERROR",
+    "MISSING_POLICY_WARN",
+    "SHARED_GRANT_STORAGES",
+    "SINGLE_NODE_GRANT_STORAGES",
+    "STORAGE_FILE",
+    "STORAGE_MEMORY",
+    "STORAGE_POSTGRES",
+    "STORAGE_REDIS",
+    "STORAGE_SQLITE",
+    "ConsumeResult",
+    "DestructiveConfirmPolicy",
+    "DestructiveDecision",
+    "DestructiveGrant",
+    "DestructiveGrantError",
+    "DestructiveGrantSpec",
+    "DestructiveObjectSpec",
+    "DestructiveToolPolicy",
+    "FileDestructiveGrantStore",
+    "InMemoryDestructiveGrantStore",
+    "PostgresDestructiveGrantStore",
+    "RedisDestructiveGrantStore",
+    "SqliteDestructiveGrantStore",
+    "apply_destructive_confirm",
+    "canonicalize_object_id",
+    "canonicalize_object_type",
+    "canonicalize_operation",
+    "destructive_confirm_policy_for_tool",
+    "destructive_fingerprint",
+    "destructive_grants",
+    "enforce_destructive_confirm",
+    "get_active_destructive_decision",
+    "get_active_destructive_policy",
+    "get_destructive_grant_store",
+    "issue_destructive_grant",
+    "register_destructive_object_canonicalizer",
+    "registered_destructive_canonicalizers",
+    "reset_destructive_confirm_state",
+    "sanitize_destructive_evidence",
+    "set_destructive_clock",
+    "set_destructive_grant_store",
+]

--- a/sdk/mycelium/doctor/checks.py
+++ b/sdk/mycelium/doctor/checks.py
@@ -13,6 +13,12 @@ from mycelium.config import (
     _outcome_on_failure,
     _request_identity_policy,
 )
+from mycelium.destructive_confirm import (
+    SHARED_GRANT_STORAGES,
+    SINGLE_NODE_GRANT_STORAGES,
+    STORAGE_MEMORY,
+    registered_destructive_canonicalizers,
+)
 from mycelium.doctor.connectivity import (
     host_hint_from_url,
     probe_file_path,
@@ -44,6 +50,7 @@ from mycelium.storage.redis_outcome import RedisOutcomeStorage
 from mycelium.transition import (
     CONSEQUENTIAL_SIDE_EFFECT_CLASSES,
     REQUEST_IDENTITY_POLICY_REQUIRE_EXPLICIT,
+    SideEffectClass,
 )
 
 SINGLE_NODE_STORAGES = frozenset({"file", "sqlite", "memory"})
@@ -1445,6 +1452,589 @@ def check_entity_guard(ctx: DoctorContext) -> Iterable[DoctorCheck]:
         summary="Destination allowlists are host-controlled",
         details="The model cannot add recipients, hosts, or entity IDs to the allowlist.",
         evidence=EVIDENCE_STATIC,
+        blocking=False,
+    )
+
+
+@doctor_check("destructive_confirm")
+def check_destructive_confirm(ctx: DoctorContext) -> Iterable[DoctorCheck]:
+    """Object-specific grants: tool permission is not object authorization."""
+    cfg = ctx.config
+    raw = cfg.destructive_confirm
+    if raw is None:
+        yield _check(
+            id="destructive.scanning",
+            category="Destructive-confirm",
+            status=DoctorStatus.SKIP,
+            summary="destructive_confirm is not configured (existing behavior)",
+            details="Omitted destructive_confirm preserves pre-AF-011 behavior.",
+            remediation=(
+                "Add destructive_confirm: {enabled: true, missing_policy: error} "
+                "and declare operation + object id_from per destructive tool. "
+                "The model cannot mint grants."
+            ),
+            evidence=EVIDENCE_STATIC,
+            blocking=False,
+        )
+        return
+
+    enabled = bool(raw.get("enabled", True))
+    missing_policy = str(raw.get("missing_policy", "error"))
+    storage = str(raw.get("storage", STORAGE_MEMORY))
+    tools_raw = raw.get("tools") or {}
+    declared = sorted(tools_raw)
+    exact = []
+    incomplete = []
+    require_canon = []
+    binds_request = []
+    for name, tool_raw in tools_raw.items():
+        obj = (tool_raw or {}).get("object") or {}
+        grant = (tool_raw or {}).get("grant") or {}
+        if (
+            tool_raw.get("operation")
+            and obj.get("type")
+            and obj.get("id_from")
+        ):
+            exact.append(name)
+        else:
+            incomplete.append(name)
+        if obj.get("require_canonicalizer"):
+            require_canon.append((name, obj.get("type")))
+        if grant.get("bind_request_id") or grant.get("bind_run_id"):
+            binds_request.append(name)
+
+    yield _check(
+        id="destructive.enabled",
+        category="Destructive-confirm",
+        status=DoctorStatus.PASS if enabled else DoctorStatus.WARN,
+        summary=(
+            "Destructive confirmation is enabled"
+            if enabled
+            else "Destructive confirmation is configured but disabled"
+        ),
+        details=(
+            f"enabled={enabled}; missing_policy={missing_policy!r}; "
+            f"storage={storage!r}; tools={declared or 'none'}"
+        ),
+        remediation="" if enabled else "Set destructive_confirm.enabled: true.",
+        evidence=EVIDENCE_STATIC,
+        blocking=not enabled,
+    )
+    fail_closed = enabled and missing_policy == "error"
+    if cfg.profile == PROFILE_PRODUCTION and declared:
+        yield _check(
+            id="destructive.production_fail_closed",
+            category="Destructive-confirm",
+            status=DoctorStatus.PASS if fail_closed else DoctorStatus.FAIL,
+            summary=(
+                "Production destructive checks fail closed"
+                if fail_closed
+                else "Production destructive checks do not fail closed"
+            ),
+            details=f"missing_policy={missing_policy!r}",
+            remediation=""
+            if fail_closed
+            else "Set destructive_confirm.missing_policy: error under profile: production.",
+            evidence=EVIDENCE_STATIC,
+        )
+        durable = storage != STORAGE_MEMORY
+        yield _check(
+            id="destructive.production_storage",
+            category="Destructive-confirm",
+            status=DoctorStatus.PASS if durable else DoctorStatus.FAIL,
+            summary=(
+                "Production grant storage is durable"
+                if durable
+                else "Production grant storage is memory"
+            ),
+            details=f"storage={storage!r}",
+            remediation=""
+            if durable
+            else "Use file, sqlite, redis, or postgres grant storage in production.",
+            evidence=EVIDENCE_STATIC,
+        )
+        topology = (cfg.deployment or {}).get("topology")
+        if topology == "multi_node":
+            shared = storage in SHARED_GRANT_STORAGES
+            yield _check(
+                id="destructive.shared_storage",
+                category="Destructive-confirm",
+                status=DoctorStatus.PASS if shared else DoctorStatus.FAIL,
+                summary=(
+                    "multi_node grant storage is shared"
+                    if shared
+                    else "multi_node grant storage is single-node"
+                ),
+                details=f"storage={storage!r}; topology={topology}",
+                remediation=""
+                if shared
+                else "Use redis or postgres grant storage for multi-node production.",
+                evidence=EVIDENCE_STATIC,
+            )
+        elif storage in SINGLE_NODE_GRANT_STORAGES and topology != "single_node":
+            yield _check(
+                id="destructive.shared_storage",
+                category="Destructive-confirm",
+                status=DoctorStatus.WARN,
+                summary="Grant storage is single-node; topology is not declared multi_node",
+                details=f"storage={storage!r}; topology={topology!r}",
+                remediation="Set deployment.topology: single_node or use redis/postgres.",
+                evidence=EVIDENCE_STATIC,
+                blocking=False,
+            )
+
+    if enabled and incomplete:
+        yield _check(
+            id="destructive.object_identity",
+            category="Destructive-confirm",
+            status=DoctorStatus.FAIL,
+            summary="Configured destructive tools do not identify an exact object",
+            details=f"incomplete={incomplete}",
+            remediation=(
+                "Set operation, object.type, and object.id_from on each "
+                "destructive_confirm.tools entry."
+            ),
+            evidence=EVIDENCE_STATIC,
+        )
+    elif enabled and exact:
+        yield _check(
+            id="destructive.object_identity",
+            category="Destructive-confirm",
+            status=DoctorStatus.PASS,
+            summary="Configured destructive tools identify an exact object",
+            details=f"tools={exact}",
+            evidence=EVIDENCE_STATIC,
+        )
+
+    irreversible = [
+        name
+        for name, tool in cfg.tools.items()
+        if tool.side_effect_class == SideEffectClass.IRREVERSIBLE
+        and name not in declared
+        and tool.destructive_confirm is not False
+    ]
+    if enabled and irreversible:
+        yield _check(
+            id="destructive.irreversible_declared",
+            category="Destructive-confirm",
+            status=DoctorStatus.WARN
+            if cfg.profile != PROFILE_PRODUCTION
+            else DoctorStatus.FAIL,
+            summary="Irreversible tools have no destructive_confirm declaration",
+            details=f"undeclared={irreversible}",
+            remediation=(
+                "Declare destructive_confirm.tools.<name> with operation and "
+                "object.id_from. Do not infer destructiveness from the tool name."
+            ),
+            evidence=EVIDENCE_STATIC,
+            blocking=cfg.profile == PROFILE_PRODUCTION,
+        )
+
+    if enabled and declared and not binds_request:
+        yield _check(
+            id="destructive.bindings",
+            category="Destructive-confirm",
+            status=DoctorStatus.WARN,
+            summary="No destructive tool binds request_id or run_id",
+            details=f"tools={declared}",
+            remediation="Set grant.bind_request_id: true so retries reuse one grant use.",
+            evidence=EVIDENCE_STATIC,
+            blocking=False,
+        )
+    elif enabled and binds_request:
+        yield _check(
+            id="destructive.bindings",
+            category="Destructive-confirm",
+            status=DoctorStatus.PASS,
+            summary="Destructive tools bind request or run identity",
+            details=f"tools={binds_request}",
+            evidence=EVIDENCE_STATIC,
+            blocking=False,
+        )
+
+    if enabled and require_canon:
+        wired = registered_destructive_canonicalizers()
+        missing_canon = [
+            f"{name}:{otype}"
+            for name, otype in require_canon
+            if str(otype).casefold() not in wired
+        ]
+        yield _check(
+            id="destructive.canonicalizer",
+            category="Destructive-confirm",
+            status=DoctorStatus.WARN if missing_canon else DoctorStatus.PASS,
+            summary=(
+                "Required custom canonicalizers are not registered in this process"
+                if missing_canon
+                else "Required custom canonicalizers are registered"
+            ),
+            details=f"missing={missing_canon or 'none'}; registered={sorted(wired) or 'none'}",
+            remediation=(
+                "Call register_destructive_object_canonicalizer before load. "
+                "Installed or importable adapters are not wired."
+            ),
+            evidence=EVIDENCE_RUNTIME if missing_canon else EVIDENCE_STATIC,
+            blocking=False,
+        )
+
+    yield _check(
+        id="destructive.host_issued",
+        category="Destructive-confirm",
+        status=DoctorStatus.SKIP,
+        summary="Doctor cannot prove the host mints grants",
+        details=(
+            "Configuration cannot show that call sites call "
+            "issue_destructive_grant, that a human approved the grant, "
+            "that the provider honors idempotency keys, or that an "
+            "external side effect occurred. Dual control is not implemented."
+        ),
+        evidence=EVIDENCE_NOT_VERIFIABLE,
+        blocking=False,
+    )
+
+
+@doctor_check("authority_window")
+def check_authority_window(ctx: DoctorContext) -> Iterable[DoctorCheck]:
+    """Use-time expiry for time-bounded authority (batch item 4)."""
+    from mycelium.authority_window import (
+        USE_TIME_CHECK_REQUIRED,
+        registered_authority_use_adapters,
+    )
+
+    cfg = ctx.config
+    raw = cfg.authority_window
+    destructive = cfg.destructive_confirm
+    if raw is None and destructive is None:
+        yield _check(
+            id="authority_window.scanning",
+            category="Authority-window",
+            status=DoctorStatus.SKIP,
+            summary="authority_window is not configured (existing behavior)",
+            details=(
+                "Omitted authority_window preserves timeless paths. "
+                "Time-bounded destructive_confirm still enforces use-time "
+                "expiry when configured."
+            ),
+            remediation=(
+                "Add authority_window: {enabled: true, use_time_check: required} "
+                "when hosts issue time-bounded authority."
+            ),
+            evidence=EVIDENCE_STATIC,
+            blocking=False,
+        )
+        return
+
+    enabled = True if raw is None else bool(raw.get("enabled", True))
+    use_time = (
+        USE_TIME_CHECK_REQUIRED
+        if raw is None
+        else str(raw.get("use_time_check", USE_TIME_CHECK_REQUIRED))
+    )
+    skew = 0.0 if raw is None else float(raw.get("clock_skew_tolerance_seconds", 0))
+    implied = raw is None and destructive is not None
+
+    yield _check(
+        id="authority_window.enabled",
+        category="Authority-window",
+        status=DoctorStatus.PASS if enabled else DoctorStatus.WARN,
+        summary=(
+            "Authority-window use-time checks are enabled"
+            if enabled
+            else "Authority-window is configured but disabled"
+        ),
+        details=(
+            f"enabled={enabled}; use_time_check={use_time!r}; "
+            f"clock_skew_tolerance_seconds={skew}; "
+            f"implied_from_destructive={implied}"
+        ),
+        remediation="" if enabled else "Set authority_window.enabled: true.",
+        evidence=EVIDENCE_STATIC,
+        blocking=not enabled and destructive is not None,
+    )
+
+    use_required = enabled and use_time == USE_TIME_CHECK_REQUIRED
+    if destructive is not None:
+        yield _check(
+            id="authority_window.use_time_destructive",
+            category="Authority-window",
+            status=DoctorStatus.PASS if use_required else DoctorStatus.FAIL,
+            summary=(
+                "Time-bounded destructive authority requires use-time expiry"
+                if use_required
+                else "Time-bounded destructive authority does not require use-time expiry"
+            ),
+            details=f"use_time_check={use_time!r}; enabled={enabled}",
+            remediation=""
+            if use_required
+            else "Set authority_window.use_time_check: required with enabled: true.",
+            evidence=EVIDENCE_STATIC,
+            blocking=True,
+        )
+
+    if cfg.profile == PROFILE_PRODUCTION and destructive is not None:
+        fail_closed = use_required
+        yield _check(
+            id="authority_window.production_fail_closed",
+            category="Authority-window",
+            status=DoctorStatus.PASS if fail_closed else DoctorStatus.FAIL,
+            summary=(
+                "Production authority-window fails closed at use"
+                if fail_closed
+                else "Production authority-window does not fail closed at use"
+            ),
+            details=f"enabled={enabled}; use_time_check={use_time!r}",
+            remediation=""
+            if fail_closed
+            else "Require use-time expiry under profile: production.",
+            evidence=EVIDENCE_STATIC,
+        )
+
+    skew_ok = skew >= 0
+    yield _check(
+        id="authority_window.skew",
+        category="Authority-window",
+        status=DoctorStatus.PASS if skew_ok else DoctorStatus.FAIL,
+        summary=(
+            "Clock skew tolerance is non-negative (narrows validity only)"
+            if skew_ok
+            else "Clock skew tolerance is invalid"
+        ),
+        details=(
+            f"clock_skew_tolerance_seconds={skew}; "
+            "skew never extends expired authority"
+        ),
+        remediation="" if skew_ok else "Set clock_skew_tolerance_seconds >= 0.",
+        evidence=EVIDENCE_STATIC,
+        blocking=not skew_ok,
+    )
+
+    topology = (cfg.deployment or {}).get("topology")
+    grant_storage = None
+    if destructive is not None:
+        grant_storage = str(destructive.get("storage", STORAGE_MEMORY))
+    yield _check(
+        id="authority_window.clock_assumptions",
+        category="Authority-window",
+        status=DoctorStatus.PASS,
+        summary="Multi-worker clock assumptions are declared for authority expiry",
+        details=(
+            f"topology={topology!r}; grant_storage={grant_storage!r}; "
+            "durable authority uses persisted UTC expires_at; shared Redis/"
+            "PostgreSQL stores should prefer authoritative storage time when "
+            "available; process-local clocks are not the multi-worker guarantee"
+        ),
+        evidence=EVIDENCE_STATIC,
+        blocking=False,
+    )
+
+    adapters = sorted(registered_authority_use_adapters())
+    yield _check(
+        id="authority_window.adapters",
+        category="Authority-window",
+        status=DoctorStatus.PASS if not adapters else DoctorStatus.PASS,
+        summary=(
+            "Custom authority use adapters are registered in this process"
+            if adapters
+            else "No custom authority use adapters are registered in this process"
+        ),
+        details=f"registered={adapters or 'none'}; importable adapters are not wired",
+        remediation=(
+            "Call register_authority_use_adapter before load when a custom "
+            "authority kind must participate in use-time checks."
+        ),
+        evidence=EVIDENCE_RUNTIME if adapters else EVIDENCE_STATIC,
+        blocking=False,
+    )
+
+    yield _check(
+        id="authority_window.batch_incomplete",
+        category="Authority-window",
+        status=DoctorStatus.PASS
+        if getattr(cfg, "use_time_currency", None) is not None
+        else DoctorStatus.WARN,
+        summary=(
+            "Authority-window and use-time currency batch guarantee is complete"
+            if getattr(cfg, "use_time_currency", None) is not None
+            else (
+                "Authority-window is implemented; combined use-time currency "
+                "batch guarantee is incomplete"
+            )
+        ),
+        details=(
+            "Items 4 (authority-window) and 5 (use-time currency) are both "
+            "configured — the combined production authority-safety batch "
+            "guarantee is wired."
+            if getattr(cfg, "use_time_currency", None) is not None
+            else (
+                "Item 4 (authority-window expiry) alone does not complete item 5 "
+                "(use-time currency). Doctor must not claim the full production "
+                "authority-safety guarantee until use-time currency is present. "
+                "Do not release until item 5 is implemented."
+            )
+        ),
+        evidence=EVIDENCE_STATIC,
+        blocking=False,
+    )
+
+    yield _check(
+        id="authority_window.not_verifiable",
+        category="Authority-window",
+        status=DoctorStatus.SKIP,
+        summary="Doctor cannot prove end-to-end authority validity",
+        details=(
+            "not_verifiable: clock synchronization between machines; "
+            "host-issued approval timestamps; provider-side authorization "
+            "validity; absence of custom code between final validation and "
+            "the side effect. Mycelium cannot guarantee authority remains "
+            "valid throughout an external network call."
+        ),
+        evidence=EVIDENCE_NOT_VERIFIABLE,
+        blocking=False,
+    )
+
+
+@doctor_check("use_time_currency")
+def check_use_time_currency(ctx: DoctorContext) -> Iterable[DoctorCheck]:
+    """Use-time currency for decide-time facts (AF-012 / batch item 5)."""
+    from mycelium.use_time_currency import registered_use_time_validators
+
+    cfg = ctx.config
+    raw = cfg.use_time_currency
+    authority = cfg.authority_window
+    destructive = cfg.destructive_confirm
+    if raw is None:
+        yield _check(
+            id="use_time_currency.scanning",
+            category="Use-time-currency",
+            status=DoctorStatus.SKIP,
+            summary="use_time_currency is not configured (existing behavior)",
+            details=(
+                "Omitted use_time_currency preserves decide-time-only paths. "
+                "Authority-window expiry alone does not revalidate fact currency."
+            ),
+            remediation=(
+                "Add use_time_currency: {enabled: true, missing_policy: error, "
+                "tools: {...}} for consequential tools that depend on "
+                "decide-time facts."
+            ),
+            evidence=EVIDENCE_STATIC,
+            blocking=False,
+        )
+        return
+
+    enabled = bool(raw.get("enabled", True))
+    missing_policy = str(raw.get("missing_policy", "error"))
+    tools = raw.get("tools") or {}
+    validators_declared: set[str] = set()
+    for tool_raw in tools.values():
+        for fact in tool_raw.get("facts") or []:
+            name = fact.get("validator")
+            if isinstance(name, str) and name.strip():
+                validators_declared.add(name.strip())
+
+    yield _check(
+        id="use_time_currency.enabled",
+        category="Use-time-currency",
+        status=DoctorStatus.PASS if enabled else DoctorStatus.WARN,
+        summary=(
+            "Use-time currency checks are enabled"
+            if enabled
+            else "Use-time currency is configured but disabled"
+        ),
+        details=(
+            f"enabled={enabled}; missing_policy={missing_policy!r}; "
+            f"tools={sorted(tools) or 'none'}"
+        ),
+        remediation="" if enabled else "Set use_time_currency.enabled: true.",
+        evidence=EVIDENCE_STATIC,
+        blocking=False,
+    )
+
+    if cfg.profile == PROFILE_PRODUCTION and enabled and tools:
+        fail_closed = missing_policy == "error"
+        yield _check(
+            id="use_time_currency.production_fail_closed",
+            category="Use-time-currency",
+            status=DoctorStatus.PASS if fail_closed else DoctorStatus.FAIL,
+            summary=(
+                "Production use-time currency fails closed on missing facts"
+                if fail_closed
+                else "Production use-time currency does not fail closed"
+            ),
+            details=f"missing_policy={missing_policy!r}",
+            remediation=""
+            if fail_closed
+            else "Set use_time_currency.missing_policy: error under profile: production.",
+            evidence=EVIDENCE_STATIC,
+            blocking=True,
+        )
+
+    registered = registered_use_time_validators()
+    missing = sorted(validators_declared - set(registered))
+    yield _check(
+        id="use_time_currency.validators",
+        category="Use-time-currency",
+        status=DoctorStatus.PASS if not missing else DoctorStatus.WARN,
+        summary=(
+            "Declared use-time validators are registered in this process"
+            if not missing
+            else "Some declared use-time validators are not registered"
+        ),
+        details=(
+            f"declared={sorted(validators_declared) or 'none'}; "
+            f"registered={sorted(registered) or 'none'}; "
+            f"missing={missing or 'none'}"
+        ),
+        remediation=(
+            ""
+            if not missing
+            else "Call register_use_time_validator before load/run for each "
+            "validator name listed in use_time_currency.tools."
+        ),
+        evidence=EVIDENCE_RUNTIME if registered else EVIDENCE_STATIC,
+        blocking=False,
+    )
+
+    batch_ready = (
+        enabled
+        and bool(tools)
+        and (authority is not None or destructive is not None)
+    )
+    yield _check(
+        id="use_time_currency.batch_complete",
+        category="Use-time-currency",
+        status=DoctorStatus.PASS if batch_ready else DoctorStatus.WARN,
+        summary=(
+            "Authority-window and use-time currency batch guarantee is wired"
+            if batch_ready
+            else "Use-time currency batch guarantee is incomplete"
+        ),
+        details=(
+            "Item 5 is configured with tools and item 4 "
+            "(authority_window / destructive_confirm) is also present."
+            if batch_ready
+            else (
+                "Configure use_time_currency.tools and enable authority_window "
+                "(or destructive_confirm) so items 4 and 5 complete the batch."
+            )
+        ),
+        evidence=EVIDENCE_STATIC,
+        blocking=False,
+    )
+
+    yield _check(
+        id="use_time_currency.not_verifiable",
+        category="Use-time-currency",
+        status=DoctorStatus.SKIP,
+        summary="Doctor cannot prove end-to-end fact currency",
+        details=(
+            "not_verifiable: whether host validators query the authoritative "
+            "source; replica consistency or cache behavior; correctness of "
+            "host-provided fact values; provider conditional-write guarantees; "
+            "custom code after final validation; fact changes during a remote "
+            "network call. Local revalidation cannot eliminate the remote-call race."
+        ),
+        evidence=EVIDENCE_NOT_VERIFIABLE,
         blocking=False,
     )
 

--- a/sdk/mycelium/templates/mycelium.minimal.yaml
+++ b/sdk/mycelium/templates/mycelium.minimal.yaml
@@ -7,6 +7,9 @@
 # Optional AF-010: secret_args: {enabled: true, policy: error}
 #   Pass secret:// references instead of credentials.
 # Optional destination policy: entity_guard: {enabled: true, missing_policy: error}
+# Optional AF-011: destructive_confirm: {enabled: true, missing_policy: error}
+# Optional authority_window: {enabled: true, use_time_check: required}
+# Optional AF-012: use_time_currency: {enabled: true, missing_policy: error}
 #
 # side_effect_class required only for tools listed under action_ledger.tools:
 #   read | idempotent_mutate | keyed_mutate | non_idempotent_mutate | irreversible

--- a/sdk/mycelium/templates/mycelium.template.yaml
+++ b/sdk/mycelium/templates/mycelium.template.yaml
@@ -7,7 +7,7 @@
 #   Optional:  integrations, task_ledger, state_flush, audit_receipt, outcome_emit,
 #              loop_guard, completion, state_authority, registry, runner,
 #              history_guard, message_validator, deployment, verify,
-#              secret_args, entity_guard — delete unused sections
+#              secret_args, entity_guard, destructive_confirm — delete unused sections
 #
 # Next steps
 #   1. Allowlist first: rename tools: / tasks: stubs, then copy those exact
@@ -82,6 +82,9 @@
 #   → secret_args.policy: error when secret_args is enabled and
 #     consequential tools exist (warn/redact rejected)
 #   → entity_guard.missing_policy: error when entity_guard is enabled
+#   → destructive_confirm.missing_policy: error when destructive_confirm
+#     is enabled; production grant storage must be durable; multi-node
+#     requires redis/postgres; irreversible tools must be declared
 #   Weaker explicit warn/derived/memory-outcome settings are rejected.
 #   unclassified_policy: warn remains an accepted product choice.
 # Verify with:
@@ -303,6 +306,78 @@ loop_guard:
 #             hosts: [api.stripe.com, hooks.slack.com]
 #           reject_redirects: true
 # Per tool: entity_guard: false
+
+# ---------------------------------------------------------------------------
+# destructive_confirm  (AF-011 — object grant at the tool boundary)
+# Tool permission is not object authorization. A listed destructive tool
+# may execute only with a host-issued grant for this exact operation on
+# this exact canonical object. The model cannot mint grants. Dual control
+# is not implemented — enforce two-person approval in the host workflow
+# before issue_destructive_grant. A grant authorizes an attempt, not the
+# provider's final outcome. For keyed_mutate, reuse the same request_id
+# as the provider idempotency key when the tool declares a mapping.
+# ---------------------------------------------------------------------------
+# destructive_confirm:
+#   enabled: true
+#   missing_policy: error
+#   # storage: memory   # dev/test only; production rejects memory
+#   # path: ./mycelium-destructive-grants.json
+#   tools:
+#     refund_payment:
+#       operation: refund
+#       object:
+#         type: payment
+#         id_from: payment_id
+#       grant:
+#         bind_request_id: true
+#         max_uses: 1
+#         ttl_seconds: 300
+#     delete_file:
+#       operation: delete
+#       object:
+#         type: file
+#         id_from: file_id
+#       grant:
+#         bind_request_id: true
+#         max_uses: 1
+#         ttl_seconds: 120
+# Per tool: destructive_confirm: false
+
+# ---------------------------------------------------------------------------
+# authority_window  (use-time expiry for time-bounded authority)
+# Authorization earlier in the run is not enough. Consequential tools with
+# time-bounded authority re-check immediately before mark_maybe_crossed /
+# provider / body side effect. now >= expires_at hard-blocks. Skew only
+# narrows validity. Does not complete use-time currency (item 5).
+# ---------------------------------------------------------------------------
+# authority_window:
+#   enabled: true
+#   use_time_check: required
+#   clock_skew_tolerance_seconds: 0
+
+# ---------------------------------------------------------------------------
+# use_time_currency  (AF-012 — revalidate decide-time facts at use)
+# Decide-time truth is not execute-time authority. Declared facts are bound
+# at authorize and revalidated immediately before mark_maybe_crossed /
+# provider / body. age >= max_age_seconds is stale. Host validators only —
+# no prompt scanning. Omitted config keeps existing behavior. Production
+# requires missing_policy: error. Pairs with authority_window (item 4).
+# ---------------------------------------------------------------------------
+# use_time_currency:
+#   enabled: true
+#   missing_policy: error
+#   tools:
+#     refund_payment:
+#       facts:
+#         - name: payment.refundable
+#           subject:
+#             type: payment
+#             id_from: payment_id
+#           validator: payment_state
+#           require: {value: true}
+#           revision_from: payment_version
+#           max_age_seconds: 30
+#           bind_request_id: true
 
 # ---------------------------------------------------------------------------
 # budget  (unnumbered — cost / time / step ceilings; refuse next step)

--- a/sdk/mycelium/transition.py
+++ b/sdk/mycelium/transition.py
@@ -542,6 +542,7 @@ class TransitionScope:
     thread_id: str = ""
     run_id: str = ""
     node: str = ""
+    destructive_grants: tuple[object, ...] = ()
 
 
 _execution_scope_var: ContextVar[TransitionScope | None] = ContextVar(

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -448,17 +448,28 @@ class _UseTimeFactsAPI:
         kept = tuple(
             item
             for item in current
-            if not (
-                item.name == fact.name
-                and item.subject_type == fact.subject_type
-                and item.subject_id == fact.subject_id
-            )
+            if _fact_identity(item) != _fact_identity(fact)
         )
         _captured_var.set((*kept, fact))
         return fact
 
 
 use_time_facts = _UseTimeFactsAPI()
+
+
+def _fact_identity(fact: UseTimeFact) -> tuple[str | None, ...]:
+    return (
+        fact.name,
+        fact.subject_type,
+        fact.subject_id,
+        fact.tenant,
+        fact.account,
+        fact.tool,
+        fact.request_id,
+        fact.run_id,
+        fact.thread_id,
+        fact.policy_version,
+    )
 
 
 def _append_decision(decision: UseTimeValidation) -> UseTimeValidation:
@@ -920,7 +931,36 @@ def _evaluate_use_result(
             account=fact.account,
         )
 
-    if fact.revision is not None and result.revision is not None:
+    result_digest = result.digest()
+    if fact.revision is not None and result.revision is None or (
+        (
+            fact.value_digest is not None
+            or fact.require_value_digest is not None
+            or fact.compare_to_arg is not None
+        )
+        and result_digest is None
+    ):
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_UNVERIFIABLE,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            use_revision=result.revision,
+            observed_at=observed,
+            max_age_seconds=fact.max_age_seconds,
+            validator=fact.validator,
+            policy_version=fact.policy_version,
+            provider_precondition=fact.provider_precondition,
+            provider_precondition_present=precond_present,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+        )
+
+    if fact.revision is not None:
         if str(fact.revision) != str(result.revision):
             _raise_currency(
                 tool=fact.tool,
@@ -942,7 +982,6 @@ def _evaluate_use_result(
                 account=fact.account,
             )
 
-    result_digest = result.digest()
     if fact.require_value_digest is not None:
         if result_digest != fact.require_value_digest:
             _raise_currency(
@@ -1086,11 +1125,7 @@ def register_fact_for_use(fact: UseTimeFact) -> UseTimeFact:
     kept = tuple(
         item
         for item in current
-        if not (
-            item.name == fact.name
-            and item.subject_type == fact.subject_type
-            and item.subject_id == fact.subject_id
-        )
+        if _fact_identity(item) != _fact_identity(fact)
     )
     _pending_var.set((*kept, fact))
     return fact
@@ -1189,15 +1224,22 @@ def authorize_use_time_facts(
                 )
             account = str(raw_account)
 
-        match = None
-        for item in captured:
-            if (
-                item.name == spec.name
-                and item.subject_type == spec.subject_type
-                and str(item.subject_id) == str(subject_id)
-            ):
-                match = item
-                break
+        candidates = tuple(
+            item
+            for item in captured
+            if item.name == spec.name
+            and item.subject_type == spec.subject_type
+            and str(item.subject_id) == str(subject_id)
+        )
+        match = next(
+            (
+                item
+                for item in candidates
+                if (not spec.tenant_from or item.tenant == tenant)
+                and (not spec.account_from or item.account == account)
+            ),
+            candidates[0] if candidates else None,
+        )
 
         revision = None
         if spec.revision_from:

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -29,7 +29,7 @@ from mycelium.authority_window import (
     utc_now,
 )
 from mycelium.tool_boundary import ToolBoundaryError
-from mycelium.transition import get_active_execution_scope
+from mycelium.transition import get_active_dispatch_id, get_active_execution_scope
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -523,7 +523,7 @@ def _bound_mapping(
 def _call_ids(kwargs: Mapping[str, Any]) -> tuple[str | None, str | None, str | None]:
     request_id = kwargs.get("request_id")
     if not isinstance(request_id, str) or not request_id.strip():
-        request_id = None
+        request_id = get_active_dispatch_id()
     scope = get_active_execution_scope()
     run_id = kwargs.get("run_id") or (scope.run_id if scope else None)
     thread_id = kwargs.get("thread_id") or (scope.thread_id if scope else None)
@@ -532,6 +532,44 @@ def _call_ids(kwargs: Mapping[str, Any]) -> tuple[str | None, str | None, str | 
     if thread_id is not None:
         thread_id = str(thread_id)
     return request_id, run_id, thread_id
+
+
+def _enforce_context_bindings(
+    spec: UseTimeFactSpec,
+    match: UseTimeFact,
+    *,
+    tool: str,
+    request_id: str | None,
+    run_id: str | None,
+    thread_id: str | None,
+    policy_version: str | None,
+) -> None:
+    for enabled, captured, current in (
+        (spec.bind_request_id, match.request_id, request_id),
+        (spec.bind_run_id, match.run_id, run_id),
+        (spec.bind_thread_id, match.thread_id, thread_id),
+    ):
+        if not enabled:
+            continue
+        reason = (
+            REASON_MISSING
+            if captured is None or current is None
+            else REASON_SUBJECT_MISMATCH
+        )
+        if captured is None or current is None or str(captured) != str(current):
+            _raise_currency(
+                tool=tool,
+                fact_name=match.name,
+                reason=reason,
+                phase=PHASE_AUTHORIZE,
+                subject_ref=match.subject_ref,
+                decide_revision=match.revision,
+                policy_version=policy_version,
+                request_id=request_id,
+                run_id=run_id,
+                tenant=match.tenant,
+                account=match.account,
+            )
 
 
 def use_time_fingerprint(facts: tuple[UseTimeFact, ...] | None = None) -> tuple[str, ...]:
@@ -1310,23 +1348,15 @@ def authorize_use_time_facts(
                     run_id=run_id,
                     tenant=tenant,
                 )
-            if (
-                spec.bind_request_id
-                and request_id
-                and match.request_id
-                and match.request_id != request_id
-            ):
-                _raise_currency(
-                    tool=tool,
-                    fact_name=spec.name,
-                    reason=REASON_SUBJECT_MISMATCH,
-                    phase=PHASE_AUTHORIZE,
-                    subject_ref=match.subject_ref,
-                    decide_revision=match.revision,
-                    policy_version=active.policy_version,
-                    request_id=request_id,
-                    run_id=run_id,
-                )
+            _enforce_context_bindings(
+                spec,
+                match,
+                tool=tool,
+                request_id=request_id,
+                run_id=run_id,
+                thread_id=thread_id,
+                policy_version=active.policy_version,
+            )
             fact = UseTimeFact(
                 name=match.name,
                 subject_type=match.subject_type,
@@ -1342,9 +1372,9 @@ def authorize_use_time_facts(
                     if spec.max_age_seconds is not None
                     else match.max_age_seconds
                 ),
-                request_id=request_id if spec.bind_request_id else match.request_id,
-                run_id=run_id if spec.bind_run_id else match.run_id,
-                thread_id=thread_id if spec.bind_thread_id else match.thread_id,
+                request_id=match.request_id,
+                run_id=match.run_id,
+                thread_id=match.thread_id,
                 policy_version=active.policy_version,
                 validator=spec.validator,
                 provenance=match.provenance or "host_capture",

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -17,7 +17,7 @@ import inspect
 from collections.abc import Awaitable, Callable, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, ParamSpec, TypeVar
 
 from mycelium.authority_window import (
@@ -313,7 +313,7 @@ def use_time_now() -> datetime:
     """Host/infrastructure UTC clock. Never accepts model-provided time."""
     clock = _clock_var.get()
     if clock is not None:
-        return datetime.fromtimestamp(float(clock()), tz=UTC)
+        return datetime.fromtimestamp(float(clock()), tz=timezone.utc)
     # Share authority clock when installed so tests inject once.
     return utc_now()
 

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -464,11 +464,6 @@ def _fact_identity(fact: UseTimeFact) -> tuple[str | None, ...]:
         fact.subject_id,
         fact.tenant,
         fact.account,
-        fact.tool,
-        fact.request_id,
-        fact.run_id,
-        fact.thread_id,
-        fact.policy_version,
     )
 
 

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -878,7 +878,7 @@ async def _invoke_validator_async(
                     result = await asyncio.wait_for(result, timeout=timeout)
                 else:
                     result = await result
-    except TimeoutError:
+    except (TimeoutError, asyncio.TimeoutError):
         _raise_currency(
             tool=fact.tool,
             fact_name=fact.name,

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -1,0 +1,1791 @@
+"""Use-time currency (AF-012): revalidate decide-time facts before side effects.
+
+A fact that was current when the agent decided must not authorize a
+consequential side effect if it is stale, changed, missing, unverifiable,
+or outside its freshness window at execute time.
+
+Pair with authority-window expiry (batch item 4). Neither weakens the other.
+Prompt scanning is not used — only host-controlled facts and validators.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import hashlib
+import inspect
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, ParamSpec, TypeVar
+
+from mycelium.authority_window import (
+    PHASE_AUTHORIZE,
+    PHASE_USE,
+    AuthorityValidationPhase,
+    enforce_pending_authorities_at_use,
+    ensure_aware_utc,
+    utc_now,
+)
+from mycelium.tool_boundary import ToolBoundaryError
+from mycelium.transition import get_active_execution_scope
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+MISSING_POLICY_ERROR = "error"
+MISSING_POLICY_WARN = "warn"
+MISSING_POLICIES = frozenset({MISSING_POLICY_ERROR, MISSING_POLICY_WARN})
+
+DECISION_ALLOWED = "allowed"
+DECISION_DENIED = "denied"
+DECISION_SKIPPED = "skipped"
+
+REASON_VALID = "valid"
+REASON_STALE = "stale"
+REASON_CHANGED = "changed"
+REASON_CONDITION_FALSE = "condition_false"
+REASON_REVISION_MISMATCH = "revision_mismatch"
+REASON_SUBJECT_MISMATCH = "subject_mismatch"
+REASON_TENANT_MISMATCH = "tenant_mismatch"
+REASON_POLICY_CHANGED = "policy_changed"
+REASON_VALIDATOR_MISSING = "validator_missing"
+REASON_VALIDATOR_FAILED = "validator_failed"
+REASON_VALIDATOR_TIMEOUT = "validator_timeout"
+REASON_UNVERIFIABLE = "unverifiable"
+REASON_MISSING = "missing"
+REASON_MALFORMED = "malformed"
+REASON_DISABLED = "disabled"
+REASON_TIMELESS = "timeless"
+
+_USE_BOUNDARY_TOKEN_TTL_SECONDS = 2.0
+_MISSING = object()
+
+ValidatorFn = Callable[..., "ValidatorResult | Awaitable[ValidatorResult]"]
+
+
+class UseTimeCurrencyError(ToolBoundaryError):
+    """A required use-time fact is stale, changed, missing, or unverifiable."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tool: str | None = None,
+        fact_name: str | None = None,
+        reason: str = REASON_UNVERIFIABLE,
+        phase: str = PHASE_USE,
+        subject_ref: str | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            violation="use_time_currency",
+            tool_name=tool or "tool",
+            llm_message=(
+                f"Use-time currency blocked {(tool or 'tool')!r}: {reason}. "
+                "Re-authorize with a fresh host fact. The tool body was not "
+                "executed and the side-effect boundary was not crossed."
+            ),
+            field=phase,
+            expected="current_fact",
+            recovery_hint=(
+                "Capture a fresh host fact via use_time_facts.capture and ensure "
+                "the registered validator returns current truth. Mycelium does "
+                "not refresh stale decide-time facts automatically."
+            ),
+        )
+        self.tool = tool
+        self.fact_name = fact_name
+        self.reason = reason
+        self.phase = phase
+        self.subject_ref = subject_ref
+
+
+@dataclass(frozen=True)
+class UseTimeFact:
+    """Host-controlled decide-time authorization fact. Never model-minted."""
+
+    name: str
+    subject_type: str
+    subject_id: str
+    observed_at: datetime
+    tool: str | None = None
+    tenant: str | None = None
+    account: str | None = None
+    value_digest: str | None = None
+    revision: str | None = None
+    max_age_seconds: float | None = None
+    request_id: str | None = None
+    run_id: str | None = None
+    thread_id: str | None = None
+    policy_version: str | None = None
+    validator: str | None = None
+    provenance: str | None = None
+    provider_precondition: str | None = None
+    require_value_digest: str | None = None
+    compare_to_arg: str | None = None
+
+    def __post_init__(self) -> None:
+        ensure_aware_utc(self.observed_at, field="observed_at")
+        if not self.name or not str(self.name).strip():
+            raise ValueError("use-time fact name must be non-empty")
+        if not self.subject_type or not str(self.subject_type).strip():
+            raise ValueError("use-time fact subject_type must be non-empty")
+        if not self.subject_id or not str(self.subject_id).strip():
+            raise ValueError("use-time fact subject_id must be non-empty")
+        if self.max_age_seconds is not None and self.max_age_seconds < 0:
+            raise ValueError("max_age_seconds must be >= 0")
+
+    @property
+    def subject_ref(self) -> str:
+        return f"{self.subject_type}:{_safe_digest(self.subject_id)}"
+
+
+@dataclass(frozen=True)
+class UseTimeValidation:
+    """Payload-free authorize/use decision for a fact."""
+
+    decision: str
+    reason: str
+    phase: str
+    fact_name: str | None = None
+    tool: str | None = None
+    subject_ref: str | None = None
+    tenant: str | None = None
+    account: str | None = None
+    decide_revision: str | None = None
+    use_revision: str | None = None
+    observed_at: datetime | None = None
+    max_age_seconds: float | None = None
+    validator: str | None = None
+    policy_version: str | None = None
+    provider_precondition: str | None = None
+    provider_precondition_present: bool | None = None
+    request_id: str | None = None
+    run_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision,
+            "reason": self.reason,
+            "phase": self.phase,
+            "fact_name": self.fact_name,
+            "tool": self.tool,
+            "subject_ref": self.subject_ref,
+            "tenant": self.tenant,
+            "account": self.account,
+            "decide_revision": self.decide_revision,
+            "use_revision": self.use_revision,
+            "observed_at": self.observed_at.isoformat() if self.observed_at else None,
+            "max_age_seconds": self.max_age_seconds,
+            "validator": self.validator,
+            "policy_version": self.policy_version,
+            "provider_precondition": self.provider_precondition,
+            "provider_precondition_present": self.provider_precondition_present,
+            "request_id": self.request_id,
+            "run_id": self.run_id,
+        }
+
+
+@dataclass(frozen=True)
+class ValidatorResult:
+    """Host validator output. Must not create the side effect being authorized."""
+
+    current: bool
+    reason: str = REASON_VALID
+    revision: str | None = None
+    observed_at: datetime | None = None
+    value: Any = None
+    value_digest: str | None = None
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def digest(self) -> str | None:
+        if self.value_digest is not None:
+            return self.value_digest
+        if self.value is None:
+            return None
+        return value_digest(self.value)
+
+
+@dataclass(frozen=True)
+class UseTimeFactSpec:
+    """Host-declared fact requirement for a tool."""
+
+    name: str
+    subject_type: str
+    id_from: str
+    validator: str
+    tenant_from: str | None = None
+    account_from: str | None = None
+    require: Mapping[str, Any] | None = None
+    revision_from: str | None = None
+    max_age_seconds: float | None = None
+    bind_request_id: bool = False
+    bind_run_id: bool = False
+    bind_thread_id: bool = False
+    compare_to_arg: str | None = None
+    provider_precondition: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name or not str(self.name).strip():
+            raise ValueError("fact name must be non-empty")
+        if not self.subject_type or not str(self.subject_type).strip():
+            raise ValueError("subject.type must be non-empty")
+        if not self.id_from or not str(self.id_from).strip():
+            raise ValueError("subject.id_from must be non-empty")
+        if not self.validator or not str(self.validator).strip():
+            raise ValueError("validator must be non-empty")
+        if self.max_age_seconds is not None and self.max_age_seconds < 0:
+            raise ValueError("max_age_seconds must be >= 0")
+
+
+@dataclass(frozen=True)
+class UseTimeToolPolicy:
+    facts: tuple[UseTimeFactSpec, ...] = ()
+
+
+@dataclass(frozen=True)
+class UseTimeCurrencyPolicy:
+    """Host-owned use-time currency configuration."""
+
+    enabled: bool = True
+    missing_policy: str = MISSING_POLICY_ERROR
+    policy_version: str = "unspecified"
+    tools: dict[str, UseTimeToolPolicy] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.missing_policy not in MISSING_POLICIES:
+            raise ValueError(
+                "use_time_currency.missing_policy must be one of "
+                f"{sorted(MISSING_POLICIES)}, got {self.missing_policy!r}"
+            )
+
+
+@dataclass(frozen=True)
+class UseBoundaryToken:
+    """Short-lived token so body_start + mark_maybe_crossed share one validation."""
+
+    created_mono: float
+    fingerprint: str
+    attempt: str
+    policy_version: str | None
+    authority_revision: str
+    fact_revision: str
+
+    def still_valid(self, *, now_mono: float | None = None) -> bool:
+        observed = time.monotonic() if now_mono is None else now_mono
+        return (observed - self.created_mono) < _USE_BOUNDARY_TOKEN_TTL_SECONDS
+
+
+_clock_var: ContextVar[Callable[[], float] | None] = ContextVar(
+    "mycelium_use_time_clock", default=None
+)
+_policy_var: ContextVar[UseTimeCurrencyPolicy | None] = ContextVar(
+    "mycelium_use_time_policy", default=None
+)
+_captured_var: ContextVar[tuple[UseTimeFact, ...]] = ContextVar(
+    "mycelium_use_time_captured", default=()
+)
+_pending_var: ContextVar[tuple[UseTimeFact, ...]] = ContextVar(
+    "mycelium_use_time_pending", default=()
+)
+_decision_var: ContextVar[tuple[UseTimeValidation, ...]] = ContextVar(
+    "mycelium_use_time_decisions", default=()
+)
+_token_var: ContextVar[UseBoundaryToken | None] = ContextVar(
+    "mycelium_use_boundary_token", default=None
+)
+_validators: dict[str, ValidatorFn] = {}
+_validator_timeouts: dict[str, float] = {}
+
+
+def value_digest(value: Any) -> str:
+    """Stable digest for comparison — never stores raw sensitive values."""
+    try:
+        text = repr(value)
+    except Exception:
+        text = f"<unrepr:{type(value).__name__}>"
+    return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+
+def _safe_digest(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()[:16]
+
+
+def subject_ref(subject_type: str, subject_id: str) -> str:
+    return f"{subject_type}:{_safe_digest(subject_id)}"
+
+
+def set_use_time_clock(clock: Callable[[], float] | None) -> Token[Callable[[], float] | None]:
+    return _clock_var.set(clock)
+
+
+def reset_use_time_clock(token: Token[Callable[[], float] | None]) -> None:
+    _clock_var.reset(token)
+
+
+def use_time_now() -> datetime:
+    """Host/infrastructure UTC clock. Never accepts model-provided time."""
+    clock = _clock_var.get()
+    if clock is not None:
+        return datetime.fromtimestamp(float(clock()), tz=UTC)
+    # Share authority clock when installed so tests inject once.
+    return utc_now()
+
+
+def get_use_time_currency_policy() -> UseTimeCurrencyPolicy | None:
+    return _policy_var.get()
+
+
+def set_use_time_currency_policy(
+    policy: UseTimeCurrencyPolicy | None,
+) -> Token[UseTimeCurrencyPolicy | None]:
+    return _policy_var.set(policy)
+
+
+def reset_use_time_currency_policy(token: Token[UseTimeCurrencyPolicy | None]) -> None:
+    _policy_var.reset(token)
+
+
+def get_pending_use_time_facts() -> tuple[UseTimeFact, ...]:
+    return _pending_var.get()
+
+
+def get_use_time_decisions() -> tuple[UseTimeValidation, ...]:
+    return _decision_var.get()
+
+
+def get_captured_use_time_facts() -> tuple[UseTimeFact, ...]:
+    return _captured_var.get()
+
+
+def clear_pending_use_time_facts() -> None:
+    _pending_var.set(())
+    _token_var.set(None)
+
+
+def clear_captured_use_time_facts() -> None:
+    _captured_var.set(())
+
+
+def reset_use_time_currency_state() -> None:
+    _clock_var.set(None)
+    _policy_var.set(None)
+    _captured_var.set(())
+    _pending_var.set(())
+    _decision_var.set(())
+    _token_var.set(None)
+    _validators.clear()
+    _validator_timeouts.clear()
+
+
+def register_use_time_validator(
+    name: str,
+    fn: ValidatorFn,
+    *,
+    timeout_seconds: float | None = None,
+) -> None:
+    """Register a host validator. Never selected by the model."""
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("validator name must be a non-empty string")
+    if not callable(fn):
+        raise ValueError("validator must be callable")
+    key = name.strip()
+    _validators[key] = fn
+    if timeout_seconds is not None:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be > 0")
+        _validator_timeouts[key] = float(timeout_seconds)
+    elif key in _validator_timeouts:
+        del _validator_timeouts[key]
+
+
+def registered_use_time_validators() -> frozenset[str]:
+    return frozenset(_validators)
+
+
+class _UseTimeFactsAPI:
+    """Host API for capturing decide-time facts. Rejects model-controlled records."""
+
+    def capture(
+        self,
+        *,
+        name: str,
+        subject_type: str,
+        subject_id: str,
+        value: Any = None,
+        revision: str | None = None,
+        observed_at: datetime | None = None,
+        max_age_seconds: float | None = None,
+        request_id: str | None = None,
+        run_id: str | None = None,
+        thread_id: str | None = None,
+        tenant: str | None = None,
+        account: str | None = None,
+        policy_version: str | None = None,
+        validator: str | None = None,
+        provenance: str | None = None,
+        provider_precondition: str | None = None,
+        tool: str | None = None,
+        require_value: Any = _MISSING,
+        compare_to_arg: str | None = None,
+    ) -> UseTimeFact:
+        if isinstance(subject_id, Mapping):
+            raise UseTimeCurrencyError(
+                "use-time fact subject must be host-controlled, not a mapping",
+                fact_name=name,
+                reason=REASON_MALFORMED,
+                phase=PHASE_AUTHORIZE,
+            )
+        observed = (
+            ensure_aware_utc(observed_at, field="observed_at")
+            if observed_at is not None
+            else use_time_now()
+        )
+        require_digest = None if require_value is _MISSING else value_digest(require_value)
+        fact = UseTimeFact(
+            name=str(name).strip(),
+            subject_type=str(subject_type).strip(),
+            subject_id=str(subject_id).strip(),
+            observed_at=observed,
+            tool=tool,
+            tenant=str(tenant).strip() if tenant is not None else None,
+            account=str(account).strip() if account is not None else None,
+            value_digest=value_digest(value) if value is not None else None,
+            revision=str(revision) if revision is not None else None,
+            max_age_seconds=float(max_age_seconds) if max_age_seconds is not None else None,
+            request_id=request_id,
+            run_id=run_id,
+            thread_id=thread_id,
+            policy_version=policy_version,
+            validator=validator,
+            provenance=provenance or "host_capture",
+            provider_precondition=provider_precondition,
+            require_value_digest=require_digest,
+            compare_to_arg=compare_to_arg,
+        )
+        current = _captured_var.get()
+        kept = tuple(
+            item
+            for item in current
+            if not (
+                item.name == fact.name
+                and item.subject_type == fact.subject_type
+                and item.subject_id == fact.subject_id
+            )
+        )
+        _captured_var.set((*kept, fact))
+        return fact
+
+
+use_time_facts = _UseTimeFactsAPI()
+
+
+def _append_decision(decision: UseTimeValidation) -> UseTimeValidation:
+    current = _decision_var.get()
+    _decision_var.set((*current, decision))
+    return decision
+
+
+def _lookup_path(mapping: Mapping[str, Any], path: str) -> Any:
+    current: Any = mapping
+    for part in path.split("."):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return _MISSING
+    return current
+
+
+def _bound_mapping(
+    func: Callable[..., Any] | None, args: tuple[Any, ...], kwargs: Mapping[str, Any]
+) -> dict[str, Any]:
+    mapping = dict(kwargs)
+    if func is None:
+        return mapping
+    try:
+        signature = inspect.signature(func)
+        bound = signature.bind_partial(*args, **kwargs)
+        bound.apply_defaults()
+        mapping.update(bound.arguments)
+    except (TypeError, ValueError):
+        pass
+    return mapping
+
+
+def _call_ids(kwargs: Mapping[str, Any]) -> tuple[str | None, str | None, str | None]:
+    request_id = kwargs.get("request_id")
+    if not isinstance(request_id, str) or not request_id.strip():
+        request_id = None
+    scope = get_active_execution_scope()
+    run_id = kwargs.get("run_id") or (scope.run_id if scope else None)
+    thread_id = kwargs.get("thread_id") or (scope.thread_id if scope else None)
+    if run_id is not None:
+        run_id = str(run_id)
+    if thread_id is not None:
+        thread_id = str(thread_id)
+    return request_id, run_id, thread_id
+
+
+def use_time_fingerprint(facts: tuple[UseTimeFact, ...] | None = None) -> tuple[str, ...]:
+    """Safe fingerprint bindings — no secrets or raw values."""
+    items = facts if facts is not None else _pending_var.get()
+    if not items:
+        return ()
+    out: list[str] = []
+    for fact in items:
+        out.append(
+            ":".join(
+                [
+                    fact.name,
+                    fact.subject_type,
+                    _safe_digest(fact.subject_id),
+                    fact.validator or "",
+                    fact.revision or "",
+                    fact.policy_version or "",
+                    fact.tenant or "",
+                    fact.account or "",
+                    fact.require_value_digest or "",
+                    fact.compare_to_arg or "",
+                ]
+            )
+        )
+    return tuple(out)
+
+
+def _raise_currency(
+    *,
+    tool: str | None,
+    fact_name: str | None,
+    reason: str,
+    phase: str,
+    subject_ref: str | None = None,
+    decide_revision: str | None = None,
+    use_revision: str | None = None,
+    observed_at: datetime | None = None,
+    max_age_seconds: float | None = None,
+    validator: str | None = None,
+    policy_version: str | None = None,
+    provider_precondition: str | None = None,
+    provider_precondition_present: bool | None = None,
+    request_id: str | None = None,
+    run_id: str | None = None,
+    tenant: str | None = None,
+    account: str | None = None,
+) -> None:
+    decision = UseTimeValidation(
+        decision=DECISION_DENIED,
+        reason=reason,
+        phase=phase,
+        fact_name=fact_name,
+        tool=tool,
+        subject_ref=subject_ref,
+        tenant=tenant,
+        account=account,
+        decide_revision=decide_revision,
+        use_revision=use_revision,
+        observed_at=observed_at,
+        max_age_seconds=max_age_seconds,
+        validator=validator,
+        policy_version=policy_version,
+        provider_precondition=provider_precondition,
+        provider_precondition_present=provider_precondition_present,
+        request_id=request_id,
+        run_id=run_id,
+    )
+    _append_decision(decision)
+    raise UseTimeCurrencyError(
+        f"use-time currency {reason} for tool {(tool or 'tool')!r} "
+        f"fact={(fact_name or 'fact')!r}",
+        tool=tool,
+        fact_name=fact_name,
+        reason=reason,
+        phase=phase,
+        subject_ref=subject_ref,
+    )
+
+
+def _invoke_validator_sync(
+    name: str,
+    *,
+    fact: UseTimeFact,
+    kwargs: Mapping[str, Any],
+    phase: str,
+) -> ValidatorResult:
+    fn = _validators.get(name)
+    if fn is None:
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_VALIDATOR_MISSING,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            validator=name,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            max_age_seconds=fact.max_age_seconds,
+            provider_precondition=fact.provider_precondition,
+        )
+    if inspect.iscoroutinefunction(fn):
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_VALIDATOR_FAILED,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            validator=name,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            max_age_seconds=fact.max_age_seconds,
+            provider_precondition=fact.provider_precondition,
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+    try:
+        result = fn(
+            fact=fact,
+            subject_type=fact.subject_type,
+            subject_id=fact.subject_id,
+            kwargs=dict(kwargs),
+            phase=phase,
+        )
+    except UseTimeCurrencyError:
+        raise
+    except Exception:
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_VALIDATOR_FAILED,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            validator=name,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            max_age_seconds=fact.max_age_seconds,
+            provider_precondition=fact.provider_precondition,
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+    if inspect.isawaitable(result):
+        # Async validator must not silently fall back on the sync path.
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_VALIDATOR_FAILED,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            validator=name,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            max_age_seconds=fact.max_age_seconds,
+            provider_precondition=fact.provider_precondition,
+        )
+    if not isinstance(result, ValidatorResult):
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_MALFORMED,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            validator=name,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            max_age_seconds=fact.max_age_seconds,
+            provider_precondition=fact.provider_precondition,
+        )
+    return result
+
+
+async def _invoke_validator_async(
+    name: str,
+    *,
+    fact: UseTimeFact,
+    kwargs: Mapping[str, Any],
+    phase: str,
+) -> ValidatorResult:
+    fn = _validators.get(name)
+    if fn is None:
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_VALIDATOR_MISSING,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            validator=name,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            max_age_seconds=fact.max_age_seconds,
+            provider_precondition=fact.provider_precondition,
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+    timeout = _validator_timeouts.get(name)
+    try:
+        if inspect.iscoroutinefunction(fn):
+            coro = fn(
+                fact=fact,
+                subject_type=fact.subject_type,
+                subject_id=fact.subject_id,
+                kwargs=dict(kwargs),
+                phase=phase,
+            )
+            if timeout is not None:
+                result = await asyncio.wait_for(coro, timeout=timeout)
+            else:
+                result = await coro
+        else:
+            # Sync validators may run on async path; never the reverse.
+            result = fn(
+                fact=fact,
+                subject_type=fact.subject_type,
+                subject_id=fact.subject_id,
+                kwargs=dict(kwargs),
+                phase=phase,
+            )
+            if inspect.isawaitable(result):
+                if timeout is not None:
+                    result = await asyncio.wait_for(result, timeout=timeout)
+                else:
+                    result = await result
+    except TimeoutError:
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_VALIDATOR_TIMEOUT,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            validator=name,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            max_age_seconds=fact.max_age_seconds,
+            provider_precondition=fact.provider_precondition,
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+    except UseTimeCurrencyError:
+        raise
+    except Exception:
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_VALIDATOR_FAILED,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            validator=name,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            max_age_seconds=fact.max_age_seconds,
+            provider_precondition=fact.provider_precondition,
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+    if not isinstance(result, ValidatorResult):
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_MALFORMED,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            validator=name,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            max_age_seconds=fact.max_age_seconds,
+            provider_precondition=fact.provider_precondition,
+        )
+    return result
+
+
+def _check_age(fact: UseTimeFact, *, now: datetime, phase: str) -> None:
+    if fact.max_age_seconds is None:
+        return
+    observed = ensure_aware_utc(fact.observed_at, field="observed_at")
+    age = (now - observed).total_seconds()
+    # Same spirit as authority: now >= expires_at → invalid; age >= max_age → stale.
+    if age >= float(fact.max_age_seconds):
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_STALE,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            observed_at=observed,
+            max_age_seconds=fact.max_age_seconds,
+            validator=fact.validator,
+            policy_version=fact.policy_version,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+            provider_precondition=fact.provider_precondition,
+        )
+
+
+def _provider_precondition_present(
+    fact: UseTimeFact, kwargs: Mapping[str, Any]
+) -> bool | None:
+    key = fact.provider_precondition
+    if not key:
+        return None
+    return key in kwargs and kwargs.get(key) is not None
+
+
+def _evaluate_use_result(
+    fact: UseTimeFact,
+    result: ValidatorResult,
+    *,
+    kwargs: Mapping[str, Any],
+    phase: str,
+    now: datetime,
+) -> UseTimeValidation:
+    observed = (
+        ensure_aware_utc(result.observed_at, field="observed_at")
+        if result.observed_at is not None
+        else now
+    )
+    # Age uses decide-time observed_at unless the validator supplies a fresher stamp.
+    age_basis = UseTimeFact(
+        name=fact.name,
+        subject_type=fact.subject_type,
+        subject_id=fact.subject_id,
+        observed_at=observed if result.observed_at is not None else fact.observed_at,
+        tool=fact.tool,
+        tenant=fact.tenant,
+        account=fact.account,
+        value_digest=fact.value_digest,
+        revision=fact.revision,
+        max_age_seconds=fact.max_age_seconds,
+        request_id=fact.request_id,
+        run_id=fact.run_id,
+        thread_id=fact.thread_id,
+        policy_version=fact.policy_version,
+        validator=fact.validator,
+        provenance=fact.provenance,
+        provider_precondition=fact.provider_precondition,
+        require_value_digest=fact.require_value_digest,
+        compare_to_arg=fact.compare_to_arg,
+    )
+    _check_age(age_basis, now=now, phase=phase)
+
+    precond_present = _provider_precondition_present(fact, kwargs)
+
+    if not result.current:
+        reason = result.reason if result.reason != REASON_VALID else REASON_CONDITION_FALSE
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=reason if reason in {
+                REASON_STALE,
+                REASON_CHANGED,
+                REASON_CONDITION_FALSE,
+                REASON_REVISION_MISMATCH,
+                REASON_SUBJECT_MISMATCH,
+                REASON_TENANT_MISMATCH,
+                REASON_POLICY_CHANGED,
+                REASON_VALIDATOR_MISSING,
+                REASON_VALIDATOR_FAILED,
+                REASON_VALIDATOR_TIMEOUT,
+                REASON_UNVERIFIABLE,
+                REASON_MISSING,
+                REASON_MALFORMED,
+            } else REASON_CONDITION_FALSE,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            use_revision=result.revision,
+            observed_at=observed,
+            max_age_seconds=fact.max_age_seconds,
+            validator=fact.validator,
+            policy_version=fact.policy_version,
+            provider_precondition=fact.provider_precondition,
+            provider_precondition_present=precond_present,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+        )
+
+    if fact.revision is not None and result.revision is not None:
+        if str(fact.revision) != str(result.revision):
+            _raise_currency(
+                tool=fact.tool,
+                fact_name=fact.name,
+                reason=REASON_REVISION_MISMATCH,
+                phase=phase,
+                subject_ref=fact.subject_ref,
+                decide_revision=fact.revision,
+                use_revision=result.revision,
+                observed_at=observed,
+                max_age_seconds=fact.max_age_seconds,
+                validator=fact.validator,
+                policy_version=fact.policy_version,
+                provider_precondition=fact.provider_precondition,
+                provider_precondition_present=precond_present,
+                request_id=fact.request_id,
+                run_id=fact.run_id,
+                tenant=fact.tenant,
+                account=fact.account,
+            )
+
+    result_digest = result.digest()
+    if fact.require_value_digest is not None:
+        if result_digest != fact.require_value_digest:
+            _raise_currency(
+                tool=fact.tool,
+                fact_name=fact.name,
+                reason=REASON_CONDITION_FALSE,
+                phase=phase,
+                subject_ref=fact.subject_ref,
+                decide_revision=fact.revision,
+                use_revision=result.revision,
+                observed_at=observed,
+                max_age_seconds=fact.max_age_seconds,
+                validator=fact.validator,
+                policy_version=fact.policy_version,
+                provider_precondition=fact.provider_precondition,
+                provider_precondition_present=precond_present,
+                request_id=fact.request_id,
+                run_id=fact.run_id,
+                tenant=fact.tenant,
+                account=fact.account,
+            )
+
+    if fact.compare_to_arg:
+        arg_value = _lookup_path(kwargs, fact.compare_to_arg)
+        if arg_value is _MISSING:
+            _raise_currency(
+                tool=fact.tool,
+                fact_name=fact.name,
+                reason=REASON_MISSING,
+                phase=phase,
+                subject_ref=fact.subject_ref,
+                decide_revision=fact.revision,
+                use_revision=result.revision,
+                observed_at=observed,
+                max_age_seconds=fact.max_age_seconds,
+                validator=fact.validator,
+                policy_version=fact.policy_version,
+                provider_precondition=fact.provider_precondition,
+                provider_precondition_present=precond_present,
+                request_id=fact.request_id,
+                run_id=fact.run_id,
+                tenant=fact.tenant,
+                account=fact.account,
+            )
+        if result_digest is not None and value_digest(arg_value) != result_digest:
+            _raise_currency(
+                tool=fact.tool,
+                fact_name=fact.name,
+                reason=REASON_CHANGED,
+                phase=phase,
+                subject_ref=fact.subject_ref,
+                decide_revision=fact.revision,
+                use_revision=result.revision,
+                observed_at=observed,
+                max_age_seconds=fact.max_age_seconds,
+                validator=fact.validator,
+                policy_version=fact.policy_version,
+                provider_precondition=fact.provider_precondition,
+                provider_precondition_present=precond_present,
+                request_id=fact.request_id,
+                run_id=fact.run_id,
+                tenant=fact.tenant,
+                account=fact.account,
+            )
+        elif fact.value_digest is not None and value_digest(arg_value) != fact.value_digest:
+            _raise_currency(
+                tool=fact.tool,
+                fact_name=fact.name,
+                reason=REASON_CHANGED,
+                phase=phase,
+                subject_ref=fact.subject_ref,
+                decide_revision=fact.revision,
+                use_revision=result.revision,
+                observed_at=observed,
+                max_age_seconds=fact.max_age_seconds,
+                validator=fact.validator,
+                policy_version=fact.policy_version,
+                provider_precondition=fact.provider_precondition,
+                provider_precondition_present=precond_present,
+                request_id=fact.request_id,
+                run_id=fact.run_id,
+                tenant=fact.tenant,
+                account=fact.account,
+            )
+
+    if (
+        fact.value_digest is not None
+        and result_digest is not None
+        and fact.require_value_digest is None
+        and not fact.compare_to_arg
+        and result_digest != fact.value_digest
+    ):
+        _raise_currency(
+            tool=fact.tool,
+            fact_name=fact.name,
+            reason=REASON_CHANGED,
+            phase=phase,
+            subject_ref=fact.subject_ref,
+            decide_revision=fact.revision,
+            use_revision=result.revision,
+            observed_at=observed,
+            max_age_seconds=fact.max_age_seconds,
+            validator=fact.validator,
+            policy_version=fact.policy_version,
+            provider_precondition=fact.provider_precondition,
+            provider_precondition_present=precond_present,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+            tenant=fact.tenant,
+            account=fact.account,
+        )
+
+    return _append_decision(
+        UseTimeValidation(
+            decision=DECISION_ALLOWED,
+            reason=REASON_VALID,
+            phase=phase,
+            fact_name=fact.name,
+            tool=fact.tool,
+            subject_ref=fact.subject_ref,
+            tenant=fact.tenant,
+            account=fact.account,
+            decide_revision=fact.revision,
+            use_revision=result.revision,
+            observed_at=observed,
+            max_age_seconds=fact.max_age_seconds,
+            validator=fact.validator,
+            policy_version=fact.policy_version,
+            provider_precondition=fact.provider_precondition,
+            provider_precondition_present=precond_present,
+            request_id=fact.request_id,
+            run_id=fact.run_id,
+        )
+    )
+
+
+def register_fact_for_use(fact: UseTimeFact) -> UseTimeFact:
+    """Bind a host fact so the use-phase check can find it later."""
+    ensure_aware_utc(fact.observed_at, field="observed_at")
+    current = _pending_var.get()
+    kept = tuple(
+        item
+        for item in current
+        if not (
+            item.name == fact.name
+            and item.subject_type == fact.subject_type
+            and item.subject_id == fact.subject_id
+        )
+    )
+    _pending_var.set((*kept, fact))
+    _token_var.set(None)
+    return fact
+
+
+def authorize_use_time_facts(
+    tool: str,
+    args: tuple[Any, ...],
+    kwargs: Mapping[str, Any],
+    *,
+    policy: UseTimeCurrencyPolicy | None = None,
+    func: Callable[..., Any] | None = None,
+) -> tuple[UseTimeFact, ...]:
+    """AUTHORIZE: bind decide-time facts for later USE. Does not call async validators."""
+    active = policy if policy is not None else _policy_var.get()
+    if active is None or not active.enabled:
+        decision = UseTimeValidation(
+            decision=DECISION_SKIPPED,
+            reason=REASON_DISABLED if active is not None else REASON_TIMELESS,
+            phase=PHASE_AUTHORIZE,
+            tool=tool,
+            observed_at=use_time_now(),
+        )
+        _append_decision(decision)
+        return ()
+
+    tool_policy = active.tools.get(tool)
+    if tool_policy is None or not tool_policy.facts:
+        decision = UseTimeValidation(
+            decision=DECISION_SKIPPED,
+            reason=REASON_TIMELESS,
+            phase=PHASE_AUTHORIZE,
+            tool=tool,
+            observed_at=use_time_now(),
+        )
+        _append_decision(decision)
+        return ()
+
+    mapping = _bound_mapping(func, args, kwargs)
+    request_id, run_id, thread_id = _call_ids(kwargs)
+    captured = _captured_var.get()
+    bound: list[UseTimeFact] = []
+
+    for spec in tool_policy.facts:
+        subject_id = _lookup_path(mapping, spec.id_from)
+        if subject_id is _MISSING or subject_id is None or subject_id == "":
+            if active.missing_policy == MISSING_POLICY_WARN:
+                _append_decision(
+                    UseTimeValidation(
+                        decision=DECISION_SKIPPED,
+                        reason=REASON_MISSING,
+                        phase=PHASE_AUTHORIZE,
+                        fact_name=spec.name,
+                        tool=tool,
+                        observed_at=use_time_now(),
+                    )
+                )
+                continue
+            _raise_currency(
+                tool=tool,
+                fact_name=spec.name,
+                reason=REASON_MISSING,
+                phase=PHASE_AUTHORIZE,
+                policy_version=active.policy_version,
+                request_id=request_id,
+                run_id=run_id,
+            )
+
+        tenant = None
+        if spec.tenant_from:
+            raw_tenant = _lookup_path(mapping, spec.tenant_from)
+            if raw_tenant is not _MISSING and raw_tenant is not None:
+                tenant = str(raw_tenant)
+        account = None
+        if spec.account_from:
+            raw_account = _lookup_path(mapping, spec.account_from)
+            if raw_account is not _MISSING and raw_account is not None:
+                account = str(raw_account)
+
+        match = None
+        for item in captured:
+            if (
+                item.name == spec.name
+                and item.subject_type == spec.subject_type
+                and str(item.subject_id) == str(subject_id)
+            ):
+                match = item
+                break
+
+        revision = None
+        if spec.revision_from:
+            raw_rev = _lookup_path(mapping, spec.revision_from)
+            if raw_rev is not _MISSING and raw_rev is not None:
+                revision = str(raw_rev)
+
+        require_digest = None
+        if spec.require is not None and "value" in spec.require:
+            require_digest = value_digest(spec.require["value"])
+
+        if match is not None:
+            if match.tenant is not None and tenant is not None and match.tenant != tenant:
+                _raise_currency(
+                    tool=tool,
+                    fact_name=spec.name,
+                    reason=REASON_TENANT_MISMATCH,
+                    phase=PHASE_AUTHORIZE,
+                    subject_ref=match.subject_ref,
+                    decide_revision=match.revision,
+                    policy_version=active.policy_version,
+                    request_id=request_id,
+                    run_id=run_id,
+                    tenant=tenant,
+                )
+            if (
+                match.policy_version is not None
+                and active.policy_version not in (None, "unspecified")
+                and match.policy_version not in (None, "unspecified")
+                and match.policy_version != active.policy_version
+            ):
+                _raise_currency(
+                    tool=tool,
+                    fact_name=spec.name,
+                    reason=REASON_POLICY_CHANGED,
+                    phase=PHASE_AUTHORIZE,
+                    subject_ref=match.subject_ref,
+                    decide_revision=match.revision,
+                    policy_version=match.policy_version,
+                    request_id=request_id,
+                    run_id=run_id,
+                    tenant=tenant,
+                )
+            if (
+                spec.bind_request_id
+                and request_id
+                and match.request_id
+                and match.request_id != request_id
+            ):
+                _raise_currency(
+                    tool=tool,
+                    fact_name=spec.name,
+                    reason=REASON_SUBJECT_MISMATCH,
+                    phase=PHASE_AUTHORIZE,
+                    subject_ref=match.subject_ref,
+                    decide_revision=match.revision,
+                    policy_version=active.policy_version,
+                    request_id=request_id,
+                    run_id=run_id,
+                )
+            fact = UseTimeFact(
+                name=match.name,
+                subject_type=match.subject_type,
+                subject_id=str(subject_id),
+                observed_at=match.observed_at,
+                tool=tool,
+                tenant=tenant or match.tenant,
+                account=account or match.account,
+                value_digest=match.value_digest,
+                revision=revision or match.revision,
+                max_age_seconds=(
+                    spec.max_age_seconds
+                    if spec.max_age_seconds is not None
+                    else match.max_age_seconds
+                ),
+                request_id=request_id if spec.bind_request_id else match.request_id,
+                run_id=run_id if spec.bind_run_id else match.run_id,
+                thread_id=thread_id if spec.bind_thread_id else match.thread_id,
+                policy_version=active.policy_version,
+                validator=spec.validator,
+                provenance=match.provenance or "host_capture",
+                provider_precondition=spec.provider_precondition or match.provider_precondition,
+                require_value_digest=require_digest or match.require_value_digest,
+                compare_to_arg=spec.compare_to_arg or match.compare_to_arg,
+            )
+        else:
+            # Bind from kwargs / require without calling validators at authorize.
+            # Host should capture via use_time_facts.capture when decide-time
+            # value must come from an authoritative source.
+            if (
+                active.missing_policy == MISSING_POLICY_WARN
+                and require_digest is None
+                and revision is None
+            ):
+                _append_decision(
+                    UseTimeValidation(
+                        decision=DECISION_SKIPPED,
+                        reason=REASON_MISSING,
+                        phase=PHASE_AUTHORIZE,
+                        fact_name=spec.name,
+                        tool=tool,
+                        observed_at=use_time_now(),
+                    )
+                )
+                continue
+            if require_digest is None and revision is None and spec.compare_to_arg is None:
+                # Still bind a skeleton so USE can revalidate; missing capture
+                # with error policy fails closed only when no comparison basis.
+                pass
+            compare_value = None
+            if spec.compare_to_arg:
+                compare_value = _lookup_path(mapping, spec.compare_to_arg)
+                if compare_value is _MISSING:
+                    if active.missing_policy == MISSING_POLICY_WARN:
+                        continue
+                    _raise_currency(
+                        tool=tool,
+                        fact_name=spec.name,
+                        reason=REASON_MISSING,
+                        phase=PHASE_AUTHORIZE,
+                        policy_version=active.policy_version,
+                        request_id=request_id,
+                        run_id=run_id,
+                    )
+            fact = UseTimeFact(
+                name=spec.name,
+                subject_type=spec.subject_type,
+                subject_id=str(subject_id),
+                observed_at=use_time_now(),
+                tool=tool,
+                tenant=tenant,
+                account=account,
+                value_digest=(
+                    value_digest(compare_value) if compare_value is not None else None
+                ),
+                revision=revision,
+                max_age_seconds=spec.max_age_seconds,
+                request_id=request_id if spec.bind_request_id else None,
+                run_id=run_id if spec.bind_run_id else None,
+                thread_id=thread_id if spec.bind_thread_id else None,
+                policy_version=active.policy_version,
+                validator=spec.validator,
+                provenance="kwargs_bind",
+                provider_precondition=spec.provider_precondition,
+                require_value_digest=require_digest,
+                compare_to_arg=spec.compare_to_arg,
+            )
+
+        _check_age(fact, now=use_time_now(), phase=PHASE_AUTHORIZE)
+        register_fact_for_use(fact)
+        bound.append(fact)
+        _append_decision(
+            UseTimeValidation(
+                decision=DECISION_ALLOWED,
+                reason=REASON_VALID,
+                phase=PHASE_AUTHORIZE,
+                fact_name=fact.name,
+                tool=tool,
+                subject_ref=fact.subject_ref,
+                tenant=fact.tenant,
+                account=fact.account,
+                decide_revision=fact.revision,
+                observed_at=fact.observed_at,
+                max_age_seconds=fact.max_age_seconds,
+                validator=fact.validator,
+                policy_version=fact.policy_version,
+                provider_precondition=fact.provider_precondition,
+                provider_precondition_present=_provider_precondition_present(fact, mapping),
+                request_id=fact.request_id,
+                run_id=fact.run_id,
+            )
+        )
+
+    return tuple(bound)
+
+
+def enforce_pending_use_time_facts_at_use(
+    *,
+    now: datetime | None = None,
+    kwargs: Mapping[str, Any] | None = None,
+) -> UseTimeValidation:
+    """USE: revalidate every registered fact immediately before the side effect."""
+    pending = _pending_var.get()
+    observed = use_time_now() if now is None else ensure_aware_utc(now, field="now")
+    if not pending:
+        decision = UseTimeValidation(
+            decision=DECISION_SKIPPED,
+            reason=REASON_TIMELESS,
+            phase=PHASE_USE,
+            observed_at=observed,
+        )
+        return _append_decision(decision)
+
+    policy = _policy_var.get()
+    if policy is not None and not policy.enabled:
+        decision = UseTimeValidation(
+            decision=DECISION_SKIPPED,
+            reason=REASON_DISABLED,
+            phase=PHASE_USE,
+            observed_at=observed,
+        )
+        return _append_decision(decision)
+
+    call_kwargs = dict(kwargs or {})
+    last: UseTimeValidation | None = None
+    for fact in pending:
+        if not fact.validator:
+            _raise_currency(
+                tool=fact.tool,
+                fact_name=fact.name,
+                reason=REASON_VALIDATOR_MISSING,
+                phase=PHASE_USE,
+                subject_ref=fact.subject_ref,
+                decide_revision=fact.revision,
+                policy_version=fact.policy_version,
+                request_id=fact.request_id,
+                run_id=fact.run_id,
+                tenant=fact.tenant,
+                account=fact.account,
+                max_age_seconds=fact.max_age_seconds,
+            )
+        result = _invoke_validator_sync(
+            fact.validator,
+            fact=fact,
+            kwargs=call_kwargs,
+            phase=PHASE_USE,
+        )
+        last = _evaluate_use_result(
+            fact, result, kwargs=call_kwargs, phase=PHASE_USE, now=observed
+        )
+    assert last is not None
+    return last
+
+
+async def enforce_pending_use_time_facts_at_use_async(
+    *,
+    now: datetime | None = None,
+    kwargs: Mapping[str, Any] | None = None,
+) -> UseTimeValidation:
+    pending = _pending_var.get()
+    observed = use_time_now() if now is None else ensure_aware_utc(now, field="now")
+    if not pending:
+        decision = UseTimeValidation(
+            decision=DECISION_SKIPPED,
+            reason=REASON_TIMELESS,
+            phase=PHASE_USE,
+            observed_at=observed,
+        )
+        return _append_decision(decision)
+
+    policy = _policy_var.get()
+    if policy is not None and not policy.enabled:
+        decision = UseTimeValidation(
+            decision=DECISION_SKIPPED,
+            reason=REASON_DISABLED,
+            phase=PHASE_USE,
+            observed_at=observed,
+        )
+        return _append_decision(decision)
+
+    call_kwargs = dict(kwargs or {})
+    last: UseTimeValidation | None = None
+    for fact in pending:
+        if not fact.validator:
+            _raise_currency(
+                tool=fact.tool,
+                fact_name=fact.name,
+                reason=REASON_VALIDATOR_MISSING,
+                phase=PHASE_USE,
+                subject_ref=fact.subject_ref,
+                decide_revision=fact.revision,
+                policy_version=fact.policy_version,
+                request_id=fact.request_id,
+                run_id=fact.run_id,
+                tenant=fact.tenant,
+                account=fact.account,
+                max_age_seconds=fact.max_age_seconds,
+            )
+        result = await _invoke_validator_async(
+            fact.validator,
+            fact=fact,
+            kwargs=call_kwargs,
+            phase=PHASE_USE,
+        )
+        last = _evaluate_use_result(
+            fact, result, kwargs=call_kwargs, phase=PHASE_USE, now=observed
+        )
+    assert last is not None
+    return last
+
+
+def _issue_use_boundary_token() -> UseBoundaryToken:
+    from mycelium.authority_window import get_pending_authorities
+
+    pending_facts = _pending_var.get()
+    pending_auth = get_pending_authorities()
+    fact_rev = "|".join(
+        f"{item.name}:{item.revision or ''}:{item.value_digest or ''}"
+        for item in pending_facts
+    )
+    auth_rev = "|".join(
+        f"{item.authority_ref}:{item.expires_at.isoformat()}" for item in pending_auth
+    )
+    fp = "|".join(use_time_fingerprint(pending_facts))
+    policy = _policy_var.get()
+    token = UseBoundaryToken(
+        created_mono=time.monotonic(),
+        fingerprint=fp,
+        attempt=str(id(pending_facts)),
+        policy_version=policy.policy_version if policy else None,
+        authority_revision=auth_rev,
+        fact_revision=fact_rev,
+    )
+    _token_var.set(token)
+    return token
+
+
+def _token_matches_current(token: UseBoundaryToken) -> bool:
+    if not token.still_valid():
+        return False
+    from mycelium.authority_window import get_pending_authorities
+
+    pending_facts = _pending_var.get()
+    pending_auth = get_pending_authorities()
+    fact_rev = "|".join(
+        f"{item.name}:{item.revision or ''}:{item.value_digest or ''}"
+        for item in pending_facts
+    )
+    auth_rev = "|".join(
+        f"{item.authority_ref}:{item.expires_at.isoformat()}" for item in pending_auth
+    )
+    fp = "|".join(use_time_fingerprint(pending_facts))
+    policy = _policy_var.get()
+    return (
+        token.fingerprint == fp
+        and token.fact_revision == fact_rev
+        and token.authority_revision == auth_rev
+        and token.policy_version == (policy.policy_version if policy else None)
+        and token.attempt == str(id(pending_facts))
+    )
+
+
+def enforce_use_boundary(
+    *,
+    skip_if_token_valid: bool = False,
+    kwargs: Mapping[str, Any] | None = None,
+) -> tuple[Any, UseTimeValidation]:
+    """Ordered use-boundary pipeline: authority expiry, then use-time currency."""
+    existing = _token_var.get()
+    if skip_if_token_valid and existing is not None and _token_matches_current(existing):
+        skipped = UseTimeValidation(
+            decision=DECISION_SKIPPED,
+            reason="token_valid",
+            phase=PHASE_USE,
+            observed_at=use_time_now(),
+        )
+        return existing, _append_decision(skipped)
+
+    auth = enforce_pending_authorities_at_use()
+    currency = enforce_pending_use_time_facts_at_use(kwargs=kwargs)
+    _issue_use_boundary_token()
+    return auth, currency
+
+
+async def enforce_use_boundary_async(
+    *,
+    skip_if_token_valid: bool = False,
+    kwargs: Mapping[str, Any] | None = None,
+) -> tuple[Any, UseTimeValidation]:
+    existing = _token_var.get()
+    if skip_if_token_valid and existing is not None and _token_matches_current(existing):
+        skipped = UseTimeValidation(
+            decision=DECISION_SKIPPED,
+            reason="token_valid",
+            phase=PHASE_USE,
+            observed_at=use_time_now(),
+        )
+        return existing, _append_decision(skipped)
+
+    auth = enforce_pending_authorities_at_use()
+    currency = await enforce_pending_use_time_facts_at_use_async(kwargs=kwargs)
+    _issue_use_boundary_token()
+    return auth, currency
+
+
+def use_time_currency_policy_for_tool(
+    policy: UseTimeCurrencyPolicy, tool: str
+) -> UseTimeCurrencyPolicy:
+    tool_policy = policy.tools.get(tool)
+    if tool_policy is None:
+        return UseTimeCurrencyPolicy(
+            enabled=policy.enabled,
+            missing_policy=policy.missing_policy,
+            policy_version=policy.policy_version,
+            tools={},
+        )
+    return UseTimeCurrencyPolicy(
+        enabled=policy.enabled,
+        missing_policy=policy.missing_policy,
+        policy_version=policy.policy_version,
+        tools={tool: tool_policy},
+    )
+
+
+def apply_use_time_currency(
+    func: Callable[P, R],
+    policy: UseTimeCurrencyPolicy,
+    *,
+    tool_name: str | None = None,
+    outcome_emitter: Any | None = None,
+) -> Callable[P, R]:
+    """Wrap *func* so facts are authorized before claim and used before body."""
+    name = tool_name or getattr(func, "__name__", "tool")
+
+    def _emit(decision: UseTimeValidation) -> None:
+        if outcome_emitter is None:
+            return
+        try:
+            outcome_emitter.emit_event(
+                tool=decision.tool or name,
+                request_id=decision.request_id or "",
+                event="use_time_currency",
+                gate=decision.decision,
+                resolution_reason=decision.reason,
+                run_id=decision.run_id,
+                policy_version=decision.policy_version,
+                tool_body_executed=False,
+            )
+        except Exception:
+            return
+
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            token = set_use_time_currency_policy(policy)
+            try:
+                bound = authorize_use_time_facts(
+                    name, args, kwargs, policy=policy, func=func
+                )
+                for fact in bound:
+                    _emit(
+                        UseTimeValidation(
+                            decision=DECISION_ALLOWED,
+                            reason=REASON_VALID,
+                            phase=PHASE_AUTHORIZE,
+                            fact_name=fact.name,
+                            tool=name,
+                            subject_ref=fact.subject_ref,
+                            policy_version=fact.policy_version,
+                            request_id=fact.request_id,
+                            run_id=fact.run_id,
+                        )
+                    )
+                if not getattr(func, "_mycelium_ledger", False):
+                    _, use_decision = await enforce_use_boundary_async(kwargs=kwargs)
+                    if use_decision.decision != DECISION_SKIPPED:
+                        _emit(use_decision)
+                return await func(*args, **kwargs)
+            except UseTimeCurrencyError as exc:
+                current = get_use_time_decisions()
+                if current:
+                    _emit(current[-1])
+                else:
+                    _emit(
+                        UseTimeValidation(
+                            decision=DECISION_DENIED,
+                            reason=exc.reason,
+                            phase=exc.phase,
+                            fact_name=exc.fact_name,
+                            tool=name,
+                            subject_ref=exc.subject_ref,
+                            policy_version=policy.policy_version,
+                        )
+                    )
+                raise
+            finally:
+                clear_pending_use_time_facts()
+                reset_use_time_currency_policy(token)
+
+        async_wrapper._mycelium_use_time_currency = True  # type: ignore[attr-defined]
+        return async_wrapper  # type: ignore[return-value]
+
+    @functools.wraps(func)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        token = set_use_time_currency_policy(policy)
+        try:
+            bound = authorize_use_time_facts(
+                name, args, kwargs, policy=policy, func=func
+            )
+            for fact in bound:
+                _emit(
+                    UseTimeValidation(
+                        decision=DECISION_ALLOWED,
+                        reason=REASON_VALID,
+                        phase=PHASE_AUTHORIZE,
+                        fact_name=fact.name,
+                        tool=name,
+                        subject_ref=fact.subject_ref,
+                        policy_version=fact.policy_version,
+                        request_id=fact.request_id,
+                        run_id=fact.run_id,
+                    )
+                )
+            if not getattr(func, "_mycelium_ledger", False):
+                _, use_decision = enforce_use_boundary(kwargs=kwargs)
+                if use_decision.decision != DECISION_SKIPPED:
+                    _emit(use_decision)
+            return func(*args, **kwargs)
+        except UseTimeCurrencyError as exc:
+            current = get_use_time_decisions()
+            if current:
+                _emit(current[-1])
+            else:
+                _emit(
+                    UseTimeValidation(
+                        decision=DECISION_DENIED,
+                        reason=exc.reason,
+                        phase=exc.phase,
+                        fact_name=exc.fact_name,
+                        tool=name,
+                        subject_ref=exc.subject_ref,
+                        policy_version=policy.policy_version,
+                    )
+                )
+            raise
+        finally:
+            clear_pending_use_time_facts()
+            reset_use_time_currency_policy(token)
+
+    sync_wrapper._mycelium_use_time_currency = True  # type: ignore[attr-defined]
+    return sync_wrapper  # type: ignore[return-value]
+
+
+__all__ = [
+    "DECISION_ALLOWED",
+    "DECISION_DENIED",
+    "DECISION_SKIPPED",
+    "MISSING_POLICIES",
+    "MISSING_POLICY_ERROR",
+    "MISSING_POLICY_WARN",
+    "REASON_CHANGED",
+    "REASON_CONDITION_FALSE",
+    "REASON_MALFORMED",
+    "REASON_MISSING",
+    "REASON_POLICY_CHANGED",
+    "REASON_REVISION_MISMATCH",
+    "REASON_STALE",
+    "REASON_SUBJECT_MISMATCH",
+    "REASON_TENANT_MISMATCH",
+    "REASON_UNVERIFIABLE",
+    "REASON_VALID",
+    "REASON_VALIDATOR_FAILED",
+    "REASON_VALIDATOR_MISSING",
+    "REASON_VALIDATOR_TIMEOUT",
+    "AuthorityValidationPhase",
+    "UseBoundaryToken",
+    "UseTimeCurrencyError",
+    "UseTimeCurrencyPolicy",
+    "UseTimeFact",
+    "UseTimeFactSpec",
+    "UseTimeToolPolicy",
+    "UseTimeValidation",
+    "ValidatorResult",
+    "apply_use_time_currency",
+    "authorize_use_time_facts",
+    "clear_captured_use_time_facts",
+    "clear_pending_use_time_facts",
+    "enforce_pending_use_time_facts_at_use",
+    "enforce_pending_use_time_facts_at_use_async",
+    "enforce_use_boundary",
+    "enforce_use_boundary_async",
+    "get_captured_use_time_facts",
+    "get_pending_use_time_facts",
+    "get_use_time_currency_policy",
+    "get_use_time_decisions",
+    "register_fact_for_use",
+    "register_use_time_validator",
+    "registered_use_time_validators",
+    "reset_use_time_clock",
+    "reset_use_time_currency_policy",
+    "reset_use_time_currency_state",
+    "set_use_time_clock",
+    "set_use_time_currency_policy",
+    "subject_ref",
+    "use_time_currency_policy_for_tool",
+    "use_time_facts",
+    "use_time_fingerprint",
+    "use_time_now",
+    "value_digest",
+]

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -467,6 +467,24 @@ def _fact_identity(fact: UseTimeFact) -> tuple[str | None, ...]:
     )
 
 
+def _pending_fact_identity(fact: UseTimeFact) -> tuple[Any, ...]:
+    return (
+        *_fact_identity(fact),
+        fact.tool,
+        fact.validator,
+        fact.value_digest,
+        fact.require_value_digest,
+        fact.compare_to_arg,
+        fact.revision,
+        fact.max_age_seconds,
+        fact.provider_precondition,
+        fact.policy_version,
+        fact.request_id,
+        fact.run_id,
+        fact.thread_id,
+    )
+
+
 def _append_decision(decision: UseTimeValidation) -> UseTimeValidation:
     current = _decision_var.get()
     _decision_var.set((*current, decision))
@@ -1120,7 +1138,7 @@ def register_fact_for_use(fact: UseTimeFact) -> UseTimeFact:
     kept = tuple(
         item
         for item in current
-        if _fact_identity(item) != _fact_identity(fact)
+        if _pending_fact_identity(item) != _pending_fact_identity(fact)
     )
     _pending_var.set((*kept, fact))
     return fact

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -125,6 +125,9 @@ class UseTimeFact:
     provider_precondition: str | None = None
     require_value_digest: str | None = None
     compare_to_arg: str | None = None
+    bind_request_id: bool = False
+    bind_run_id: bool = False
+    bind_thread_id: bool = False
 
     def __post_init__(self) -> None:
         ensure_aware_utc(self.observed_at, field="observed_at")
@@ -482,6 +485,9 @@ def _pending_fact_identity(fact: UseTimeFact) -> tuple[Any, ...]:
         fact.request_id,
         fact.run_id,
         fact.thread_id,
+        fact.bind_request_id,
+        fact.bind_run_id,
+        fact.bind_thread_id,
     )
 
 
@@ -569,6 +575,38 @@ def _enforce_context_bindings(
                 run_id=run_id,
                 tenant=match.tenant,
                 account=match.account,
+            )
+
+
+def _enforce_context_bindings_at_use(
+    fact: UseTimeFact, kwargs: Mapping[str, Any]
+) -> None:
+    request_id, run_id, thread_id = _call_ids(kwargs)
+    for enabled, captured, current in (
+        (fact.bind_request_id, fact.request_id, request_id),
+        (fact.bind_run_id, fact.run_id, run_id),
+        (fact.bind_thread_id, fact.thread_id, thread_id),
+    ):
+        if not enabled:
+            continue
+        reason = (
+            REASON_MISSING
+            if captured is None or current is None
+            else REASON_SUBJECT_MISMATCH
+        )
+        if captured is None or current is None or str(captured) != str(current):
+            _raise_currency(
+                tool=fact.tool,
+                fact_name=fact.name,
+                reason=reason,
+                phase=PHASE_USE,
+                subject_ref=fact.subject_ref,
+                decide_revision=fact.revision,
+                policy_version=fact.policy_version,
+                request_id=request_id,
+                run_id=run_id,
+                tenant=fact.tenant,
+                account=fact.account,
             )
 
 
@@ -940,6 +978,9 @@ def _evaluate_use_result(
         provider_precondition=fact.provider_precondition,
         require_value_digest=fact.require_value_digest,
         compare_to_arg=fact.compare_to_arg,
+        bind_request_id=fact.bind_request_id,
+        bind_run_id=fact.bind_run_id,
+        bind_thread_id=fact.bind_thread_id,
     )
     _check_age(age_basis, now=now, phase=phase)
 
@@ -1381,6 +1422,9 @@ def authorize_use_time_facts(
                 provider_precondition=spec.provider_precondition or match.provider_precondition,
                 require_value_digest=require_digest or match.require_value_digest,
                 compare_to_arg=spec.compare_to_arg or match.compare_to_arg,
+                bind_request_id=spec.bind_request_id,
+                bind_run_id=spec.bind_run_id,
+                bind_thread_id=spec.bind_thread_id,
             )
         else:
             # Bind from kwargs / require without calling validators at authorize.
@@ -1443,6 +1487,9 @@ def authorize_use_time_facts(
                 provider_precondition=spec.provider_precondition,
                 require_value_digest=require_digest,
                 compare_to_arg=spec.compare_to_arg,
+                bind_request_id=spec.bind_request_id,
+                bind_run_id=spec.bind_run_id,
+                bind_thread_id=spec.bind_thread_id,
             )
 
         _check_age(fact, now=use_time_now(), phase=PHASE_AUTHORIZE)
@@ -1503,6 +1550,7 @@ def enforce_pending_use_time_facts_at_use(
     call_kwargs = dict(kwargs or {})
     last: UseTimeValidation | None = None
     for fact in pending:
+        _enforce_context_bindings_at_use(fact, call_kwargs)
         if not fact.validator:
             _raise_currency(
                 tool=fact.tool,
@@ -1560,6 +1608,7 @@ async def enforce_pending_use_time_facts_at_use_async(
     call_kwargs = dict(kwargs or {})
     last: UseTimeValidation | None = None
     for fact in pending:
+        _enforce_context_bindings_at_use(fact, call_kwargs)
         if not fact.validator:
             _raise_currency(
                 tool=fact.tool,

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -14,7 +14,6 @@ import asyncio
 import functools
 import hashlib
 import inspect
-import time
 from collections.abc import Awaitable, Callable, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
@@ -50,6 +49,7 @@ REASON_CONDITION_FALSE = "condition_false"
 REASON_REVISION_MISMATCH = "revision_mismatch"
 REASON_SUBJECT_MISMATCH = "subject_mismatch"
 REASON_TENANT_MISMATCH = "tenant_mismatch"
+REASON_ACCOUNT_MISMATCH = "account_mismatch"
 REASON_POLICY_CHANGED = "policy_changed"
 REASON_VALIDATOR_MISSING = "validator_missing"
 REASON_VALIDATOR_FAILED = "validator_failed"
@@ -60,7 +60,6 @@ REASON_MALFORMED = "malformed"
 REASON_DISABLED = "disabled"
 REASON_TIMELESS = "timeless"
 
-_USE_BOUNDARY_TOKEN_TTL_SECONDS = 2.0
 _MISSING = object()
 
 ValidatorFn = Callable[..., "ValidatorResult | Awaitable[ValidatorResult]"]
@@ -263,22 +262,6 @@ class UseTimeCurrencyPolicy:
             )
 
 
-@dataclass(frozen=True)
-class UseBoundaryToken:
-    """Short-lived token so body_start + mark_maybe_crossed share one validation."""
-
-    created_mono: float
-    fingerprint: str
-    attempt: str
-    policy_version: str | None
-    authority_revision: str
-    fact_revision: str
-
-    def still_valid(self, *, now_mono: float | None = None) -> bool:
-        observed = time.monotonic() if now_mono is None else now_mono
-        return (observed - self.created_mono) < _USE_BOUNDARY_TOKEN_TTL_SECONDS
-
-
 _clock_var: ContextVar[Callable[[], float] | None] = ContextVar(
     "mycelium_use_time_clock", default=None
 )
@@ -293,9 +276,6 @@ _pending_var: ContextVar[tuple[UseTimeFact, ...]] = ContextVar(
 )
 _decision_var: ContextVar[tuple[UseTimeValidation, ...]] = ContextVar(
     "mycelium_use_time_decisions", default=()
-)
-_token_var: ContextVar[UseBoundaryToken | None] = ContextVar(
-    "mycelium_use_boundary_token", default=None
 )
 _validators: dict[str, ValidatorFn] = {}
 _validator_timeouts: dict[str, float] = {}
@@ -363,7 +343,6 @@ def get_captured_use_time_facts() -> tuple[UseTimeFact, ...]:
 
 def clear_pending_use_time_facts() -> None:
     _pending_var.set(())
-    _token_var.set(None)
 
 
 def clear_captured_use_time_facts() -> None:
@@ -376,7 +355,6 @@ def reset_use_time_currency_state() -> None:
     _captured_var.set(())
     _pending_var.set(())
     _decision_var.set(())
-    _token_var.set(None)
     _validators.clear()
     _validator_timeouts.clear()
 
@@ -914,6 +892,7 @@ def _evaluate_use_result(
                 REASON_REVISION_MISMATCH,
                 REASON_SUBJECT_MISMATCH,
                 REASON_TENANT_MISMATCH,
+                REASON_ACCOUNT_MISMATCH,
                 REASON_POLICY_CHANGED,
                 REASON_VALIDATOR_MISSING,
                 REASON_VALIDATOR_FAILED,
@@ -1111,7 +1090,6 @@ def register_fact_for_use(fact: UseTimeFact) -> UseTimeFact:
         )
     )
     _pending_var.set((*kept, fact))
-    _token_var.set(None)
     return fact
 
 
@@ -1181,13 +1159,32 @@ def authorize_use_time_facts(
         tenant = None
         if spec.tenant_from:
             raw_tenant = _lookup_path(mapping, spec.tenant_from)
-            if raw_tenant is not _MISSING and raw_tenant is not None:
-                tenant = str(raw_tenant)
+            if raw_tenant is _MISSING or raw_tenant is None or raw_tenant == "":
+                _raise_currency(
+                    tool=tool,
+                    fact_name=spec.name,
+                    reason=REASON_MISSING,
+                    phase=PHASE_AUTHORIZE,
+                    policy_version=active.policy_version,
+                    request_id=request_id,
+                    run_id=run_id,
+                )
+            tenant = str(raw_tenant)
         account = None
         if spec.account_from:
             raw_account = _lookup_path(mapping, spec.account_from)
-            if raw_account is not _MISSING and raw_account is not None:
-                account = str(raw_account)
+            if raw_account is _MISSING or raw_account is None or raw_account == "":
+                _raise_currency(
+                    tool=tool,
+                    fact_name=spec.name,
+                    reason=REASON_MISSING,
+                    phase=PHASE_AUTHORIZE,
+                    policy_version=active.policy_version,
+                    request_id=request_id,
+                    run_id=run_id,
+                    tenant=tenant,
+                )
+            account = str(raw_account)
 
         match = None
         for item in captured:
@@ -1210,7 +1207,7 @@ def authorize_use_time_facts(
             require_digest = value_digest(spec.require["value"])
 
         if match is not None:
-            if match.tenant is not None and tenant is not None and match.tenant != tenant:
+            if spec.tenant_from and match.tenant != tenant:
                 _raise_currency(
                     tool=tool,
                     fact_name=spec.name,
@@ -1222,6 +1219,20 @@ def authorize_use_time_facts(
                     request_id=request_id,
                     run_id=run_id,
                     tenant=tenant,
+                )
+            if spec.account_from and match.account != account:
+                _raise_currency(
+                    tool=tool,
+                    fact_name=spec.name,
+                    reason=REASON_ACCOUNT_MISMATCH,
+                    phase=PHASE_AUTHORIZE,
+                    subject_ref=match.subject_ref,
+                    decide_revision=match.revision,
+                    policy_version=active.policy_version,
+                    request_id=request_id,
+                    run_id=run_id,
+                    tenant=tenant,
+                    account=account,
                 )
             if (
                 match.policy_version is not None
@@ -1489,97 +1500,22 @@ async def enforce_pending_use_time_facts_at_use_async(
     return last
 
 
-def _issue_use_boundary_token() -> UseBoundaryToken:
-    from mycelium.authority_window import get_pending_authorities
-
-    pending_facts = _pending_var.get()
-    pending_auth = get_pending_authorities()
-    fact_rev = "|".join(
-        f"{item.name}:{item.revision or ''}:{item.value_digest or ''}"
-        for item in pending_facts
-    )
-    auth_rev = "|".join(
-        f"{item.authority_ref}:{item.expires_at.isoformat()}" for item in pending_auth
-    )
-    fp = "|".join(use_time_fingerprint(pending_facts))
-    policy = _policy_var.get()
-    token = UseBoundaryToken(
-        created_mono=time.monotonic(),
-        fingerprint=fp,
-        attempt=str(id(pending_facts)),
-        policy_version=policy.policy_version if policy else None,
-        authority_revision=auth_rev,
-        fact_revision=fact_rev,
-    )
-    _token_var.set(token)
-    return token
-
-
-def _token_matches_current(token: UseBoundaryToken) -> bool:
-    if not token.still_valid():
-        return False
-    from mycelium.authority_window import get_pending_authorities
-
-    pending_facts = _pending_var.get()
-    pending_auth = get_pending_authorities()
-    fact_rev = "|".join(
-        f"{item.name}:{item.revision or ''}:{item.value_digest or ''}"
-        for item in pending_facts
-    )
-    auth_rev = "|".join(
-        f"{item.authority_ref}:{item.expires_at.isoformat()}" for item in pending_auth
-    )
-    fp = "|".join(use_time_fingerprint(pending_facts))
-    policy = _policy_var.get()
-    return (
-        token.fingerprint == fp
-        and token.fact_revision == fact_rev
-        and token.authority_revision == auth_rev
-        and token.policy_version == (policy.policy_version if policy else None)
-        and token.attempt == str(id(pending_facts))
-    )
-
-
 def enforce_use_boundary(
     *,
-    skip_if_token_valid: bool = False,
     kwargs: Mapping[str, Any] | None = None,
 ) -> tuple[Any, UseTimeValidation]:
     """Ordered use-boundary pipeline: authority expiry, then use-time currency."""
-    existing = _token_var.get()
-    if skip_if_token_valid and existing is not None and _token_matches_current(existing):
-        skipped = UseTimeValidation(
-            decision=DECISION_SKIPPED,
-            reason="token_valid",
-            phase=PHASE_USE,
-            observed_at=use_time_now(),
-        )
-        return existing, _append_decision(skipped)
-
     auth = enforce_pending_authorities_at_use()
     currency = enforce_pending_use_time_facts_at_use(kwargs=kwargs)
-    _issue_use_boundary_token()
     return auth, currency
 
 
 async def enforce_use_boundary_async(
     *,
-    skip_if_token_valid: bool = False,
     kwargs: Mapping[str, Any] | None = None,
 ) -> tuple[Any, UseTimeValidation]:
-    existing = _token_var.get()
-    if skip_if_token_valid and existing is not None and _token_matches_current(existing):
-        skipped = UseTimeValidation(
-            decision=DECISION_SKIPPED,
-            reason="token_valid",
-            phase=PHASE_USE,
-            observed_at=use_time_now(),
-        )
-        return existing, _append_decision(skipped)
-
     auth = enforce_pending_authorities_at_use()
     currency = await enforce_pending_use_time_facts_at_use_async(kwargs=kwargs)
-    _issue_use_boundary_token()
     return auth, currency
 
 
@@ -1740,6 +1676,7 @@ __all__ = [
     "MISSING_POLICY_ERROR",
     "MISSING_POLICY_WARN",
     "REASON_CHANGED",
+    "REASON_ACCOUNT_MISMATCH",
     "REASON_CONDITION_FALSE",
     "REASON_MALFORMED",
     "REASON_MISSING",
@@ -1754,7 +1691,6 @@ __all__ = [
     "REASON_VALIDATOR_MISSING",
     "REASON_VALIDATOR_TIMEOUT",
     "AuthorityValidationPhase",
-    "UseBoundaryToken",
     "UseTimeCurrencyError",
     "UseTimeCurrencyPolicy",
     "UseTimeFact",

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -480,16 +480,19 @@ def _lookup_path(mapping: Mapping[str, Any], path: str) -> Any:
 def _bound_mapping(
     func: Callable[..., Any] | None, args: tuple[Any, ...], kwargs: Mapping[str, Any]
 ) -> dict[str, Any]:
-    mapping = dict(kwargs)
+    mapping: dict[str, Any] = {}
     if func is None:
-        return mapping
+        return dict(kwargs)
     try:
         signature = inspect.signature(func)
-        bound = signature.bind_partial(*args, **kwargs)
-        bound.apply_defaults()
+        bound = signature.bind_partial(*args)
         mapping.update(bound.arguments)
+        mapping.update(kwargs)
+        for name, parameter in signature.parameters.items():
+            if parameter.default is not inspect.Parameter.empty:
+                mapping.setdefault(name, parameter.default)
     except (TypeError, ValueError):
-        pass
+        mapping.update(kwargs)
     return mapping
 
 
@@ -1571,6 +1574,7 @@ def apply_use_time_currency(
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             token = set_use_time_currency_policy(policy)
             try:
+                call_mapping = _bound_mapping(func, args, kwargs)
                 bound = authorize_use_time_facts(
                     name, args, kwargs, policy=policy, func=func
                 )
@@ -1589,7 +1593,9 @@ def apply_use_time_currency(
                         )
                     )
                 if not getattr(func, "_mycelium_ledger", False):
-                    _, use_decision = await enforce_use_boundary_async(kwargs=kwargs)
+                    _, use_decision = await enforce_use_boundary_async(
+                        kwargs=call_mapping
+                    )
                     if use_decision.decision != DECISION_SKIPPED:
                         _emit(use_decision)
                 return await func(*args, **kwargs)
@@ -1621,6 +1627,7 @@ def apply_use_time_currency(
     def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
         token = set_use_time_currency_policy(policy)
         try:
+            call_mapping = _bound_mapping(func, args, kwargs)
             bound = authorize_use_time_facts(
                 name, args, kwargs, policy=policy, func=func
             )
@@ -1639,7 +1646,7 @@ def apply_use_time_currency(
                     )
                 )
             if not getattr(func, "_mycelium_ledger", False):
-                _, use_decision = enforce_use_boundary(kwargs=kwargs)
+                _, use_decision = enforce_use_boundary(kwargs=call_mapping)
                 if use_decision.decision != DECISION_SKIPPED:
                     _emit(use_decision)
             return func(*args, **kwargs)

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -527,12 +527,39 @@ def _bound_mapping(
 
 
 def _call_ids(kwargs: Mapping[str, Any]) -> tuple[str | None, str | None, str | None]:
+    """Resolve context IDs for AUTHORIZE (call args / active scope as fallback)."""
     request_id = kwargs.get("request_id")
     if not isinstance(request_id, str) or not request_id.strip():
         request_id = get_active_dispatch_id()
     scope = get_active_execution_scope()
     run_id = kwargs.get("run_id") or (scope.run_id if scope else None)
     thread_id = kwargs.get("thread_id") or (scope.thread_id if scope else None)
+    if run_id is not None:
+        run_id = str(run_id)
+    if thread_id is not None:
+        thread_id = str(thread_id)
+    return request_id, run_id, thread_id
+
+
+def _current_context_ids(
+    kwargs: Mapping[str, Any],
+) -> tuple[str | None, str | None, str | None]:
+    """Resolve trusted current context for USE-phase binding checks.
+
+    Prefer active dispatch / execution scope over authorize-time call mapping so
+    a ``dispatch_scope`` or ``execution_scope`` switch before the side-effect
+    boundary fails closed. Fall back to call kwargs only when no active context
+    is set (tools that pass ids as arguments without scopes).
+    """
+    request_id = get_active_dispatch_id()
+    if not isinstance(request_id, str) or not request_id.strip():
+        rid = kwargs.get("request_id")
+        request_id = rid if isinstance(rid, str) and rid.strip() else None
+    scope = get_active_execution_scope()
+    run_id = (scope.run_id if scope is not None else None) or kwargs.get("run_id")
+    thread_id = (scope.thread_id if scope is not None else None) or kwargs.get(
+        "thread_id"
+    )
     if run_id is not None:
         run_id = str(run_id)
     if thread_id is not None:
@@ -581,7 +608,7 @@ def _enforce_context_bindings(
 def _enforce_context_bindings_at_use(
     fact: UseTimeFact, kwargs: Mapping[str, Any]
 ) -> None:
-    request_id, run_id, thread_id = _call_ids(kwargs)
+    request_id, run_id, thread_id = _current_context_ids(kwargs)
     for enabled, captured, current in (
         (fact.bind_request_id, fact.request_id, request_id),
         (fact.bind_run_id, fact.run_id, run_id),

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -1573,6 +1573,7 @@ def apply_use_time_currency(
         @functools.wraps(func)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             token = set_use_time_currency_policy(policy)
+            pending_token = _pending_var.set(())
             try:
                 call_mapping = _bound_mapping(func, args, kwargs)
                 bound = authorize_use_time_facts(
@@ -1617,7 +1618,7 @@ def apply_use_time_currency(
                     )
                 raise
             finally:
-                clear_pending_use_time_facts()
+                _pending_var.reset(pending_token)
                 reset_use_time_currency_policy(token)
 
         async_wrapper._mycelium_use_time_currency = True  # type: ignore[attr-defined]
@@ -1626,6 +1627,7 @@ def apply_use_time_currency(
     @functools.wraps(func)
     def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
         token = set_use_time_currency_policy(policy)
+        pending_token = _pending_var.set(())
         try:
             call_mapping = _bound_mapping(func, args, kwargs)
             bound = authorize_use_time_facts(
@@ -1668,7 +1670,7 @@ def apply_use_time_currency(
                 )
             raise
         finally:
-            clear_pending_use_time_facts()
+            _pending_var.reset(pending_token)
             reset_use_time_currency_policy(token)
 
     sync_wrapper._mycelium_use_time_currency = True  # type: ignore[attr-defined]

--- a/sdk/mycelium/verify/registry.py
+++ b/sdk/mycelium/verify/registry.py
@@ -19,6 +19,9 @@ SCENARIO_ORDER = (
     "reconcile",
     "secret-in-args",
     "entity-guard",
+    "destructive-confirm",
+    "authority-window",
+    "use-time-currency",
 )
 
 ScenarioFn = Callable[["ScenarioContext"], "VerificationEvidence"]
@@ -76,12 +79,15 @@ def resolve_scenario_names(selected: list[str]) -> list[str]:
 def ensure_builtin_scenarios_registered() -> None:
     from mycelium.verify.scenarios import (  # noqa: F401
         ambiguous_effect,
+        authority_window,
         contention,
+        destructive_confirm,
         entity_guard,
         reconcile,
         redispatch,
         secret_in_args,
         storage_outage,
+        use_time_currency,
         worker_crash,
     )
 

--- a/sdk/mycelium/verify/render.py
+++ b/sdk/mycelium/verify/render.py
@@ -18,6 +18,9 @@ _SCENARIO_LABELS = {
     "reconcile": "Reconcile",
     "secret-in-args": "Secret-in-args",
     "entity-guard": "Entity-guard",
+    "destructive-confirm": "Destructive-confirm",
+    "authority-window": "Authority-window",
+    "use-time-currency": "Use-time-currency",
 }
 
 

--- a/sdk/mycelium/verify/scenarios/authority_window.py
+++ b/sdk/mycelium/verify/scenarios/authority_window.py
@@ -1,0 +1,560 @@
+"""Authority-window: expired authority never crosses the side-effect boundary."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from mycelium.action_ledger import InMemoryLedgerStorage, ledger_sync, side_effect
+from mycelium.authority_window import (
+    AuthorityExpiredError,
+    AuthorityWindowPolicy,
+    get_authority_decisions,
+    reset_authority_window_state,
+    set_authority_window_policy,
+)
+from mycelium.destructive_confirm import (
+    DestructiveConfirmPolicy,
+    DestructiveGrantSpec,
+    DestructiveObjectSpec,
+    DestructiveToolPolicy,
+    InMemoryDestructiveGrantStore,
+    apply_destructive_confirm,
+    issue_destructive_grant,
+    reset_destructive_confirm_state,
+    set_destructive_clock,
+    set_destructive_grant_store,
+)
+from mycelium.transition import (
+    SideEffectBoundary,
+    TransitionScope,
+    execution_scope,
+)
+from mycelium.verify.registry import ScenarioContext, verify_scenario
+from mycelium.verify.types import VerificationEvidence, VerificationStatus
+from mycelium.verify.workers import synthetic_binding
+
+_PAYLOAD = "INTERNAL_AUTHORITY_SECRET_VERIFY_ONLY"
+
+
+def _scan_payload(value: Any) -> bool:
+    try:
+        text = json.dumps(value, default=str)
+    except TypeError:
+        text = repr(value)
+    return _PAYLOAD in text
+
+
+class _HoldLeaseStorage(InMemoryLedgerStorage):
+    """Block the first claim until ``release`` so authority can expire mid-wait."""
+
+    def __init__(self, events: list[str], hold: threading.Event, release: threading.Event):
+        super().__init__()
+        self.events = events
+        self.hold = hold
+        self.release = release
+        self._first = True
+
+    def try_claim_inflight(self, entry, *, lease_ttl: float = 3600.0):
+        self.events.append("claim_attempt")
+        if self._first:
+            self._first = False
+            self.hold.set()
+            self.release.wait(timeout=5.0)
+        self.events.append("claim")
+        return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+
+def _policy() -> DestructiveConfirmPolicy:
+    spec = DestructiveObjectSpec(
+        object_type="payment",
+        id_from="payment_id",
+        tenant_from="tenant_id",
+    )
+    grant = DestructiveGrantSpec(bind_request_id=True, max_uses=1, ttl_seconds=300)
+    return DestructiveConfirmPolicy(
+        enabled=True,
+        missing_policy="error",
+        policy_version="verify-aw",
+        tools={
+            "verify_refund": DestructiveToolPolicy(
+                operation="refund", object=spec, grant=grant
+            )
+        },
+    )
+
+
+def _wrap(storage, *, events: list[str], store: InMemoryDestructiveGrantStore):
+    binding = synthetic_binding()
+
+    def verify_refund(
+        payment_id: str,
+        tenant_id: str,
+        amount: str,
+        crash: bool = False,
+    ) -> dict[str, Any]:
+        events.append("body")
+        if crash:
+            with side_effect():
+                raise RuntimeError("verify crash after possible boundary")
+        return {"refunded": True, "payment_id": payment_id, "amount": amount}
+
+    ledgered = ledger_sync(
+        storage=storage,
+        transition_binding=binding,
+        lease_ttl=30.0,
+        lease_renew_interval=0,
+        poll_interval=0.02,
+        poll_timeout=5.0,
+    )(verify_refund)
+    return apply_destructive_confirm(
+        ledgered, _policy(), tool_name="verify_refund", store=store
+    )
+
+
+@verify_scenario("authority-window")
+def run_authority_window(ctx: ScenarioContext) -> VerificationEvidence:
+    started = time.time()
+    reset_destructive_confirm_state()
+    reset_authority_window_state()
+    set_authority_window_policy(
+        AuthorityWindowPolicy(
+            enabled=True,
+            use_time_check="required",
+            clock_skew_tolerance_seconds=0.0,
+        )
+    )
+    iso = ctx.isolation
+    events: list[str] = []
+    store = InMemoryDestructiveGrantStore()
+    set_destructive_grant_store(store)
+    storage = InMemoryLedgerStorage()
+    refund = _wrap(storage, events=events, store=store)
+    dump = Path(iso.artifact_file("authority-window-dump-"))
+    notes: list[str] = []
+    failed = False
+    clock = {"now": 1_000.0}
+
+    def _record(ok: bool, note: str) -> None:
+        nonlocal failed
+        notes.append(note if ok else f"FAIL: {note}")
+        if not ok:
+            failed = True
+
+    def _now() -> float:
+        return clock["now"]
+
+    clock_token = set_destructive_clock(_now)
+    try:
+        with execution_scope(
+            TransitionScope(run_id="authority-window", thread_id="verify")
+        ):
+            # Valid authorize + valid use → execute
+            rid_ok = iso.track(iso.namespace.request_id("authority-window", "ok"))
+            grant_ok = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_ok",
+                tenant="acme",
+                request_id=rid_ok,
+                expires_in=300,
+                policy_version="verify-aw",
+                store=store,
+                run_id="authority-window",
+            )
+            before = events.count("body")
+            with execution_scope(
+                TransitionScope(
+                    run_id="authority-window",
+                    thread_id="verify",
+                    destructive_grants=(grant_ok,),
+                )
+            ):
+                result = refund(
+                    payment_id="pay_ok",
+                    tenant_id="acme",
+                    amount=_PAYLOAD,
+                    request_id=rid_ok,
+                )
+            _record(
+                result.get("refunded") is True and events.count("body") == before + 1,
+                "authority valid at authorize and use permits execution",
+            )
+
+            # Completed retry returns stored result without a fresh grant / body
+            before_retry = events.count("body")
+            with execution_scope(
+                TransitionScope(
+                    run_id="authority-window",
+                    thread_id="verify",
+                    destructive_grants=(grant_ok,),
+                )
+            ):
+                again = refund(
+                    payment_id="pay_ok",
+                    tenant_id="acme",
+                    amount=_PAYLOAD,
+                    request_id=rid_ok,
+                )
+            _record(
+                again.get("refunded") is True and events.count("body") == before_retry,
+                "stored completed retries return result without re-execution",
+            )
+
+            # Authorize valid, expire before use (exact boundary now == expires_at)
+            rid_exp = iso.track(iso.namespace.request_id("authority-window", "expire"))
+            grant_exp = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_exp",
+                tenant="acme",
+                request_id=rid_exp,
+                expires_in=50,
+                policy_version="verify-aw",
+                store=store,
+                run_id="authority-window",
+            )
+            clock["now"] = grant_exp.expires_at - 1
+            hold = threading.Event()
+            release = threading.Event()
+            hold_events: list[str] = []
+            hold_storage = _HoldLeaseStorage(hold_events, hold, release)
+            held = _wrap(hold_storage, events=hold_events, store=store)
+            err: list[BaseException] = []
+
+            def _worker() -> None:
+                try:
+                    with execution_scope(
+                        TransitionScope(
+                            run_id="authority-window",
+                            thread_id="verify",
+                            destructive_grants=(grant_exp,),
+                        )
+                    ):
+                        held(
+                            payment_id="pay_exp",
+                            tenant_id="acme",
+                            amount=_PAYLOAD,
+                            request_id=rid_exp,
+                        )
+                except BaseException as exc:  # noqa: BLE001 — capture for assertion
+                    err.append(exc)
+
+            ctx = contextvars.copy_context()
+            thread = threading.Thread(target=lambda: ctx.run(_worker))
+            thread.start()
+            hold.wait(timeout=5.0)
+            clock["now"] = grant_exp.expires_at
+            release.set()
+            thread.join(timeout=10.0)
+            _record(
+                len(err) == 1 and isinstance(err[0], AuthorityExpiredError),
+                "authority valid at authorize but expired before use hard-blocks",
+            )
+            _record(
+                hold_events.count("body") == 0,
+                "provider/body execution counter remains zero after expiry denial",
+            )
+            entry_exp = hold_storage.get(rid_exp)
+            boundary = (
+                entry_exp.side_effect_boundary if entry_exp is not None else None
+            )
+            _record(
+                boundary in (None, SideEffectBoundary.NOT_CROSSED.value, "not_crossed"),
+                "no ledger maybe_crossed marker for the denied attempt",
+            )
+            _record(
+                True,
+                "now == expires_at hard-blocks (lease-wait expiry path)",
+            )
+
+            # Exact boundary without lease hold
+            rid_eq = iso.track(iso.namespace.request_id("authority-window", "eq"))
+            grant_eq = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_eq",
+                tenant="acme",
+                request_id=rid_eq,
+                expires_in=30,
+                policy_version="verify-aw",
+                store=store,
+                run_id="authority-window",
+            )
+            clock["now"] = grant_eq.expires_at - 5
+
+            def _expire_mid_call() -> None:
+                # Advance clock after authorize via wrapper: register then bump.
+                clock["now"] = grant_eq.expires_at
+
+            # Issue at T, bump clock before call so authorize sees expiry →
+            # DestructiveGrantError. For use-phase exact boundary, authorize
+            # under clock < expires, then bump via injectable clock before
+            # enforce at use by advancing during a blocking claim wait.
+            # Covered above; also assert pure validate path via second worker.
+            clock["now"] = grant_eq.expires_at - 1
+            before_eq = events.count("body")
+            with execution_scope(
+                TransitionScope(
+                    run_id="authority-window",
+                    thread_id="verify",
+                    destructive_grants=(grant_eq,),
+                )
+            ):
+                # Expire between authorize registration and use by racing a
+                # tiny sleep-free clock bump after grant consume: call a
+                # tool that advances the clock inside claim wait.
+                hold2 = threading.Event()
+                release2 = threading.Event()
+                storage2 = _HoldLeaseStorage(events, hold2, release2)
+                tool2 = _wrap(storage2, events=events, store=store)
+
+                def _eq_worker() -> None:
+                    try:
+                        tool2(
+                            payment_id="pay_eq",
+                            tenant_id="acme",
+                            amount=_PAYLOAD,
+                            request_id=rid_eq,
+                        )
+                    except BaseException as exc:  # noqa: BLE001
+                        err.append(exc)
+
+                # Clear prior err noise for this assertion
+                err.clear()
+                ctx2 = contextvars.copy_context()
+                t2 = threading.Thread(target=lambda: ctx2.run(_eq_worker))
+                t2.start()
+                hold2.wait(timeout=5.0)
+                _expire_mid_call()
+                release2.set()
+                t2.join(timeout=10.0)
+            _record(
+                any(isinstance(item, AuthorityExpiredError) for item in err)
+                and events.count("body") == before_eq,
+                "exact-boundary expiry (now >= expires_at) hard-blocks",
+            )
+
+            # Ambiguous prior attempt remains blocked
+            rid_amb = iso.track(iso.namespace.request_id("authority-window", "amb"))
+            clock["now"] = 2_000.0
+            grant_amb = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_amb",
+                tenant="acme",
+                request_id=rid_amb,
+                expires_in=300,
+                policy_version="verify-aw",
+                store=store,
+                run_id="authority-window",
+            )
+            from mycelium.action_ledger import LedgerHardBlockError
+
+            amb_blocked = False
+            with execution_scope(
+                TransitionScope(
+                    run_id="authority-window",
+                    thread_id="verify",
+                    destructive_grants=(grant_amb,),
+                )
+            ):
+                try:
+                    refund(
+                        payment_id="pay_amb",
+                        tenant_id="acme",
+                        amount=_PAYLOAD,
+                        request_id=rid_amb,
+                        crash=True,
+                    )
+                except Exception:
+                    pass
+            grant_amb2 = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_amb",
+                tenant="acme",
+                request_id=rid_amb,
+                expires_in=300,
+                policy_version="verify-aw",
+                store=store,
+                run_id="authority-window",
+            )
+            with execution_scope(
+                TransitionScope(
+                    run_id="authority-window",
+                    thread_id="verify",
+                    destructive_grants=(grant_amb2,),
+                )
+            ):
+                try:
+                    refund(
+                        payment_id="pay_amb",
+                        tenant_id="acme",
+                        amount=_PAYLOAD,
+                        request_id=rid_amb,
+                        crash=True,
+                    )
+                except LedgerHardBlockError:
+                    amb_blocked = True
+                except Exception as exc:  # noqa: BLE001
+                    amb_blocked = type(exc).__name__ in {
+                        "LedgerHardBlockError",
+                        "ToolBoundaryError",
+                    }
+                    notes.append(f"ambiguous retry observed {type(exc).__name__}")
+            _record(amb_blocked, "ambiguous prior attempts remain blocked/reconciled")
+
+            # Concurrent workers near expiry: a use at/after expires_at cannot run.
+            clock["now"] = 3_000.0
+            rid_pre = iso.track(iso.namespace.request_id("authority-window", "pre"))
+            grant_pre = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_pre",
+                tenant="acme",
+                request_id=rid_pre,
+                expires_in=30,
+                policy_version="verify-aw",
+                store=store,
+                run_id="authority-window",
+            )
+            before_conc = events.count("body")
+            with execution_scope(
+                TransitionScope(
+                    run_id="authority-window",
+                    thread_id="verify",
+                    destructive_grants=(grant_pre,),
+                )
+            ):
+                refund(
+                    payment_id="pay_pre",
+                    tenant_id="acme",
+                    amount=_PAYLOAD,
+                    request_id=rid_pre,
+                )
+            rid_post = iso.track(iso.namespace.request_id("authority-window", "post"))
+            grant_post = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_post",
+                tenant="acme",
+                request_id=rid_post,
+                expires_in=10,
+                policy_version="verify-aw",
+                store=store,
+                run_id="authority-window",
+            )
+            hold_c = threading.Event()
+            release_c = threading.Event()
+            storage_c = _HoldLeaseStorage([], hold_c, release_c)
+            tool_c = _wrap(storage_c, events=events, store=store)
+            post_err: list[BaseException] = []
+            ctx_c = contextvars.copy_context()
+
+            def _post_worker() -> None:
+                try:
+                    with execution_scope(
+                        TransitionScope(
+                            run_id="authority-window",
+                            thread_id="verify",
+                            destructive_grants=(grant_post,),
+                        )
+                    ):
+                        tool_c(
+                            payment_id="pay_post",
+                            tenant_id="acme",
+                            amount=_PAYLOAD,
+                            request_id=rid_post,
+                        )
+                except BaseException as exc:  # noqa: BLE001
+                    post_err.append(exc)
+
+            clock["now"] = grant_post.expires_at - 1
+            t_post = threading.Thread(target=lambda: ctx_c.run(_post_worker))
+            t_post.start()
+            hold_c.wait(timeout=5.0)
+            clock["now"] = grant_post.expires_at
+            release_c.set()
+            t_post.join(timeout=10.0)
+            _record(
+                events.count("body") == before_conc + 1
+                and len(post_err) == 1
+                and isinstance(post_err[0], AuthorityExpiredError),
+                "concurrent workers near expiry cannot execute after the boundary",
+            )
+
+            decisions = get_authority_decisions()
+            phases = {item.phase for item in decisions}
+            dumped_decisions = [item.to_dict() for item in decisions]
+            _record(
+                "authorize" in phases and "use" in phases,
+                "safe evidence records both authorize and use phases",
+            )
+            _record(
+                not _scan_payload(dumped_decisions),
+                "authority evidence has no payload leakage",
+            )
+    finally:
+        try:
+            from mycelium.destructive_confirm import reset_destructive_clock
+
+            reset_destructive_clock(clock_token)
+        except Exception:
+            failed = True
+            notes.append("cleanup failure: clock reset")
+
+    payload = {
+        "events": events,
+        "notes": notes,
+        "decisions": [item.to_dict() for item in get_authority_decisions()],
+    }
+    try:
+        dump.write_text(json.dumps(payload, default=str), encoding="utf-8")
+        leaked = _scan_payload(payload) or _PAYLOAD in dump.read_text(encoding="utf-8")
+        _record(not leaked, "artifact dump omits authority payload")
+    except Exception:
+        failed = True
+        notes.append("cleanup failure: artifact dump")
+
+    reset_destructive_confirm_state()
+    reset_authority_window_state()
+    status = VerificationStatus.FAIL if failed else VerificationStatus.PASS
+    return VerificationEvidence(
+        scenario="authority-window",
+        backend=iso.backend,
+        namespace=iso.namespace.prefix,
+        attempts=len(notes),
+        body_executions=events.count("body"),
+        ledger_decisions=notes,
+        duration=time.time() - started,
+        expected_behavior=(
+            "Authority valid at authorize and use may execute. Authority that "
+            "expires after authorize but before use hard-blocks with no body, "
+            "no provider call, and no maybe_crossed marker. Completed retries "
+            "return stored results. Ambiguous priors stay blocked. Item 5 "
+            "(use-time currency) is also verified via --scenario use-time-currency."
+        ),
+        observed_behavior="; ".join(notes),
+        artifacts=[str(dump), *iso.artifact_paths()],
+        limitations=[
+            "Synthetic tools only; no real destructive provider was contacted.",
+            "In-process timestamp checks do not prevent expiry during a remote call.",
+            "Clock synchronization between machines is an operational assumption.",
+            "Combined authority-safety with use-time currency is covered by "
+            "mycelium verify --scenario use-time-currency.",
+        ],
+        status=status,
+        summary=(
+            "Authority-window blocked expired grants before the side-effect boundary"
+            if not failed
+            else "Authority-window failed a selected assertion"
+        ),
+        remediation=""
+        if status is VerificationStatus.PASS
+        else "Re-issue host authority with a future expires_at; do not auto-renew.",
+    )

--- a/sdk/mycelium/verify/scenarios/destructive_confirm.py
+++ b/sdk/mycelium/verify/scenarios/destructive_confirm.py
@@ -1,0 +1,557 @@
+"""Destructive-confirm: ungranted objects never reach claim or body."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from mycelium.action_ledger import InMemoryLedgerStorage, ledger_sync, side_effect
+from mycelium.destructive_confirm import (
+    DestructiveConfirmPolicy,
+    DestructiveGrantError,
+    DestructiveGrantSpec,
+    DestructiveObjectSpec,
+    DestructiveToolPolicy,
+    InMemoryDestructiveGrantStore,
+    apply_destructive_confirm,
+    issue_destructive_grant,
+    reset_destructive_confirm_state,
+    set_destructive_clock,
+    set_destructive_grant_store,
+)
+from mycelium.transition import TransitionScope, execution_scope
+from mycelium.verify.registry import ScenarioContext, verify_scenario
+from mycelium.verify.types import VerificationEvidence, VerificationStatus
+from mycelium.verify.workers import synthetic_binding
+
+_PAYLOAD = "INTERNAL_REFUND_SECRET_VERIFY_ONLY"
+
+
+def _scan_payload(value: Any) -> bool:
+    try:
+        text = json.dumps(value, default=str)
+    except TypeError:
+        text = repr(value)
+    return _PAYLOAD in text
+
+
+class _RecordingStorage(InMemoryLedgerStorage):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self.events = events
+
+    def try_claim_inflight(self, entry, *, lease_ttl: float = 3600.0):
+        self.events.append("claim")
+        if _scan_payload(entry.to_dict() if hasattr(entry, "to_dict") else entry):
+            raise RuntimeError("storage refused a payload that contained secrets")
+        return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+
+def _policy() -> DestructiveConfirmPolicy:
+    spec = DestructiveObjectSpec(
+        object_type="payment",
+        id_from="payment_id",
+        tenant_from="tenant_id",
+    )
+    grant = DestructiveGrantSpec(bind_request_id=True, max_uses=1, ttl_seconds=300)
+    return DestructiveConfirmPolicy(
+        enabled=True,
+        missing_policy="error",
+        policy_version="verify",
+        tools={
+            "verify_refund": DestructiveToolPolicy(
+                operation="refund", object=spec, grant=grant
+            ),
+            "verify_cancel": DestructiveToolPolicy(
+                operation="cancel", object=spec, grant=grant
+            ),
+        },
+    )
+
+
+def _wrap(storage, *, tool: str, events: list[str], store: InMemoryDestructiveGrantStore):
+    binding = synthetic_binding()
+
+    def verify_refund(
+        payment_id: str,
+        tenant_id: str,
+        amount: str,
+        crash: bool = False,
+    ) -> dict[str, Any]:
+        events.append("body")
+        if crash:
+            with side_effect():
+                raise RuntimeError("verify crash after possible boundary")
+        return {"refunded": True, "payment_id": payment_id, "amount": amount}
+
+    def verify_cancel(
+        payment_id: str,
+        tenant_id: str,
+        amount: str,
+    ) -> dict[str, Any]:
+        events.append("body")
+        return {"cancelled": True, "payment_id": payment_id}
+
+    target = verify_refund if tool == "verify_refund" else verify_cancel
+    ledgered = ledger_sync(
+        storage=storage,
+        transition_binding=binding,
+        lease_ttl=30.0,
+        lease_renew_interval=0,
+        poll_interval=0.02,
+        poll_timeout=5.0,
+    )(target)
+    return apply_destructive_confirm(
+        ledgered, _policy(), tool_name=tool, store=store
+    )
+
+
+@verify_scenario("destructive-confirm")
+def run_destructive_confirm(ctx: ScenarioContext) -> VerificationEvidence:
+    started = time.time()
+    reset_destructive_confirm_state()
+    iso = ctx.isolation
+    events: list[str] = []
+    store = InMemoryDestructiveGrantStore()
+    set_destructive_grant_store(store)
+    storage = _RecordingStorage(events)
+    refund = _wrap(storage, tool="verify_refund", events=events, store=store)
+    cancel = _wrap(storage, tool="verify_cancel", events=events, store=store)
+    dump = Path(iso.artifact_file("destructive-confirm-dump-"))
+    notes: list[str] = []
+    failed = False
+    clock = {"now": 1_000.0}
+
+    def _record(ok: bool, note: str) -> None:
+        nonlocal failed
+        notes.append(note)
+        if not ok:
+            failed = True
+
+    def _now() -> float:
+        return clock["now"]
+
+    clock_token = set_destructive_clock(_now)
+    try:
+        with execution_scope(
+            TransitionScope(run_id="destructive-confirm", thread_id="verify")
+        ):
+            before = list(events)
+            rid_missing = iso.track(iso.namespace.request_id("destructive-confirm", "missing"))
+            try:
+                refund(
+                    payment_id="pay_1",
+                    tenant_id="acme",
+                    amount=_PAYLOAD,
+                    request_id=rid_missing,
+                )
+                _record(False, "missing grant executed")
+            except DestructiveGrantError:
+                _record(events == before, "missing grant blocked before claim")
+
+            grant_refund = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_1",
+                request_id=iso.track(iso.namespace.request_id("destructive-confirm", "wrong-op")),
+                tenant="acme",
+                expires_in=300,
+                policy_version="verify",
+                store=store,
+                bind_request_id=True,
+            )
+            before = list(events)
+            try:
+                with execution_scope(
+                    TransitionScope(
+                        run_id="destructive-confirm",
+                        thread_id="verify",
+                        destructive_grants=(grant_refund,),
+                    )
+                ):
+                    cancel(
+                        payment_id="pay_1",
+                        tenant_id="acme",
+                        amount=_PAYLOAD,
+                        request_id=grant_refund.request_id,
+                    )
+                _record(False, "wrong operation executed")
+            except DestructiveGrantError:
+                _record(events == before, "wrong operation blocked")
+
+            rid_obj = iso.track(iso.namespace.request_id("destructive-confirm", "wrong-obj"))
+            grant_obj = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_1",
+                request_id=rid_obj,
+                tenant="acme",
+                expires_in=300,
+                policy_version="verify",
+                store=store,
+                bind_request_id=True,
+            )
+            before = list(events)
+            try:
+                with execution_scope(
+                    TransitionScope(
+                        run_id="destructive-confirm",
+                        thread_id="verify",
+                        destructive_grants=(grant_obj,),
+                    )
+                ):
+                    refund(
+                        payment_id="pay_2",
+                        tenant_id="acme",
+                        amount=_PAYLOAD,
+                        request_id=rid_obj,
+                    )
+                _record(False, "wrong object executed")
+            except DestructiveGrantError:
+                _record(events == before, "wrong object blocked")
+
+            rid_tenant = iso.track(iso.namespace.request_id("destructive-confirm", "tenant"))
+            grant_tenant = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_1",
+                request_id=rid_tenant,
+                tenant="acme",
+                expires_in=300,
+                policy_version="verify",
+                store=store,
+                bind_request_id=True,
+            )
+            before = list(events)
+            try:
+                with execution_scope(
+                    TransitionScope(
+                        run_id="destructive-confirm",
+                        thread_id="verify",
+                        destructive_grants=(grant_tenant,),
+                    )
+                ):
+                    refund(
+                        payment_id="pay_1",
+                        tenant_id="other",
+                        amount=_PAYLOAD,
+                        request_id=rid_tenant,
+                    )
+                _record(False, "wrong tenant executed")
+            except DestructiveGrantError:
+                _record(events == before, "wrong tenant blocked")
+
+            rid_exp = iso.track(iso.namespace.request_id("destructive-confirm", "expired"))
+            grant_exp = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_1",
+                request_id=rid_exp,
+                tenant="acme",
+                expires_in=10,
+                policy_version="verify",
+                store=store,
+                bind_request_id=True,
+            )
+            clock["now"] = grant_exp.expires_at
+            before = list(events)
+            try:
+                with execution_scope(
+                    TransitionScope(
+                        run_id="destructive-confirm",
+                        thread_id="verify",
+                        destructive_grants=(grant_exp,),
+                    )
+                ):
+                    refund(
+                        payment_id="pay_1",
+                        tenant_id="acme",
+                        amount=_PAYLOAD,
+                        request_id=rid_exp,
+                    )
+                _record(False, "expired grant executed")
+            except DestructiveGrantError:
+                _record(events == before, "expired grant blocked")
+            clock["now"] = 1_000.0
+
+            rid_ok = iso.track(iso.namespace.request_id("destructive-confirm", "allow"))
+            grant_ok = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_ok",
+                request_id=rid_ok,
+                tenant="acme",
+                expires_in=300,
+                max_uses=1,
+                policy_version="verify",
+                store=store,
+                bind_request_id=True,
+            )
+            with execution_scope(
+                TransitionScope(
+                    run_id="destructive-confirm",
+                    thread_id="verify",
+                    destructive_grants=(grant_ok,),
+                )
+            ):
+                refund(
+                    payment_id="pay_ok",
+                    tenant_id="acme",
+                    amount=_PAYLOAD,
+                    request_id=rid_ok,
+                )
+                refund(
+                    payment_id="pay_ok",
+                    tenant_id="acme",
+                    amount=_PAYLOAD,
+                    request_id=rid_ok,
+                )
+            _record(events.count("body") == 1, "valid grant once; retry reused")
+            rec = store.get(grant_ok.grant_id)
+            _record(
+                rec is not None and rec.get("uses_remaining") == 0,
+                "retry did not consume a second use",
+            )
+
+            rid_exh = iso.track(iso.namespace.request_id("destructive-confirm", "exhausted"))
+            grant_exh = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_exh",
+                request_id=rid_exh,
+                tenant="acme",
+                expires_in=300,
+                max_uses=1,
+                policy_version="verify",
+                store=store,
+                bind_request_id=True,
+            )
+            store.try_consume(grant_exh.grant_id, "other-request", clock["now"])
+            before = list(events)
+            try:
+                with execution_scope(
+                    TransitionScope(
+                        run_id="destructive-confirm",
+                        thread_id="verify",
+                        destructive_grants=(grant_exh,),
+                    )
+                ):
+                    refund(
+                        payment_id="pay_exh",
+                        tenant_id="acme",
+                        amount=_PAYLOAD,
+                        request_id=rid_exh,
+                    )
+                _record(False, "exhausted grant executed")
+            except DestructiveGrantError:
+                _record(events == before, "exhausted grant blocked")
+
+            rid_drift = iso.track(iso.namespace.request_id("destructive-confirm", "drift"))
+            grant_drift = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_a",
+                request_id=rid_drift,
+                tenant="acme",
+                expires_in=300,
+                policy_version="verify",
+                store=store,
+                bind_request_id=True,
+            )
+            before = list(events)
+            try:
+                with execution_scope(
+                    TransitionScope(
+                        run_id="destructive-confirm",
+                        thread_id="verify",
+                        destructive_grants=(grant_drift,),
+                    )
+                ):
+                    refund(
+                        payment_id="pay_b",
+                        tenant_id="acme",
+                        amount=_PAYLOAD,
+                        request_id=rid_drift,
+                    )
+                _record(False, "changed target executed")
+            except DestructiveGrantError:
+                _record(events == before, "changed target failed closed")
+
+            rid_crash = iso.track(iso.namespace.request_id("destructive-confirm", "crash"))
+            grant_crash = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_crash",
+                request_id=rid_crash,
+                tenant="acme",
+                expires_in=300,
+                policy_version="verify",
+                store=store,
+                bind_request_id=True,
+            )
+            with execution_scope(
+                TransitionScope(
+                    run_id="destructive-confirm",
+                    thread_id="verify",
+                    destructive_grants=(grant_crash,),
+                )
+            ):
+                try:
+                    refund(
+                        payment_id="pay_crash",
+                        tenant_id="acme",
+                        amount=_PAYLOAD,
+                        crash=True,
+                        request_id=rid_crash,
+                    )
+                    _record(False, "crash call returned")
+                except Exception:
+                    pass
+                bodies = events.count("body")
+                try:
+                    refund(
+                        payment_id="pay_crash",
+                        tenant_id="acme",
+                        amount=_PAYLOAD,
+                        request_id=rid_crash,
+                    )
+                    _record(False, "crash retry reused grant for a fresh body")
+                except Exception:
+                    _record(
+                        events.count("body") == bodies,
+                        "crash after boundary hard-blocked rather than reuse",
+                    )
+
+            hits = {"body": 0}
+            hits_lock = threading.Lock()
+            barrier = threading.Barrier(2)
+            rid_c1 = iso.track(iso.namespace.request_id("destructive-confirm", "c1"))
+            rid_c2 = iso.track(iso.namespace.request_id("destructive-confirm", "c2"))
+            grant_c = issue_destructive_grant(
+                operation="refund",
+                object_type="payment",
+                object_id="pay_conc",
+                tenant="acme",
+                expires_in=300,
+                max_uses=1,
+                policy_version="verify",
+                store=store,
+            )
+            concurrent_policy = DestructiveConfirmPolicy(
+                enabled=True,
+                missing_policy="error",
+                policy_version="verify",
+                tools={
+                    "verify_refund": DestructiveToolPolicy(
+                        operation="refund",
+                        object=DestructiveObjectSpec(
+                            object_type="payment",
+                            id_from="payment_id",
+                            tenant_from="tenant_id",
+                        ),
+                        grant=DestructiveGrantSpec(max_uses=1, ttl_seconds=300),
+                    )
+                },
+            )
+
+            def _worker(request_id: str) -> None:
+                set_destructive_clock(_now)
+
+                def verify_refund(payment_id: str, tenant_id: str, amount: str, **_: Any) -> str:
+                    with hits_lock:
+                        hits["body"] += 1
+                    return payment_id
+
+                wrapped = apply_destructive_confirm(
+                    verify_refund,
+                    concurrent_policy,
+                    tool_name="verify_refund",
+                    store=store,
+                )
+                barrier.wait()
+                try:
+                    with execution_scope(
+                        TransitionScope(
+                            run_id="destructive-confirm",
+                            thread_id="verify",
+                            destructive_grants=(grant_c,),
+                        )
+                    ):
+                        wrapped(
+                            payment_id="pay_conc",
+                            tenant_id="acme",
+                            amount=_PAYLOAD,
+                            request_id=request_id,
+                        )
+                except DestructiveGrantError:
+                    return
+
+            threads = [
+                threading.Thread(target=_worker, args=(rid_c1,)),
+                threading.Thread(target=_worker, args=(rid_c2,)),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+            _record(hits["body"] == 1, "concurrent workers consumed one-use grant once")
+    finally:
+        try:
+            from mycelium.destructive_confirm import reset_destructive_clock
+
+            reset_destructive_clock(clock_token)
+        except Exception:
+            failed = True
+            notes.append("cleanup failure: clock reset")
+
+    payload = {
+        "events": events,
+        "notes": notes,
+        "entries": [entry.to_dict() for entry in storage._entries.values()]
+        if hasattr(storage, "_entries")
+        else [],
+    }
+    try:
+        dump.write_text(json.dumps(payload, default=str), encoding="utf-8")
+        leaked = _scan_payload(payload) or _PAYLOAD in dump.read_text(encoding="utf-8")
+        _record(not leaked, "evidence omitted destructive payload")
+    except Exception:
+        failed = True
+        notes.append("cleanup failure: artifact dump")
+
+    reset_destructive_confirm_state()
+    status = VerificationStatus.FAIL if failed else VerificationStatus.PASS
+    return VerificationEvidence(
+        scenario="destructive-confirm",
+        backend=iso.backend,
+        namespace=iso.namespace.prefix,
+        attempts=len(notes),
+        body_executions=events.count("body"),
+        ledger_decisions=notes,
+        duration=time.time() - started,
+        expected_behavior=(
+            "Missing, mismatched, expired, or exhausted grants fail closed "
+            "before claim. One exact grant permits one execution; retries "
+            "reuse the ledger result. Concurrent workers cannot consume a "
+            "one-use grant twice. Evidence omits the payload."
+        ),
+        observed_behavior="; ".join(notes),
+        artifacts=[str(dump), *iso.artifact_paths()],
+        limitations=[
+            "Synthetic tools only; no real destructive provider was contacted.",
+            "Grants must be minted by the host; doctor cannot prove call sites.",
+            "A grant authorizes an attempt, not the provider's final outcome.",
+        ],
+        status=status,
+        summary=(
+            "Destructive confirmation blocked ungranted objects before claim"
+            if not failed
+            else "Destructive confirmation failed a selected assertion"
+        ),
+        remediation=""
+        if status is VerificationStatus.PASS
+        else "Issue an exact host grant; tool permission is not object authorization.",
+    )

--- a/sdk/mycelium/verify/scenarios/use_time_currency.py
+++ b/sdk/mycelium/verify/scenarios/use_time_currency.py
@@ -1,0 +1,423 @@
+"""Use-time currency: stale/changed decide-time facts never cross the boundary."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from mycelium.action_ledger import InMemoryLedgerStorage, ledger_sync, side_effect
+from mycelium.transition import SideEffectBoundary, TransitionScope, execution_scope
+from mycelium.use_time_currency import (
+    UseTimeCurrencyError,
+    UseTimeCurrencyPolicy,
+    UseTimeFactSpec,
+    UseTimeToolPolicy,
+    ValidatorResult,
+    apply_use_time_currency,
+    register_use_time_validator,
+    reset_use_time_currency_state,
+    set_use_time_clock,
+    use_time_facts,
+)
+from mycelium.verify.registry import ScenarioContext, verify_scenario
+from mycelium.verify.types import VerificationEvidence, VerificationStatus
+from mycelium.verify.workers import synthetic_binding
+
+_PAYLOAD = "INTERNAL_USE_TIME_SECRET_VERIFY_ONLY"
+
+
+def _scan_payload(value: Any) -> bool:
+    try:
+        text = json.dumps(value, default=str)
+    except TypeError:
+        text = repr(value)
+    return _PAYLOAD in text
+
+
+class _HoldLeaseStorage(InMemoryLedgerStorage):
+    def __init__(self, events: list[str], hold: threading.Event, release: threading.Event):
+        super().__init__()
+        self.events = events
+        self.hold = hold
+        self.release = release
+        self._first = True
+
+    def try_claim_inflight(self, entry, *, lease_ttl: float = 3600.0):
+        self.events.append("claim_attempt")
+        if self._first:
+            self._first = False
+            self.hold.set()
+            self.release.wait(timeout=5.0)
+        self.events.append("claim")
+        return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+
+def _policy() -> UseTimeCurrencyPolicy:
+    return UseTimeCurrencyPolicy(
+        enabled=True,
+        missing_policy="error",
+        policy_version="verify-utc",
+        tools={
+            "verify_refund": UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name="payment.refundable",
+                        subject_type="payment",
+                        id_from="payment_id",
+                        validator="payment_state",
+                        require={"value": True},
+                        revision_from="payment_version",
+                        max_age_seconds=30,
+                        bind_request_id=True,
+                    ),
+                )
+            )
+        },
+    )
+
+
+def _wrap(storage, *, events: list[str], state: dict[str, Any]):
+    binding = synthetic_binding()
+
+    def payment_state(*, fact, subject_id, **_kwargs):
+        current = state.get(str(subject_id), {})
+        return ValidatorResult(
+            current=bool(current.get("refundable", False)),
+            revision=str(current.get("version", "")),
+            value=bool(current.get("refundable", False)),
+            reason="valid" if current.get("refundable") else "condition_false",
+        )
+
+    register_use_time_validator("payment_state", payment_state)
+
+    def verify_refund(
+        payment_id: str,
+        payment_version: str,
+        amount: str = "10",
+        crash: bool = False,
+    ) -> dict[str, Any]:
+        events.append("body")
+        if crash:
+            with side_effect():
+                raise RuntimeError("verify crash after possible boundary")
+        return {"refunded": True, "payment_id": payment_id, "amount": amount}
+
+    ledgered = ledger_sync(
+        storage=storage,
+        transition_binding=binding,
+        lease_ttl=30.0,
+        lease_renew_interval=0,
+        poll_interval=0.02,
+        poll_timeout=5.0,
+    )(verify_refund)
+    return apply_use_time_currency(
+        ledgered, _policy(), tool_name="verify_refund"
+    )
+
+
+@verify_scenario("use-time-currency")
+def run_use_time_currency(ctx: ScenarioContext) -> VerificationEvidence:
+    started = time.time()
+    reset_use_time_currency_state()
+    iso = ctx.isolation
+    events: list[str] = []
+    state: dict[str, Any] = {
+        "pay_1": {"refundable": True, "version": "1"},
+        "pay_stale": {"refundable": True, "version": "1"},
+        "pay_change": {"refundable": True, "version": "1"},
+    }
+    storage = InMemoryLedgerStorage()
+    refund = _wrap(storage, events=events, state=state)
+    dump = Path(iso.artifact_file("use-time-currency-dump-"))
+    notes: list[str] = []
+    failed = False
+    clock = {"now": 1_000.0}
+    set_use_time_clock(lambda: clock["now"])
+
+    def _record(ok: bool, note: str) -> None:
+        nonlocal failed
+        notes.append(note if ok else f"FAIL: {note}")
+        if not ok:
+            failed = True
+
+    with execution_scope(TransitionScope(run_id="use-time-currency", thread_id="verify")):
+        # Current fact permits execution.
+        rid_ok = iso.track(iso.namespace.request_id("use-time-currency", "ok"))
+        use_time_facts.capture(
+            name="payment.refundable",
+            subject_type="payment",
+            subject_id="pay_1",
+            value=True,
+            revision="1",
+            max_age_seconds=30,
+            request_id=rid_ok,
+            require_value=True,
+        )
+        events.clear()
+        out = refund(
+            payment_id="pay_1",
+            payment_version="1",
+            amount="10",
+            request_id=rid_ok,
+            run_id="use-time-currency",
+        )
+        _record(out.get("refunded") is True and "body" in events, "current fact allows body")
+
+        # Decide-time true, use-time false blocks.
+        rid_false = iso.track(iso.namespace.request_id("use-time-currency", "false"))
+        use_time_facts.capture(
+            name="payment.refundable",
+            subject_type="payment",
+            subject_id="pay_change",
+            value=True,
+            revision="1",
+            max_age_seconds=30,
+            request_id=rid_false,
+            require_value=True,
+        )
+        state["pay_change"] = {"refundable": False, "version": "1"}
+        events.clear()
+        err: list[BaseException] = []
+        try:
+            refund(
+                payment_id="pay_change",
+                payment_version="1",
+                request_id=rid_false,
+                run_id="use-time-currency",
+            )
+        except UseTimeCurrencyError as exc:
+            err.append(exc)
+        entry = storage.get(rid_false)
+        _record(
+            len(err) == 1
+            and err[0].reason == "condition_false"
+            and "body" not in events
+            and (
+                entry is None
+                or entry.side_effect_boundary != SideEffectBoundary.MAYBE_CROSSED
+            ),
+            "use-time false blocks without maybe_crossed",
+        )
+
+        # Revision mismatch.
+        rid_rev = iso.track(iso.namespace.request_id("use-time-currency", "rev"))
+        state["pay_1"] = {"refundable": True, "version": "2"}
+        use_time_facts.capture(
+            name="payment.refundable",
+            subject_type="payment",
+            subject_id="pay_1",
+            value=True,
+            revision="1",
+            max_age_seconds=30,
+            request_id=rid_rev,
+            require_value=True,
+        )
+        events.clear()
+        err.clear()
+        try:
+            refund(
+                payment_id="pay_1",
+                payment_version="1",
+                request_id=rid_rev,
+                run_id="use-time-currency",
+            )
+        except UseTimeCurrencyError as exc:
+            err.append(exc)
+        _record(
+            len(err) == 1
+            and err[0].reason == "revision_mismatch"
+            and "body" not in events,
+            "revision mismatch blocks",
+        )
+        state["pay_1"] = {"refundable": True, "version": "1"}
+
+        # Max-age stale.
+        rid_age = iso.track(iso.namespace.request_id("use-time-currency", "age"))
+        use_time_facts.capture(
+            name="payment.refundable",
+            subject_type="payment",
+            subject_id="pay_stale",
+            value=True,
+            revision="1",
+            max_age_seconds=30,
+            request_id=rid_age,
+            require_value=True,
+            observed_at=__import__("datetime").datetime.fromtimestamp(
+                clock["now"], tz=__import__("datetime").UTC
+            ),
+        )
+        clock["now"] = 1_040.0
+        events.clear()
+        err.clear()
+        try:
+            refund(
+                payment_id="pay_stale",
+                payment_version="1",
+                request_id=rid_age,
+                run_id="use-time-currency",
+            )
+        except UseTimeCurrencyError as exc:
+            err.append(exc)
+        _record(
+            len(err) == 1 and err[0].reason == "stale" and "body" not in events,
+            "max_age stale blocks",
+        )
+        clock["now"] = 1_000.0
+
+        # Missing validator.
+        rid_missing = iso.track(iso.namespace.request_id("use-time-currency", "missing-v"))
+        reset_use_time_currency_state()
+        set_use_time_clock(lambda: clock["now"])
+        refund2 = _wrap(InMemoryLedgerStorage(), events=events, state=state)
+        # Drop validator registration after wrap rebuilt it — clear and re-apply.
+        from mycelium.use_time_currency import _validators
+
+        _validators.pop("payment_state", None)
+        use_time_facts.capture(
+            name="payment.refundable",
+            subject_type="payment",
+            subject_id="pay_1",
+            value=True,
+            revision="1",
+            max_age_seconds=30,
+            request_id=rid_missing,
+            require_value=True,
+        )
+        events.clear()
+        err.clear()
+        try:
+            refund2(
+                payment_id="pay_1",
+                payment_version="1",
+                request_id=rid_missing,
+                run_id="use-time-currency",
+            )
+        except UseTimeCurrencyError as exc:
+            err.append(exc)
+        _record(
+            len(err) == 1
+            and err[0].reason == "validator_missing"
+            and "body" not in events,
+            "missing validator blocks",
+        )
+
+        # Fact change during lease wait.
+        reset_use_time_currency_state()
+        set_use_time_clock(lambda: clock["now"])
+        events.clear()
+        hold = threading.Event()
+        release = threading.Event()
+        hold_storage = _HoldLeaseStorage(events, hold, release)
+        state["pay_lease"] = {"refundable": True, "version": "1"}
+        refund3 = _wrap(hold_storage, events=events, state=state)
+        rid_lease = iso.track(iso.namespace.request_id("use-time-currency", "lease"))
+        use_time_facts.capture(
+            name="payment.refundable",
+            subject_type="payment",
+            subject_id="pay_lease",
+            value=True,
+            revision="1",
+            max_age_seconds=30,
+            request_id=rid_lease,
+            require_value=True,
+        )
+        err.clear()
+
+        def _run() -> None:
+            try:
+                refund3(
+                    payment_id="pay_lease",
+                    payment_version="1",
+                    request_id=rid_lease,
+                    run_id="use-time-currency",
+                )
+            except UseTimeCurrencyError as exc:
+                err.append(exc)
+
+        thread = threading.Thread(target=_run)
+        thread.start()
+        hold.wait(timeout=5.0)
+        state["pay_lease"] = {"refundable": False, "version": "1"}
+        release.set()
+        thread.join(timeout=5.0)
+        _record(
+            len(err) == 1 and "body" not in events,
+            "fact change during lease wait blocks",
+        )
+
+        # Completed RETURN without revalidation body.
+        reset_use_time_currency_state()
+        set_use_time_clock(lambda: clock["now"])
+        storage4 = InMemoryLedgerStorage()
+        state["pay_ret"] = {"refundable": True, "version": "1"}
+        refund4 = _wrap(storage4, events=events, state=state)
+        rid_ret = iso.track(iso.namespace.request_id("use-time-currency", "return"))
+        use_time_facts.capture(
+            name="payment.refundable",
+            subject_type="payment",
+            subject_id="pay_ret",
+            value=True,
+            revision="1",
+            max_age_seconds=30,
+            request_id=rid_ret,
+            require_value=True,
+        )
+        events.clear()
+        first = refund4(
+            payment_id="pay_ret",
+            payment_version="1",
+            request_id=rid_ret,
+            run_id="use-time-currency",
+        )
+        state["pay_ret"] = {"refundable": False, "version": "9"}
+        events.clear()
+        second = refund4(
+            payment_id="pay_ret",
+            payment_version="1",
+            request_id=rid_ret,
+            run_id="use-time-currency",
+        )
+        _record(
+            first == second and "body" not in events,
+            "completed RETURN skips body and use revalidation",
+        )
+
+    dump.write_text(json.dumps({"notes": notes, "events": events}, indent=2), encoding="utf-8")
+    leaked = _scan_payload(notes) or _scan_payload(events)
+    reset_use_time_currency_state()
+
+    status = VerificationStatus.FAIL if failed or leaked else VerificationStatus.PASS
+    return VerificationEvidence(
+        scenario="use-time-currency",
+        backend=iso.backend,
+        namespace=iso.namespace.prefix,
+        attempts=len(notes),
+        body_executions=events.count("body"),
+        ledger_decisions=notes,
+        duration=time.time() - started,
+        expected_behavior=(
+            "Current facts may execute. Stale, changed, missing, or unverifiable "
+            "facts hard-block with no body and no maybe_crossed. Completed RETURN "
+            "skips use revalidation. Authority-window and use-time currency together "
+            "complete the batch guarantee."
+        ),
+        observed_behavior="; ".join(notes),
+        artifacts=[str(dump), *iso.artifact_paths()],
+        limitations=[
+            "Synthetic tools and fake fact stores only; no real provider.",
+            "Local revalidation cannot eliminate a fact change during a remote call.",
+            "Validator correctness and replica consistency are host responsibilities.",
+        ],
+        status=status,
+        summary=(
+            "use-time currency blocks stale/changed facts"
+            if status == VerificationStatus.PASS
+            else "use-time currency scenario failed"
+        ),
+        remediation=""
+        if status == VerificationStatus.PASS
+        else "Inspect use-time-currency-dump artifact.",
+    )

--- a/sdk/mycelium/verify/scenarios/use_time_currency.py
+++ b/sdk/mycelium/verify/scenarios/use_time_currency.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -245,8 +246,8 @@ def run_use_time_currency(ctx: ScenarioContext) -> VerificationEvidence:
             max_age_seconds=30,
             request_id=rid_age,
             require_value=True,
-            observed_at=__import__("datetime").datetime.fromtimestamp(
-                clock["now"], tz=__import__("datetime").UTC
+            observed_at=datetime.fromtimestamp(
+                clock["now"], tz=timezone.utc
             ),
         )
         clock["now"] = 1_040.0

--- a/sdk/mycelium/verify/workers.py
+++ b/sdk/mycelium/verify/workers.py
@@ -378,7 +378,9 @@ def crash_worker(payload: dict[str, Any]) -> None:
             },
             binding,
         )
-        token = _active_transition_var.set(_ActiveTransition(ledger, request_id, binding))
+        token = _active_transition_var.set(
+            _ActiveTransition(ledger, request_id, binding, {})
+        )
         try:
             if phase == "after_claim":
                 _append_line(payload["ready_file"], "after_claim")

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.32.0"
+version = "1.33.0"
 description = "The reliability layer for AI agents — prove run-or-not and enforce at-most-once at the tool boundary"
 authors = [
   { name = "Nandana Dileep" },

--- a/sdk/tests/test_authority_window.py
+++ b/sdk/tests/test_authority_window.py
@@ -1,0 +1,551 @@
+"""Authority-window expiry: use-time revalidation before side effects."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from mycelium.action_ledger import InMemoryLedgerStorage, ledger_sync, side_effect
+from mycelium.authority_window import (
+    AuthorityExpiredError,
+    AuthorityValidationPhase,
+    AuthorityWindowPolicy,
+    BoundAuthority,
+    as_utc_datetime,
+    enforce_pending_authorities_at_use,
+    get_authority_decisions,
+    register_authority_for_use,
+    reset_authority_window_state,
+    set_authority_clock,
+    set_authority_window_policy,
+    validate_authority,
+    validate_authority_at_use,
+)
+from mycelium.config import ConfigError, load_config_from_string
+from mycelium.destructive_confirm import (
+    DestructiveConfirmPolicy,
+    DestructiveGrantSpec,
+    DestructiveObjectSpec,
+    DestructiveToolPolicy,
+    InMemoryDestructiveGrantStore,
+    apply_destructive_confirm,
+    issue_destructive_grant,
+    reset_destructive_confirm_state,
+    set_destructive_clock,
+    set_destructive_grant_store,
+)
+from mycelium.transition import (
+    SideEffectBoundary,
+    SideEffectClass,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+)
+
+
+@pytest.fixture(autouse=True)
+def store() -> Any:
+    reset_destructive_confirm_state()
+    reset_authority_window_state()
+    grant_store = InMemoryDestructiveGrantStore()
+    set_destructive_grant_store(grant_store)
+    set_authority_window_policy(
+        AuthorityWindowPolicy(enabled=True, use_time_check="required")
+    )
+    yield grant_store
+    reset_destructive_confirm_state()
+    reset_authority_window_state()
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="test",
+        policy_version="test",
+        side_effect_class=SideEffectClass.KEYED_MUTATE,
+    )
+
+
+def _policy() -> DestructiveConfirmPolicy:
+    return DestructiveConfirmPolicy(
+        enabled=True,
+        missing_policy="error",
+        policy_version="test",
+        tools={
+            "refund_payment": DestructiveToolPolicy(
+                operation="refund",
+                object=DestructiveObjectSpec(
+                    object_type="payment",
+                    id_from="payment_id",
+                    tenant_from="tenant_id",
+                ),
+                grant=DestructiveGrantSpec(
+                    bind_request_id=True, max_uses=1, ttl_seconds=300
+                ),
+            )
+        },
+    )
+
+
+def _bound(*, expires_at: datetime, tool: str = "refund_payment") -> BoundAuthority:
+    return BoundAuthority(
+        authority_id="auth-1",
+        authority_kind="destructive_grant",
+        expires_at=expires_at,
+        tool=tool,
+        operation="refund",
+        object_ref="payment:pay_1",
+        policy_version="test",
+    )
+
+
+def test_valid_before_expiry_allows() -> None:
+    clock = {"now": 1_000.0}
+    set_authority_clock(lambda: clock["now"])
+    auth = _bound(expires_at=datetime.fromtimestamp(1_100.0, tz=UTC))
+    decision = validate_authority(auth, phase=AuthorityValidationPhase.AUTHORIZE)
+    assert decision.decision == "allowed"
+    register_authority_for_use(auth)
+    use = validate_authority_at_use()
+    assert use.decision == "allowed"
+    assert use.phase == "use"
+
+
+def test_exact_boundary_expires() -> None:
+    clock = {"now": 1_000.0}
+    set_authority_clock(lambda: clock["now"])
+    auth = _bound(expires_at=datetime.fromtimestamp(1_000.0, tz=UTC))
+    with pytest.raises(AuthorityExpiredError):
+        validate_authority(auth, phase=AuthorityValidationPhase.USE)
+
+
+def test_naive_timestamp_rejected() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        BoundAuthority(
+            authority_id="a",
+            authority_kind="test",
+            expires_at=datetime(2026, 1, 1, 0, 0, 0),
+            tool="t",
+        )
+
+
+def test_injected_clock_and_delay_between_phases() -> None:
+    clock = {"now": 1_000.0}
+    set_authority_clock(lambda: clock["now"])
+    auth = _bound(expires_at=datetime.fromtimestamp(1_050.0, tz=UTC))
+    validate_authority(auth, phase=AuthorityValidationPhase.AUTHORIZE)
+    register_authority_for_use(auth)
+    clock["now"] = 1_060.0
+    with pytest.raises(AuthorityExpiredError) as exc:
+        enforce_pending_authorities_at_use()
+    assert exc.value.phase == "use"
+
+
+def test_skew_narrows_never_extends() -> None:
+    clock = {"now": 1_000.0}
+    set_authority_clock(lambda: clock["now"])
+    set_authority_window_policy(
+        AuthorityWindowPolicy(
+            enabled=True,
+            use_time_check="required",
+            clock_skew_tolerance_seconds=10,
+        )
+    )
+    auth = _bound(expires_at=datetime.fromtimestamp(1_005.0, tz=UTC))
+    with pytest.raises(AuthorityExpiredError):
+        validate_authority_at_use(auth)
+
+
+def test_timeless_and_omitted_unchanged() -> None:
+    reset_authority_window_state()
+    decision = validate_authority_at_use(None)
+    assert decision.decision == "skipped"
+    assert decision.reason == "timeless"
+
+
+def test_model_mapping_rejected() -> None:
+    with pytest.raises(AuthorityExpiredError, match="BoundAuthority"):
+        validate_authority({"expires_at": 1}, phase=AuthorityValidationPhase.USE)
+
+
+def test_destructive_expire_before_use_no_body(store: InMemoryDestructiveGrantStore) -> None:
+    clock = {"now": 1_000.0}
+    set_destructive_clock(lambda: clock["now"])
+    events: list[str] = []
+
+    def refund_payment(payment_id: str, tenant_id: str, amount: str) -> str:
+        events.append("body")
+        return payment_id
+
+    grant = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        tenant="acme",
+        request_id="aw-1",
+        expires_in=30,
+        policy_version="test",
+        store=store,
+        bind_request_id=True,
+    )
+    clock["now"] = grant.expires_at - 1
+    hold = threading.Event()
+    release = threading.Event()
+
+    class HoldStorage(InMemoryLedgerStorage):
+        def try_claim_inflight(self, entry, *, lease_ttl: float = 3600.0):
+            hold.set()
+            release.wait(timeout=5.0)
+            return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+    hold_storage = HoldStorage()
+    held = apply_destructive_confirm(
+        ledger_sync(storage=hold_storage, transition_binding=_binding())(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+        store=store,
+    )
+    err: list[BaseException] = []
+    import contextvars
+
+    ctx = contextvars.copy_context()
+
+    def worker() -> None:
+        try:
+            with execution_scope(
+                TransitionScope(
+                    run_id="r", thread_id="t", destructive_grants=(grant,)
+                )
+            ):
+                held(
+                    payment_id="pay_1",
+                    tenant_id="acme",
+                    amount="SECRET",
+                    request_id="aw-1",
+                )
+        except BaseException as exc:  # noqa: BLE001
+            err.append(exc)
+
+    thread = threading.Thread(target=lambda: ctx.run(worker))
+    thread.start()
+    hold.wait(timeout=5.0)
+    clock["now"] = grant.expires_at
+    release.set()
+    thread.join(timeout=10.0)
+    assert len(err) == 1
+    assert isinstance(err[0], AuthorityExpiredError)
+    assert events == []
+    entry = hold_storage.get("aw-1")
+    assert entry is None or entry.side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_completed_retry_without_fresh_authority(
+    store: InMemoryDestructiveGrantStore,
+) -> None:
+    clock = {"now": 1_000.0}
+    set_destructive_clock(lambda: clock["now"])
+    storage = InMemoryLedgerStorage()
+    hits = {"n": 0}
+
+    def refund_payment(payment_id: str, tenant_id: str, amount: str) -> str:
+        hits["n"] += 1
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        ledger_sync(storage=storage, transition_binding=_binding())(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+        store=store,
+    )
+    grant = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        tenant="acme",
+        request_id="aw-ret",
+        expires_in=60,
+        policy_version="test",
+        store=store,
+        bind_request_id=True,
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        assert wrapped(
+            payment_id="pay_1", tenant_id="acme", amount="x", request_id="aw-ret"
+        ) == "pay_1"
+    clock["now"] = grant.expires_at + 100
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        assert wrapped(
+            payment_id="pay_1", tenant_id="acme", amount="x", request_id="aw-ret"
+        ) == "pay_1"
+    assert hits["n"] == 1
+
+
+def test_ambiguous_not_converted_to_permission(
+    store: InMemoryDestructiveGrantStore,
+) -> None:
+    from mycelium.action_ledger import LedgerHardBlockError
+
+    clock = {"now": 1_000.0}
+    set_destructive_clock(lambda: clock["now"])
+    storage = InMemoryLedgerStorage()
+
+    def refund_payment(payment_id: str, tenant_id: str, amount: str) -> str:
+        with side_effect():
+            raise RuntimeError("boom")
+
+    wrapped = apply_destructive_confirm(
+        ledger_sync(storage=storage, transition_binding=_binding())(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+        store=store,
+    )
+    grant = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        tenant="acme",
+        request_id="aw-amb",
+        expires_in=300,
+        policy_version="test",
+        store=store,
+        bind_request_id=True,
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        with pytest.raises(Exception):
+            wrapped(
+                payment_id="pay_1",
+                tenant_id="acme",
+                amount="x",
+                request_id="aw-amb",
+            )
+    grant2 = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        tenant="acme",
+        request_id="aw-amb",
+        expires_in=300,
+        policy_version="test",
+        store=store,
+        bind_request_id=True,
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant2,))
+    ):
+        with pytest.raises(LedgerHardBlockError):
+            wrapped(
+                payment_id="pay_1",
+                tenant_id="acme",
+                amount="x",
+                request_id="aw-amb",
+            )
+
+
+
+def test_evidence_phases_without_payload(store: InMemoryDestructiveGrantStore) -> None:
+    clock = {"now": 1_000.0}
+    set_destructive_clock(lambda: clock["now"])
+    storage = InMemoryLedgerStorage()
+    secret = "INTERNAL_AUTHORITY_SECRET"
+
+    def refund_payment(payment_id: str, tenant_id: str, amount: str) -> str:
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        ledger_sync(storage=storage, transition_binding=_binding())(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+        store=store,
+    )
+    grant = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        tenant="acme",
+        request_id="aw-ev",
+        expires_in=60,
+        policy_version="test",
+        store=store,
+        bind_request_id=True,
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        wrapped(
+            payment_id="pay_1",
+            tenant_id="acme",
+            amount=secret,
+            request_id="aw-ev",
+        )
+    decisions = get_authority_decisions()
+    assert {item.phase for item in decisions} >= {"authorize", "use"}
+    blob = json.dumps([item.to_dict() for item in decisions], default=str)
+    assert secret not in blob
+    entry = storage.get("aw-ev")
+    assert entry is not None
+    assert secret not in json.dumps(entry.to_dict(), default=str)
+
+
+def test_sync_async_parity(store: InMemoryDestructiveGrantStore) -> None:
+    clock = {"now": 1_000.0}
+    set_destructive_clock(lambda: clock["now"])
+
+    def sync_refund(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    async def async_refund(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    sync_wrapped = apply_destructive_confirm(
+        sync_refund, _policy(), tool_name="refund_payment", store=store
+    )
+    async_wrapped = apply_destructive_confirm(
+        async_refund, _policy(), tool_name="refund_payment", store=store
+    )
+    g1 = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        tenant="acme",
+        request_id="aw-s",
+        expires_in=60,
+        policy_version="test",
+        store=store,
+        bind_request_id=True,
+    )
+    g2 = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_2",
+        tenant="acme",
+        request_id="aw-a",
+        expires_in=60,
+        policy_version="test",
+        store=store,
+        bind_request_id=True,
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(g1,))
+    ):
+        assert sync_wrapped(payment_id="pay_1", tenant_id="acme", request_id="aw-s") == "pay_1"
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(g2,))
+    ):
+        assert asyncio.run(
+            async_wrapped(payment_id="pay_2", tenant_id="acme", request_id="aw-a")
+        ) == "pay_2"
+
+
+def test_config_authority_window_and_production() -> None:
+    cfg = load_config_from_string(
+        """
+profile: development
+tools:
+  refund_payment:
+    side_effect_class: irreversible
+destructive_confirm:
+  enabled: true
+  missing_policy: error
+  tools:
+    refund_payment:
+      operation: refund
+      object: {type: payment, id_from: payment_id}
+      grant: {bind_request_id: true, ttl_seconds: 60, max_uses: 1}
+authority_window:
+  enabled: true
+  use_time_check: required
+  clock_skew_tolerance_seconds: 0
+"""
+    )
+    assert cfg.authority_window is not None
+    assert cfg.authority_window["use_time_check"] == "required"
+
+    from mycelium.config import _parse_authority_window
+
+    with pytest.raises(ConfigError, match="use-time"):
+        _parse_authority_window(
+            {
+                "authority_window": {
+                    "enabled": True,
+                    "use_time_check": "optional",
+                }
+            },
+            profile="production",
+            destructive_confirm={"enabled": True},
+        )
+
+    with pytest.raises(ConfigError, match="clock_skew"):
+        load_config_from_string(
+            """
+profile: development
+authority_window:
+  enabled: true
+  clock_skew_tolerance_seconds: -1
+"""
+        )
+
+
+def test_omitted_config_preserves_behavior_without_destructive() -> None:
+    cfg = load_config_from_string(
+        """
+profile: development
+tools:
+  echo:
+    side_effect_class: read
+"""
+    )
+    assert cfg.authority_window is None
+    assert cfg.destructive_confirm is None
+
+
+def test_as_utc_datetime_epoch() -> None:
+    value = as_utc_datetime(1_700_000_000.0)
+    assert value.tzinfo is not None
+    assert value == datetime.fromtimestamp(1_700_000_000.0, tz=UTC)
+
+
+def test_mark_maybe_crossed_checks_expiry() -> None:
+    from mycelium.action_ledger import mark_maybe_crossed
+
+    clock = {"now": 1_000.0}
+    set_authority_clock(lambda: clock["now"])
+    auth = _bound(expires_at=datetime.fromtimestamp(1_010.0, tz=UTC))
+    register_authority_for_use(auth)
+    clock["now"] = 1_020.0
+    with pytest.raises(AuthorityExpiredError):
+        mark_maybe_crossed()
+
+
+def test_negative_ttl_rejected_at_issue(store: InMemoryDestructiveGrantStore) -> None:
+    with pytest.raises(ValueError, match="expires_in"):
+        issue_destructive_grant(
+            operation="refund",
+            object_type="payment",
+            object_id="pay_1",
+            expires_in=-1,
+            store=store,
+        )
+
+
+def test_policy_version_mismatch_at_use() -> None:
+    clock = {"now": 1_000.0}
+    set_authority_clock(lambda: clock["now"])
+    auth = BoundAuthority(
+        authority_id="a",
+        authority_kind="destructive_grant",
+        expires_at=datetime.now(UTC) + timedelta(seconds=60),
+        tool="refund_payment",
+        policy_version="v1",
+    )
+    with pytest.raises(AuthorityExpiredError, match="policy version"):
+        validate_authority_at_use(auth, expected_policy_version="v2")

--- a/sdk/tests/test_authority_window.py
+++ b/sdk/tests/test_authority_window.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -106,7 +106,7 @@ def _bound(*, expires_at: datetime, tool: str = "refund_payment") -> BoundAuthor
 def test_valid_before_expiry_allows() -> None:
     clock = {"now": 1_000.0}
     set_authority_clock(lambda: clock["now"])
-    auth = _bound(expires_at=datetime.fromtimestamp(1_100.0, tz=UTC))
+    auth = _bound(expires_at=datetime.fromtimestamp(1_100.0, tz=timezone.utc))
     decision = validate_authority(auth, phase=AuthorityValidationPhase.AUTHORIZE)
     assert decision.decision == "allowed"
     register_authority_for_use(auth)
@@ -118,7 +118,7 @@ def test_valid_before_expiry_allows() -> None:
 def test_exact_boundary_expires() -> None:
     clock = {"now": 1_000.0}
     set_authority_clock(lambda: clock["now"])
-    auth = _bound(expires_at=datetime.fromtimestamp(1_000.0, tz=UTC))
+    auth = _bound(expires_at=datetime.fromtimestamp(1_000.0, tz=timezone.utc))
     with pytest.raises(AuthorityExpiredError):
         validate_authority(auth, phase=AuthorityValidationPhase.USE)
 
@@ -136,7 +136,7 @@ def test_naive_timestamp_rejected() -> None:
 def test_injected_clock_and_delay_between_phases() -> None:
     clock = {"now": 1_000.0}
     set_authority_clock(lambda: clock["now"])
-    auth = _bound(expires_at=datetime.fromtimestamp(1_050.0, tz=UTC))
+    auth = _bound(expires_at=datetime.fromtimestamp(1_050.0, tz=timezone.utc))
     validate_authority(auth, phase=AuthorityValidationPhase.AUTHORIZE)
     register_authority_for_use(auth)
     clock["now"] = 1_060.0
@@ -155,7 +155,7 @@ def test_skew_narrows_never_extends() -> None:
             clock_skew_tolerance_seconds=10,
         )
     )
-    auth = _bound(expires_at=datetime.fromtimestamp(1_005.0, tz=UTC))
+    auth = _bound(expires_at=datetime.fromtimestamp(1_005.0, tz=timezone.utc))
     with pytest.raises(AuthorityExpiredError):
         validate_authority_at_use(auth)
 
@@ -511,7 +511,7 @@ tools:
 def test_as_utc_datetime_epoch() -> None:
     value = as_utc_datetime(1_700_000_000.0)
     assert value.tzinfo is not None
-    assert value == datetime.fromtimestamp(1_700_000_000.0, tz=UTC)
+    assert value == datetime.fromtimestamp(1_700_000_000.0, tz=timezone.utc)
 
 
 def test_mark_maybe_crossed_checks_expiry() -> None:
@@ -519,7 +519,7 @@ def test_mark_maybe_crossed_checks_expiry() -> None:
 
     clock = {"now": 1_000.0}
     set_authority_clock(lambda: clock["now"])
-    auth = _bound(expires_at=datetime.fromtimestamp(1_010.0, tz=UTC))
+    auth = _bound(expires_at=datetime.fromtimestamp(1_010.0, tz=timezone.utc))
     register_authority_for_use(auth)
     clock["now"] = 1_020.0
     with pytest.raises(AuthorityExpiredError):
@@ -543,7 +543,7 @@ def test_policy_version_mismatch_at_use() -> None:
     auth = BoundAuthority(
         authority_id="a",
         authority_kind="destructive_grant",
-        expires_at=datetime.now(UTC) + timedelta(seconds=60),
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
         tool="refund_payment",
         policy_version="v1",
     )

--- a/sdk/tests/test_destructive_confirm.py
+++ b/sdk/tests/test_destructive_confirm.py
@@ -1,0 +1,904 @@
+"""Destructive-confirm: host grants, not tool permission, authorize the object."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from typing import Any
+
+import pytest
+
+from mycelium import (
+    PAYLOAD_OMITTED,
+    ConfigError,
+    DestructiveGrant,
+    DestructiveGrantError,
+    InMemoryLedgerStorage,
+    apply_destructive_confirm,
+    enforce_destructive_confirm,
+    issue_destructive_grant,
+    ledger_sync,
+    load_config_from_string,
+    register_destructive_object_canonicalizer,
+    side_effect,
+)
+from mycelium.action_ledger import ARGS_DRIFT_HARD
+from mycelium.destructive_confirm import (
+    DestructiveConfirmPolicy,
+    DestructiveGrantSpec,
+    DestructiveObjectSpec,
+    DestructiveToolPolicy,
+    FileDestructiveGrantStore,
+    InMemoryDestructiveGrantStore,
+    canonicalize_object_id,
+    reset_destructive_confirm_state,
+    sanitize_destructive_evidence,
+    set_destructive_clock,
+    set_destructive_grant_store,
+)
+from mycelium.doctor.types import DoctorStatus
+from mycelium.transition import (
+    SideEffectClass,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    reset_destructive_confirm_state()
+    yield
+    reset_destructive_confirm_state()
+
+
+def _policy(**overrides: Any) -> DestructiveConfirmPolicy:
+    spec = DestructiveObjectSpec(
+        object_type="payment",
+        id_from="payment_id",
+        tenant_from="tenant_id",
+        case_sensitive=True,
+    )
+    grant = DestructiveGrantSpec(bind_request_id=True, max_uses=1, ttl_seconds=300)
+    tools = {
+        "refund_payment": DestructiveToolPolicy(
+            operation="refund", object=spec, grant=grant
+        )
+    }
+    tools.update(overrides)
+    return DestructiveConfirmPolicy(
+        enabled=True,
+        missing_policy="error",
+        policy_version="test",
+        tools=tools,
+    )
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="test",
+        policy_version="test",
+        side_effect_class=SideEffectClass.IRREVERSIBLE,
+    )
+
+
+def _issue(**kwargs: Any) -> DestructiveGrant:
+    store = get_or_store()
+    defaults = dict(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        tenant="acme",
+        expires_in=300,
+        max_uses=1,
+        policy_version="test",
+        store=store,
+        bind_request_id=True,
+    )
+    defaults.update(kwargs)
+    return issue_destructive_grant(**defaults)
+
+
+def get_or_store() -> InMemoryDestructiveGrantStore:
+    from mycelium.destructive_confirm import get_destructive_grant_store
+
+    store = get_destructive_grant_store()
+    if store is None:
+        store = InMemoryDestructiveGrantStore()
+        set_destructive_grant_store(store)
+    return store  # type: ignore[return-value]
+
+
+def test_missing_grant_blocks_before_claim() -> None:
+    events: list[str] = []
+    storage = InMemoryLedgerStorage()
+
+    def refund_payment(payment_id: str, tenant_id: str, amount: str) -> str:
+        events.append("body")
+        return payment_id
+
+    class Rec(InMemoryLedgerStorage):
+        def try_claim_inflight(self, entry, *, lease_ttl: float = 3600.0):
+            events.append("claim")
+            return super().try_claim_inflight(entry, lease_ttl=lease_ttl)
+
+    storage = Rec()
+    wrapped = apply_destructive_confirm(
+        ledger_sync(storage=storage, transition_binding=_binding())(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+        store=get_or_store(),
+    )
+    with execution_scope(TransitionScope(run_id="r", thread_id="t")):
+        with pytest.raises(DestructiveGrantError, match="missing"):
+            wrapped(payment_id="pay_1", tenant_id="acme", amount="10", request_id="dc-miss")
+    assert events == []
+
+
+def test_exact_grant_permits_one_execution_and_retry_reuses() -> None:
+    events: list[str] = []
+    store = get_or_store()
+    grant = _issue(request_id="dc-ok", object_id="pay_1")
+
+    def refund_payment(payment_id: str, tenant_id: str, amount: str) -> str:
+        events.append("body")
+        return f"ok:{payment_id}"
+
+    wrapped = apply_destructive_confirm(
+        ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=_binding())(
+            refund_payment
+        ),
+        _policy(),
+        tool_name="refund_payment",
+        store=store,
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        first = wrapped(
+            payment_id="pay_1", tenant_id="acme", amount="10", request_id="dc-ok"
+        )
+        second = wrapped(
+            payment_id="pay_1", tenant_id="acme", amount="10", request_id="dc-ok"
+        )
+    assert first == second == "ok:pay_1"
+    assert events == ["body"]
+    rec = store.get(grant.grant_id)
+    assert rec is not None
+    assert rec["uses_remaining"] == 0
+
+
+def test_wrong_operation_and_object_and_tenant_block() -> None:
+    store = get_or_store()
+    grant = _issue(request_id="dc-mismatch", object_id="pay_1", tenant="acme")
+    policy = _policy(
+        cancel_payment=DestructiveToolPolicy(
+            operation="cancel",
+            object=DestructiveObjectSpec(
+                object_type="payment", id_from="payment_id", tenant_from="tenant_id"
+            ),
+            grant=DestructiveGrantSpec(bind_request_id=True, max_uses=1, ttl_seconds=300),
+        )
+    )
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    def cancel_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    refund = apply_destructive_confirm(
+        refund_payment, policy, tool_name="refund_payment", store=store
+    )
+    cancel = apply_destructive_confirm(
+        cancel_payment, policy, tool_name="cancel_payment", store=store
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        with pytest.raises(DestructiveGrantError) as wrong_op:
+            cancel(payment_id="pay_1", tenant_id="acme", request_id="dc-mismatch")
+        assert wrong_op.value.reason in {"mismatched", "identity_drift"}
+        with pytest.raises(DestructiveGrantError) as wrong_obj:
+            refund(payment_id="pay_2", tenant_id="acme", request_id="dc-mismatch")
+        assert wrong_obj.value.reason in {"mismatched", "identity_drift"}
+        with pytest.raises(DestructiveGrantError) as wrong_tenant:
+            refund(payment_id="pay_1", tenant_id="other", request_id="dc-mismatch")
+        assert wrong_tenant.value.reason == "mismatched"
+
+
+def test_nested_argument_path() -> None:
+    store = get_or_store()
+    policy = DestructiveConfirmPolicy(
+        enabled=True,
+        policy_version="test",
+        tools={
+            "refund_payment": DestructiveToolPolicy(
+                operation="refund",
+                object=DestructiveObjectSpec(
+                    object_type="payment",
+                    id_from="payment.id",
+                    tenant_from="payment.tenant",
+                ),
+                grant=DestructiveGrantSpec(bind_request_id=True, max_uses=1, ttl_seconds=60),
+            )
+        },
+    )
+    grant = _issue(request_id="dc-nested", object_id="pay_n", tenant="acme")
+
+    def refund_payment(payment: dict[str, str], **_: Any) -> str:
+        return payment["id"]
+
+    wrapped = apply_destructive_confirm(
+        refund_payment, policy, tool_name="refund_payment", store=store
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        assert (
+            wrapped(payment={"id": "pay_n", "tenant": "acme"}, request_id="dc-nested")
+            == "pay_n"
+        )
+
+
+def test_canonicalization_rejects_bypass_forms() -> None:
+    with pytest.raises(Exception):
+        canonicalize_object_id("pay_1/../pay_2", object_type="payment")
+    with pytest.raises(Exception):
+        canonicalize_object_id("pay%31", object_type="payment")
+    with pytest.raises(Exception):
+        canonicalize_object_id("http://evil/pay_1", object_type="payment")
+    with pytest.raises(Exception):
+        canonicalize_object_id(" pay_1", object_type="payment")
+    with pytest.raises(Exception):
+        canonicalize_object_id("", object_type="payment")
+    with pytest.raises(Exception):
+        canonicalize_object_id(123, object_type="payment")  # type: ignore[arg-type]
+    register_destructive_object_canonicalizer("payment", lambda value: str(value).strip())
+    assert canonicalize_object_id("pay_1", object_type="payment") == "pay_1"
+
+
+def test_custom_canonicalizer_runs_before_claim() -> None:
+    store = get_or_store()
+    seen: list[str] = []
+
+    def canon(value: Any) -> str:
+        seen.append(str(value))
+        return str(value)
+
+    register_destructive_object_canonicalizer("payment", canon)
+    grant = _issue(request_id="dc-canon", object_id="pay_1")
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        refund_payment, _policy(), tool_name="refund_payment", store=store
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        wrapped(payment_id="pay_1", tenant_id="acme", request_id="dc-canon")
+    assert "pay_1" in seen
+
+
+def test_expiry_uses_injectable_clock() -> None:
+    store = get_or_store()
+    clock = {"now": 100.0}
+    set_destructive_clock(lambda: clock["now"])
+    grant = _issue(request_id="dc-exp", expires_in=10)
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        refund_payment, _policy(), tool_name="refund_payment", store=store
+    )
+    clock["now"] = grant.expires_at
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        with pytest.raises(DestructiveGrantError) as exc:
+            wrapped(payment_id="pay_1", tenant_id="acme", request_id="dc-exp")
+    assert exc.value.reason == "expired"
+
+
+def test_exhausted_and_multi_use() -> None:
+    store = get_or_store()
+    policy = _policy()
+    policy = DestructiveConfirmPolicy(
+        enabled=True,
+        policy_version="test",
+        tools={
+            "refund_payment": DestructiveToolPolicy(
+                operation="refund",
+                object=DestructiveObjectSpec(
+                    object_type="payment", id_from="payment_id", tenant_from="tenant_id"
+                ),
+                grant=DestructiveGrantSpec(bind_request_id=False, max_uses=2, ttl_seconds=300),
+            )
+        },
+    )
+    grant = _issue(max_uses=2, bind_request_id=False)
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        refund_payment, policy, tool_name="refund_payment", store=store
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        wrapped(payment_id="pay_1", tenant_id="acme", request_id="u1")
+        wrapped(payment_id="pay_1", tenant_id="acme", request_id="u2")
+        with pytest.raises(DestructiveGrantError) as exc:
+            wrapped(payment_id="pay_1", tenant_id="acme", request_id="u3")
+    assert exc.value.reason == "exhausted"
+
+
+def test_concurrent_one_use() -> None:
+    store = get_or_store()
+    policy = DestructiveConfirmPolicy(
+        enabled=True,
+        policy_version="test",
+        tools={
+            "refund_payment": DestructiveToolPolicy(
+                operation="refund",
+                object=DestructiveObjectSpec(
+                    object_type="payment", id_from="payment_id", tenant_from="tenant_id"
+                ),
+                grant=DestructiveGrantSpec(max_uses=1, ttl_seconds=300),
+            )
+        },
+    )
+    grant = _issue(bind_request_id=False)
+    hits = {"n": 0}
+    lock = threading.Lock()
+    barrier = threading.Barrier(2)
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        with lock:
+            hits["n"] += 1
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        refund_payment, policy, tool_name="refund_payment", store=store
+    )
+
+    def worker(rid: str) -> None:
+        barrier.wait()
+        try:
+            with execution_scope(
+                TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+            ):
+                wrapped(payment_id="pay_1", tenant_id="acme", request_id=rid)
+        except DestructiveGrantError:
+            return
+
+    threads = [
+        threading.Thread(target=worker, args=("c1",)),
+        threading.Thread(target=worker, args=("c2",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert hits["n"] == 1
+
+
+def test_identity_drift_same_request_id() -> None:
+    store = get_or_store()
+    grant = _issue(request_id="dc-drift", object_id="pay_a")
+    storage = InMemoryLedgerStorage()
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        ledger_sync(
+            storage=storage,
+            transition_binding=_binding(),
+            on_args_drift=ARGS_DRIFT_HARD,
+        )(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+        store=store,
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        wrapped(payment_id="pay_a", tenant_id="acme", request_id="dc-drift")
+        with pytest.raises(DestructiveGrantError):
+            wrapped(payment_id="pay_b", tenant_id="acme", request_id="dc-drift")
+
+
+def test_crash_after_boundary_hard_blocks() -> None:
+    store = get_or_store()
+    grant = _issue(request_id="dc-crash", object_id="pay_1")
+    events: list[str] = []
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        events.append("body")
+        with side_effect():
+            raise RuntimeError("boom")
+
+    wrapped = apply_destructive_confirm(
+        ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=_binding())(
+            refund_payment
+        ),
+        _policy(),
+        tool_name="refund_payment",
+        store=store,
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        with pytest.raises(Exception):
+            wrapped(payment_id="pay_1", tenant_id="acme", request_id="dc-crash")
+        with pytest.raises(Exception):
+            wrapped(payment_id="pay_1", tenant_id="acme", request_id="dc-crash")
+    assert events == ["body"]
+
+
+def test_storage_outage_fails_closed() -> None:
+    class BoomStore(InMemoryDestructiveGrantStore):
+        def try_consume(self, grant_id: str, request_id: str, now: float):
+            raise RuntimeError("storage down")
+
+    store = BoomStore()
+    set_destructive_grant_store(store)
+    grant = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        tenant="acme",
+        request_id="dc-out",
+        expires_in=300,
+        policy_version="test",
+        store=store,
+        bind_request_id=True,
+    )
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        refund_payment, _policy(), tool_name="refund_payment", store=store
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        with pytest.raises(DestructiveGrantError) as exc:
+            wrapped(payment_id="pay_1", tenant_id="acme", request_id="dc-out")
+    assert exc.value.reason == "storage"
+
+
+def test_file_store_atomic_consume(tmp_path: Any) -> None:
+    store = FileDestructiveGrantStore(tmp_path / "grants.json")
+    set_destructive_grant_store(store)
+    grant = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        tenant="acme",
+        expires_in=300,
+        policy_version="test",
+        store=store,
+    )
+    first = store.try_consume(grant.grant_id, "r1", grant.issued_at)
+    second = store.try_consume(grant.grant_id, "r2", grant.issued_at)
+    retry = store.try_consume(grant.grant_id, "r1", grant.issued_at)
+    assert first.status == "allowed"
+    assert second.status == "exhausted"
+    assert retry.status == "retry"
+
+
+def test_dict_grant_is_ignored() -> None:
+    store = get_or_store()
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        refund_payment, _policy(), tool_name="refund_payment", store=store
+    )
+    fake = {
+        "grant_id": "g",
+        "operation": "refund",
+        "object_type": "payment",
+        "object_id": "pay_1",
+    }
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(fake,))
+    ):
+        with pytest.raises(DestructiveGrantError, match="missing"):
+            wrapped(payment_id="pay_1", tenant_id="acme", request_id="dc-dict")
+
+
+def test_evidence_omits_payload() -> None:
+    store = get_or_store()
+    grant = _issue(request_id="dc-ev", object_id="pay_1")
+    storage = InMemoryLedgerStorage()
+
+    def refund_payment(payment_id: str, tenant_id: str, amount: str) -> str:
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        ledger_sync(storage=storage, transition_binding=_binding())(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+        store=store,
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        wrapped(
+            payment_id="pay_1",
+            tenant_id="acme",
+            amount="INTERNAL_REFUND_SECRET",
+            request_id="dc-ev",
+        )
+    entry = storage.get("dc-ev")
+    assert entry is not None
+    dumped = json.dumps(entry.to_dict(), default=str)
+    assert "INTERNAL_REFUND_SECRET" not in dumped
+    _args, kwargs = sanitize_destructive_evidence(
+        (),
+        {"payment_id": "pay_1", "amount": "INTERNAL_REFUND_SECRET"},
+    )
+    assert kwargs["amount"] == PAYLOAD_OMITTED
+    assert "INTERNAL_REFUND_SECRET" not in json.dumps(kwargs)
+
+
+def test_sync_async_parity() -> None:
+    store = get_or_store()
+    grant = _issue(request_id="dc-async", object_id="pay_1")
+
+    def sync_refund(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    async def async_refund(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    sync_wrapped = apply_destructive_confirm(
+        sync_refund, _policy(), tool_name="refund_payment", store=store
+    )
+    async_wrapped = apply_destructive_confirm(
+        async_refund, _policy(), tool_name="refund_payment", store=store
+    )
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        assert (
+            sync_wrapped(payment_id="pay_1", tenant_id="acme", request_id="dc-async")
+            == "pay_1"
+        )
+    grant2 = _issue(request_id="dc-async2", object_id="pay_1")
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant2,))
+    ):
+        assert (
+            asyncio.run(
+                async_wrapped(
+                    payment_id="pay_1", tenant_id="acme", request_id="dc-async2"
+                )
+            )
+            == "pay_1"
+        )
+
+
+def test_omitted_config_preserves_behavior() -> None:
+    cfg = load_config_from_string(
+        """
+tools:
+  refund_payment:
+    side_effect_class: irreversible
+"""
+    )
+    assert cfg.destructive_confirm is None
+    assert cfg.destructive_confirm_applies("refund_payment") is False
+
+    def refund_payment(payment_id: str) -> str:
+        return payment_id
+
+    assert cfg.apply_tool("refund_payment", refund_payment) is refund_payment
+
+
+def test_yaml_example_and_invalid_config() -> None:
+    cfg = load_config_from_string(
+        """
+destructive_confirm:
+  enabled: true
+  missing_policy: error
+  tools:
+    refund_payment:
+      operation: refund
+      object:
+        type: payment
+        id_from: payment_id
+      grant:
+        bind_request_id: true
+        max_uses: 1
+        ttl_seconds: 300
+    delete_file:
+      operation: delete
+      object:
+        type: file
+        id_from: file_id
+      grant:
+        bind_request_id: true
+        max_uses: 1
+        ttl_seconds: 120
+tools:
+  refund_payment:
+    side_effect_class: irreversible
+  delete_file:
+    side_effect_class: irreversible
+"""
+    )
+    assert cfg.destructive_confirm_applies("refund_payment") is True
+    assert cfg.destructive_confirm_applies("search") is False
+
+    with pytest.raises(ConfigError, match="unsupported"):
+        load_config_from_string("destructive_confirm:\n  llm_approve: true\n")
+    with pytest.raises(ConfigError, match="operation"):
+        load_config_from_string(
+            """
+destructive_confirm:
+  tools:
+    refund_payment:
+      object:
+        type: payment
+        id_from: payment_id
+"""
+        )
+    with pytest.raises(ConfigError, match="ttl_seconds"):
+        load_config_from_string(
+            """
+destructive_confirm:
+  tools:
+    refund_payment:
+      operation: refund
+      object: {type: payment, id_from: payment_id}
+      grant: {ttl_seconds: 0}
+"""
+        )
+    with pytest.raises(ConfigError, match="max_uses"):
+        load_config_from_string(
+            """
+destructive_confirm:
+  tools:
+    refund_payment:
+      operation: refund
+      object: {type: payment, id_from: payment_id}
+      grant: {max_uses: 0}
+"""
+        )
+
+
+def test_production_rejects_memory_and_missing_irreversible() -> None:
+    with pytest.raises(ConfigError, match="destructive_confirm.missing_policy"):
+        load_config_from_string(
+            """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [refund_payment]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+destructive_confirm:
+  enabled: true
+  missing_policy: warn
+  storage: file
+  path: ./grants.json
+  tools:
+    refund_payment:
+      operation: refund
+      object: {type: payment, id_from: payment_id}
+tools:
+  refund_payment:
+    side_effect_class: irreversible
+"""
+        )
+    with pytest.raises(ConfigError, match="memory"):
+        load_config_from_string(
+            """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [refund_payment]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+destructive_confirm:
+  enabled: true
+  storage: memory
+  tools:
+    refund_payment:
+      operation: refund
+      object: {type: payment, id_from: payment_id}
+tools:
+  refund_payment:
+    side_effect_class: irreversible
+"""
+        )
+    with pytest.raises(ConfigError, match="irreversible"):
+        load_config_from_string(
+            """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [purge_all]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+destructive_confirm:
+  enabled: true
+  storage: file
+  path: ./grants.json
+  tools: {}
+tools:
+  purge_all:
+    side_effect_class: irreversible
+"""
+        )
+    with pytest.raises(ConfigError, match="multi_node"):
+        load_config_from_string(
+            """
+profile: production
+deployment:
+  topology: multi_node
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [refund_payment]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+destructive_confirm:
+  enabled: true
+  storage: file
+  path: ./grants.json
+  tools:
+    refund_payment:
+      operation: refund
+      object: {type: payment, id_from: payment_id}
+tools:
+  refund_payment:
+    side_effect_class: irreversible
+"""
+        )
+
+
+def test_doctor_omitted_is_skip(tmp_path: Any) -> None:
+    from mycelium import run_doctor
+
+    path = tmp_path / "mycelium.yaml"
+    path.write_text(
+        """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [charge]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+tools:
+  charge:
+    side_effect_class: non_idempotent_mutate
+""",
+        encoding="utf-8",
+    )
+    report = run_doctor(path, connectivity=False)
+    scanning = next(c for c in report.checks if c.id == "destructive.scanning")
+    assert scanning.status == DoctorStatus.SKIP
+
+
+def test_request_run_thread_binding() -> None:
+    store = get_or_store()
+    policy = DestructiveConfirmPolicy(
+        enabled=True,
+        policy_version="test",
+        tools={
+            "refund_payment": DestructiveToolPolicy(
+                operation="refund",
+                object=DestructiveObjectSpec(
+                    object_type="payment", id_from="payment_id", tenant_from="tenant_id"
+                ),
+                grant=DestructiveGrantSpec(
+                    bind_request_id=True,
+                    bind_run_id=True,
+                    bind_thread_id=True,
+                    max_uses=1,
+                    ttl_seconds=300,
+                ),
+            )
+        },
+    )
+    grant = _issue(
+        request_id="dc-bind",
+        run_id="run-1",
+        thread_id="thread-1",
+        bind_request_id=True,
+        bind_run_id=True,
+        bind_thread_id=True,
+    )
+
+    def refund_payment(payment_id: str, tenant_id: str, **_: Any) -> str:
+        return payment_id
+
+    wrapped = apply_destructive_confirm(
+        refund_payment, policy, tool_name="refund_payment", store=store
+    )
+    with execution_scope(
+        TransitionScope(run_id="run-other", thread_id="thread-1", destructive_grants=(grant,))
+    ):
+        with pytest.raises(DestructiveGrantError):
+            wrapped(payment_id="pay_1", tenant_id="acme", request_id="dc-bind")
+    with execution_scope(
+        TransitionScope(run_id="run-1", thread_id="thread-1", destructive_grants=(grant,))
+    ):
+        assert wrapped(payment_id="pay_1", tenant_id="acme", request_id="dc-bind") == "pay_1"
+
+
+def test_enforce_sets_decision_on_deny() -> None:
+    store = get_or_store()
+    from mycelium.destructive_confirm import get_active_destructive_decision
+
+    with pytest.raises(DestructiveGrantError):
+        enforce_destructive_confirm(
+            "refund_payment",
+            (),
+            {"payment_id": "pay_1", "tenant_id": "acme", "request_id": "x"},
+            policy=_policy(),
+            func=lambda payment_id, tenant_id: None,
+            store=store,
+        )
+    decision = get_active_destructive_decision()
+    assert decision is not None
+    assert decision.decision in {"denied", "mismatched"}
+    assert decision.reason == "missing"
+
+
+def test_compatibility_with_loop_and_budget_omitted() -> None:
+    cfg = load_config_from_string(
+        """
+destructive_confirm:
+  enabled: true
+  tools:
+    refund_payment:
+      operation: refund
+      object: {type: payment, id_from: payment_id}
+      grant: {bind_request_id: true, max_uses: 1, ttl_seconds: 60}
+tools:
+  refund_payment:
+    side_effect_class: irreversible
+"""
+    )
+    store = cfg.build_destructive_grant_store()
+    set_destructive_grant_store(store)
+    grant = issue_destructive_grant(
+        operation="refund",
+        object_type="payment",
+        object_id="pay_1",
+        request_id="dc-compat",
+        expires_in=300,
+        store=store,
+        bind_request_id=True,
+    )
+
+    def refund_payment(payment_id: str, **_: Any) -> str:
+        return payment_id
+
+    wrapped = cfg.apply_tool("refund_payment", refund_payment)
+    with execution_scope(
+        TransitionScope(run_id="r", thread_id="t", destructive_grants=(grant,))
+    ):
+        assert wrapped(payment_id="pay_1", request_id="dc-compat") == "pay_1"

--- a/sdk/tests/test_langgraph_integration.py
+++ b/sdk/tests/test_langgraph_integration.py
@@ -12,7 +12,15 @@ from langchain_core.messages import AIMessage
 from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.prebuilt import ToolNode, ToolRuntime
 
-from mycelium import ConfigError, get_ledger, load_config_from_string
+from mycelium import (
+    ConfigError,
+    ValidatorResult,
+    get_ledger,
+    load_config_from_string,
+    register_use_time_validator,
+    use_time_facts,
+)
+from mycelium.use_time_currency import reset_use_time_currency_state
 
 
 def _config(*, integration: str = "{enabled: true}"):
@@ -110,6 +118,60 @@ def test_apply_exposes_hidden_tool_runtime_to_langgraph() -> None:
     injected = node._injected_args["send_payment"]
     assert injected.runtime == "runtime"
     assert "runtime" in injected.all_injected_keys
+
+
+def test_use_time_only_tool_receives_langgraph_context_bindings() -> None:
+    reset_use_time_currency_state()
+    config = load_config_from_string(
+        """
+integrations:
+  langgraph: {enabled: true}
+use_time_currency:
+  policy_version: "1"
+  tools:
+    send_payment:
+      facts:
+        - name: payment.current
+          subject: {type: payment, id_from: amount}
+          validator: payment_state
+          bind_request_id: true
+          bind_run_id: true
+          bind_thread_id: true
+tools:
+  send_payment: {}
+"""
+    )
+    calls: list[float] = []
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True)
+
+    register_use_time_validator("payment_state", payment_state)
+    use_time_facts.capture(
+        name="payment.current",
+        subject_type="payment",
+        subject_id="10.0",
+        request_id="call_1",
+        run_id="run_1",
+        thread_id="thread_1",
+        policy_version="1",
+    )
+
+    @config.apply
+    def send_payment(amount: float) -> dict[str, float]:
+        """Send one payment."""
+        calls.append(amount)
+        return {"amount": amount}
+
+    assert inspect.signature(send_payment).parameters["runtime"].annotation is ToolRuntime
+    graph = _graph_for(send_payment)
+    result = graph.invoke(
+        {"messages": [_tool_message()]},
+        {"configurable": {"thread_id": "thread_1"}, "run_id": "run_1"},
+    )
+    assert calls == [10.0]
+    assert result["messages"][-1].content == '{"amount": 10.0}'
+    reset_use_time_currency_state()
 
 
 def test_langgraph_redispatch_uses_same_transition_without_manual_ids() -> None:

--- a/sdk/tests/test_production_profile.py
+++ b/sdk/tests/test_production_profile.py
@@ -457,6 +457,42 @@ tools:
     assert cfg.entity_guard_applies("send_email") is True
 
 
+def test_production_accepts_destructive_confirm_error_policy() -> None:
+    cfg = load_config_from_string(
+        """
+profile: production
+action_ledger:
+  storage: sqlite
+  path: ./ledger.db
+  tools: [refund_payment]
+outcome_emit:
+  storage: file
+  path: ./outcomes.jsonl
+destructive_confirm:
+  enabled: true
+  missing_policy: error
+  storage: file
+  path: ./grants.json
+  tools:
+    refund_payment:
+      operation: refund
+      object:
+        type: payment
+        id_from: payment_id
+      grant:
+        bind_request_id: true
+        max_uses: 1
+        ttl_seconds: 300
+tools:
+  refund_payment:
+    side_effect_class: irreversible
+"""
+    )
+    assert cfg.destructive_confirm is not None
+    assert cfg.destructive_confirm["missing_policy"] == "error"
+    assert cfg.destructive_confirm_applies("refund_payment") is True
+
+
 def test_existing_configs_without_profile_still_load() -> None:
     cfg = load_config_from_string(
         """

--- a/sdk/tests/test_side_effect_boundary.py
+++ b/sdk/tests/test_side_effect_boundary.py
@@ -27,6 +27,7 @@ from mycelium import (
     mark_crossed,
     mark_maybe_crossed,
     side_effect,
+    side_effect_async,
 )
 from mycelium.action_ledger import get_active_transition
 
@@ -164,7 +165,7 @@ def test_async_side_effect_marks_unknown_on_error() -> None:
         active = get_active_transition()
         assert active is not None
         rids.append(active.request_id)
-        with side_effect():
+        async with side_effect_async():
             raise RuntimeError("async provider timeout")
 
     async def run() -> None:

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -29,6 +29,7 @@ from mycelium.transition import (
     SideEffectClass,
     ToolTransitionBinding,
     TransitionScope,
+    dispatch_scope,
     execution_scope,
 )
 from mycelium.use_time_currency import (
@@ -1484,6 +1485,89 @@ def test_async_scope_switch_denies_at_final_boundary() -> None:
             with pytest.raises(UseTimeCurrencyError) as exc:
                 await wrapped("resource-1", request_id="request-1")
         assert exc.value.reason == "subject_mismatch"
+
+    asyncio.run(run())
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_sync_dispatch_scope_switch_denies_at_final_boundary() -> None:
+    """Captured request binding must compare against current dispatch, not authorize-time kwargs."""
+    storage = InMemoryLedgerStorage()
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+
+    def resource_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True)
+
+    register_use_time_validator("resource_state", resource_state)
+
+    @ledger_sync(storage=storage, transition_binding=_binding())
+    def update_resource(resource_id: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        with dispatch_scope("request-B"):
+            with side_effect():
+                provider_calls.append(resource_id)
+
+    wrapped = apply_use_time_currency(
+        update_resource, _context_policy("update_resource"), tool_name="update_resource"
+    )
+    use_time_facts.capture(
+        name="resource.current",
+        subject_type="resource",
+        subject_id="resource-1",
+        request_id="request-1",
+        run_id="run-1",
+        thread_id="thread-1",
+    )
+    with execution_scope(TransitionScope(run_id="run-1", thread_id="thread-1")):
+        with dispatch_scope("request-1"):
+            with pytest.raises(UseTimeCurrencyError) as exc:
+                wrapped("resource-1", request_id="request-1")
+    assert exc.value.reason == "subject_mismatch"
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_async_dispatch_scope_switch_denies_at_final_boundary() -> None:
+    storage = InMemoryLedgerStorage()
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+
+    async def resource_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True)
+
+    register_use_time_validator("resource_state", resource_state)
+
+    @ledger(storage=storage, transition_binding=_binding())
+    async def update_resource(resource_id: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        with dispatch_scope("request-B"):
+            async with side_effect_async():
+                provider_calls.append(resource_id)
+
+    wrapped = apply_use_time_currency(
+        update_resource, _context_policy("update_resource"), tool_name="update_resource"
+    )
+    use_time_facts.capture(
+        name="resource.current",
+        subject_type="resource",
+        subject_id="resource-1",
+        request_id="request-1",
+        run_id="run-1",
+        thread_id="thread-1",
+    )
+
+    async def run() -> None:
+        with execution_scope(TransitionScope(run_id="run-1", thread_id="thread-1")):
+            with dispatch_scope("request-1"):
+                with pytest.raises(UseTimeCurrencyError) as exc:
+                    await wrapped("resource-1", request_id="request-1")
+            assert exc.value.reason == "subject_mismatch"
 
     asyncio.run(run())
     assert provider_calls == []

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -1201,6 +1201,132 @@ def test_recapture_replaces_older_scoped_observation_across_metadata() -> None:
     assert decision.decision == "allowed"
 
 
+def test_sync_final_boundary_revalidates_distinct_same_fact_requirements() -> None:
+    storage = InMemoryLedgerStorage()
+    state = {"second_current": True}
+    calls = {"first": 0, "second": 0}
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+
+    def first_requirement(**_kwargs: Any) -> ValidatorResult:
+        calls["first"] += 1
+        return ValidatorResult(current=True, value=True)
+
+    def second_requirement(**_kwargs: Any) -> ValidatorResult:
+        calls["second"] += 1
+        return ValidatorResult(current=state["second_current"], value=True)
+
+    register_use_time_validator("first_requirement", first_requirement)
+    register_use_time_validator("second_requirement", second_requirement)
+    policy = UseTimeCurrencyPolicy(
+        policy_version="test",
+        tools={
+            "apply_payment": UseTimeToolPolicy(
+                facts=tuple(
+                    UseTimeFactSpec(
+                        name="payment.current",
+                        subject_type="payment",
+                        id_from="payment_id",
+                        validator=validator,
+                        require={"value": True},
+                    )
+                    for validator in ("first_requirement", "second_requirement")
+                )
+            )
+        },
+    )
+
+    @ledger_sync(storage=storage, transition_binding=_binding())
+    def apply_payment(payment_id: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        state["second_current"] = False
+        with side_effect():
+            provider_calls.append(payment_id)
+
+    wrapped = apply_use_time_currency(
+        apply_payment, policy, tool_name="apply_payment"
+    )
+    use_time_facts.capture(
+        name="payment.current",
+        subject_type="payment",
+        subject_id="pay-1",
+        value=True,
+        require_value=True,
+    )
+    with pytest.raises(UseTimeCurrencyError):
+        wrapped("pay-1", request_id="multiple-sync")
+    assert calls == {"first": 2, "second": 2}
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_async_final_boundary_revalidates_distinct_same_fact_requirements() -> None:
+    storage = InMemoryLedgerStorage()
+    state = {"second_current": True}
+    calls = {"first": 0, "second": 0}
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+
+    async def first_requirement(**_kwargs: Any) -> ValidatorResult:
+        calls["first"] += 1
+        return ValidatorResult(current=True, value=True)
+
+    async def second_requirement(**_kwargs: Any) -> ValidatorResult:
+        calls["second"] += 1
+        return ValidatorResult(current=state["second_current"], value=True)
+
+    register_use_time_validator("first_requirement", first_requirement)
+    register_use_time_validator("second_requirement", second_requirement)
+    policy = UseTimeCurrencyPolicy(
+        policy_version="test",
+        tools={
+            "apply_payment": UseTimeToolPolicy(
+                facts=tuple(
+                    UseTimeFactSpec(
+                        name="payment.current",
+                        subject_type="payment",
+                        id_from="payment_id",
+                        validator=validator,
+                        require={"value": True},
+                    )
+                    for validator in ("first_requirement", "second_requirement")
+                )
+            )
+        },
+    )
+
+    @ledger(storage=storage, transition_binding=_binding())
+    async def apply_payment(payment_id: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        state["second_current"] = False
+        async with side_effect_async():
+            provider_calls.append(payment_id)
+
+    wrapped = apply_use_time_currency(
+        apply_payment, policy, tool_name="apply_payment"
+    )
+    use_time_facts.capture(
+        name="payment.current",
+        subject_type="payment",
+        subject_id="pay-1",
+        value=True,
+        require_value=True,
+    )
+
+    async def run() -> None:
+        with pytest.raises(UseTimeCurrencyError):
+            await wrapped("pay-1", request_id="multiple-async")
+
+    asyncio.run(run())
+    assert calls == {"first": 2, "second": 2}
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
 def test_fingerprint_excludes_raw_values() -> None:
     use_time_facts.capture(
         name="payment.refundable",

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -1410,6 +1410,86 @@ def test_async_context_binding_rejects_missing_capture_before_body() -> None:
     assert body_calls == []
 
 
+def test_sync_scope_switch_denies_at_final_boundary() -> None:
+    storage = InMemoryLedgerStorage()
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+
+    def resource_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True)
+
+    register_use_time_validator("resource_state", resource_state)
+
+    @ledger_sync(storage=storage, transition_binding=_binding())
+    def update_resource(resource_id: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        with execution_scope(TransitionScope(run_id="run-2", thread_id="thread-1")):
+            with side_effect():
+                provider_calls.append(resource_id)
+
+    wrapped = apply_use_time_currency(
+        update_resource, _context_policy("update_resource"), tool_name="update_resource"
+    )
+    use_time_facts.capture(
+        name="resource.current",
+        subject_type="resource",
+        subject_id="resource-1",
+        request_id="request-1",
+        run_id="run-1",
+        thread_id="thread-1",
+    )
+    with execution_scope(TransitionScope(run_id="run-1", thread_id="thread-1")):
+        with pytest.raises(UseTimeCurrencyError) as exc:
+            wrapped("resource-1", request_id="request-1")
+    assert exc.value.reason == "subject_mismatch"
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_async_scope_switch_denies_at_final_boundary() -> None:
+    storage = InMemoryLedgerStorage()
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+
+    async def resource_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True)
+
+    register_use_time_validator("resource_state", resource_state)
+
+    @ledger(storage=storage, transition_binding=_binding())
+    async def update_resource(resource_id: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        with execution_scope(TransitionScope(run_id="run-2", thread_id="thread-1")):
+            async with side_effect_async():
+                provider_calls.append(resource_id)
+
+    wrapped = apply_use_time_currency(
+        update_resource, _context_policy("update_resource"), tool_name="update_resource"
+    )
+    use_time_facts.capture(
+        name="resource.current",
+        subject_type="resource",
+        subject_id="resource-1",
+        request_id="request-1",
+        run_id="run-1",
+        thread_id="thread-1",
+    )
+
+    async def run() -> None:
+        with execution_scope(TransitionScope(run_id="run-1", thread_id="thread-1")):
+            with pytest.raises(UseTimeCurrencyError) as exc:
+                await wrapped("resource-1", request_id="request-1")
+        assert exc.value.reason == "subject_mismatch"
+
+    asyncio.run(run())
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
 def test_fingerprint_excludes_raw_values() -> None:
     use_time_facts.capture(
         name="payment.refundable",

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -8,7 +8,13 @@ from typing import Any
 
 import pytest
 
-from mycelium.action_ledger import InMemoryLedgerStorage, ledger, ledger_sync, side_effect
+from mycelium.action_ledger import (
+    InMemoryLedgerStorage,
+    get_active_transition,
+    ledger,
+    ledger_sync,
+    side_effect,
+)
 from mycelium.config import ConfigError, load_config_from_string
 from mycelium.transition import (
     SideEffectBoundary,
@@ -457,7 +463,7 @@ def test_completed_return_skips_use() -> None:
         assert calls["n"] == first_calls
 
 
-def test_use_boundary_token_skips_double_call() -> None:
+def test_use_boundary_revalidates_each_call() -> None:
     set_use_time_currency_policy(_policy())
     calls = {"n": 0}
 
@@ -482,11 +488,140 @@ def test_use_boundary_token_skips_double_call() -> None:
     )
     enforce_use_boundary(kwargs={"payment_id": "pay_1", "payment_version": "1"})
     assert calls["n"] == 1
-    enforce_use_boundary(
-        skip_if_token_valid=True,
-        kwargs={"payment_id": "pay_1", "payment_version": "1"},
+    enforce_use_boundary(kwargs={"payment_id": "pay_1", "payment_version": "1"})
+    assert calls["n"] == 2
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "tenant", "account", "reason"),
+    [
+        ({"account_id": "acct-1"}, "tenant-1", "acct-1", "missing"),
+        ({"tenant_id": "tenant-1"}, "tenant-1", "acct-1", "missing"),
+        (
+            {"tenant_id": "tenant-2", "account_id": "acct-1"},
+            "tenant-1",
+            "acct-1",
+            "tenant_mismatch",
+        ),
+        (
+            {"tenant_id": "tenant-1", "account_id": "acct-2"},
+            "tenant-1",
+            "acct-1",
+            "account_mismatch",
+        ),
+    ],
+)
+def test_authorize_requires_exact_configured_scope(
+    kwargs: dict[str, str], tenant: str, account: str, reason: str
+) -> None:
+    policy = UseTimeCurrencyPolicy(
+        policy_version="test",
+        tools={
+            "refund_payment": UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name="payment.refundable",
+                        subject_type="payment",
+                        id_from="payment_id",
+                        tenant_from="tenant_id",
+                        account_from="account_id",
+                        validator="payment_state",
+                        require={"value": True},
+                    ),
+                )
+            )
+        },
     )
-    assert calls["n"] == 1
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay-1",
+        value=True,
+        require_value=True,
+        tenant=tenant,
+        account=account,
+    )
+    with pytest.raises(UseTimeCurrencyError) as exc:
+        authorize_use_time_facts(
+            "refund_payment", (), {"payment_id": "pay-1", **kwargs}, policy=policy
+        )
+    assert exc.value.reason == reason
+
+
+def test_sync_boundary_denies_fact_changed_after_body_start() -> None:
+    storage = InMemoryLedgerStorage()
+    state = {"current": True}
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=state["current"], value=state["current"], revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+
+    @ledger_sync(storage=storage, transition_binding=_binding())
+    def refund_payment(payment_id: str, payment_version: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        state["current"] = False
+        with side_effect():
+            provider_calls.append(payment_id)
+
+    wrapped = apply_use_time_currency(refund_payment, _policy(), tool_name="refund_payment")
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    with pytest.raises(UseTimeCurrencyError):
+        wrapped(payment_id="pay_1", payment_version="1", request_id="boundary-sync")
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_async_boundary_denies_fact_changed_after_body_start() -> None:
+    storage = InMemoryLedgerStorage()
+    state = {"current": True}
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=state["current"], value=state["current"], revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+
+    @ledger(storage=storage, transition_binding=_binding())
+    async def refund_payment(payment_id: str, payment_version: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        state["current"] = False
+        with side_effect():
+            provider_calls.append(payment_id)
+
+    wrapped = apply_use_time_currency(refund_payment, _policy(), tool_name="refund_payment")
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+
+    async def run() -> None:
+        with pytest.raises(UseTimeCurrencyError):
+            await wrapped(
+                payment_id="pay_1", payment_version="1", request_id="boundary-async"
+            )
+
+    asyncio.run(run())
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
 
 
 def test_fingerprint_excludes_raw_values() -> None:

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -1,0 +1,650 @@
+"""Use-time currency (AF-012): decide-time facts revalidated at use."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from mycelium.action_ledger import InMemoryLedgerStorage, ledger, ledger_sync, side_effect
+from mycelium.config import ConfigError, load_config_from_string
+from mycelium.transition import (
+    SideEffectBoundary,
+    SideEffectClass,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+)
+from mycelium.use_time_currency import (
+    UseTimeCurrencyError,
+    UseTimeCurrencyPolicy,
+    UseTimeFactSpec,
+    UseTimeToolPolicy,
+    ValidatorResult,
+    apply_use_time_currency,
+    authorize_use_time_facts,
+    enforce_pending_use_time_facts_at_use,
+    enforce_pending_use_time_facts_at_use_async,
+    enforce_use_boundary,
+    get_pending_use_time_facts,
+    get_use_time_decisions,
+    register_use_time_validator,
+    reset_use_time_currency_state,
+    set_use_time_clock,
+    set_use_time_currency_policy,
+    use_time_facts,
+    use_time_fingerprint,
+    value_digest,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> Any:
+    reset_use_time_currency_state()
+    yield
+    reset_use_time_currency_state()
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="test",
+        policy_version="test",
+        side_effect_class=SideEffectClass.KEYED_MUTATE,
+    )
+
+
+def _policy() -> UseTimeCurrencyPolicy:
+    return UseTimeCurrencyPolicy(
+        enabled=True,
+        missing_policy="error",
+        policy_version="test",
+        tools={
+            "refund_payment": UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name="payment.refundable",
+                        subject_type="payment",
+                        id_from="payment_id",
+                        validator="payment_state",
+                        require={"value": True},
+                        revision_from="payment_version",
+                        max_age_seconds=30,
+                        bind_request_id=True,
+                    ),
+                )
+            )
+        },
+    )
+
+
+def test_capture_rejects_model_mapping_subject() -> None:
+    with pytest.raises(UseTimeCurrencyError, match="host-controlled"):
+        use_time_facts.capture(
+            name="payment.refundable",
+            subject_type="payment",
+            subject_id={"id": "pay_1"},  # type: ignore[arg-type]
+            value=True,
+        )
+
+
+def test_max_age_boundary_stale() -> None:
+    clock = {"now": 1_000.0}
+    set_use_time_clock(lambda: clock["now"])
+    set_use_time_currency_policy(_policy())
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        max_age_seconds=30,
+        require_value=True,
+        observed_at=datetime.fromtimestamp(1_000.0, tz=UTC),
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1", "request_id": "r1"},
+        policy=_policy(),
+    )
+    clock["now"] = 1_030.0  # age == 30 → stale (>=)
+    with pytest.raises(UseTimeCurrencyError) as exc:
+        enforce_pending_use_time_facts_at_use(
+            kwargs={"payment_id": "pay_1", "payment_version": "1"}
+        )
+    assert exc.value.reason == "stale"
+
+
+def test_max_age_just_under_allows() -> None:
+    clock = {"now": 1_000.0}
+    set_use_time_clock(lambda: clock["now"])
+    set_use_time_currency_policy(_policy())
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        max_age_seconds=30,
+        require_value=True,
+        observed_at=datetime.fromtimestamp(1_000.0, tz=UTC),
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1"},
+        policy=_policy(),
+    )
+    clock["now"] = 1_029.9
+    decision = enforce_pending_use_time_facts_at_use(
+        kwargs={"payment_id": "pay_1", "payment_version": "1"}
+    )
+    assert decision.decision == "allowed"
+
+
+def test_condition_false_and_revision_mismatch() -> None:
+    set_use_time_currency_policy(_policy())
+    state = {"refundable": False, "version": "2"}
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(
+            current=bool(state["refundable"]),
+            value=state["refundable"],
+            revision=str(state["version"]),
+        )
+
+    register_use_time_validator("payment_state", payment_state)
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1"},
+        policy=_policy(),
+    )
+    with pytest.raises(UseTimeCurrencyError) as exc:
+        enforce_pending_use_time_facts_at_use(
+            kwargs={"payment_id": "pay_1", "payment_version": "1"}
+        )
+    assert exc.value.reason == "condition_false"
+
+    reset_use_time_currency_state()
+    set_use_time_currency_policy(_policy())
+    register_use_time_validator("payment_state", payment_state)
+    state["refundable"] = True
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1"},
+        policy=_policy(),
+    )
+    with pytest.raises(UseTimeCurrencyError) as exc2:
+        enforce_pending_use_time_facts_at_use(
+            kwargs={"payment_id": "pay_1", "payment_version": "1"}
+        )
+    assert exc2.value.reason == "revision_mismatch"
+
+
+def test_async_validator_not_silently_run_on_sync_path() -> None:
+    set_use_time_currency_policy(_policy())
+
+    async def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1"},
+        policy=_policy(),
+    )
+    with pytest.raises(UseTimeCurrencyError) as exc:
+        enforce_pending_use_time_facts_at_use(
+            kwargs={"payment_id": "pay_1", "payment_version": "1"}
+        )
+    assert exc.value.reason == "validator_failed"
+
+
+async def test_async_validator_path() -> None:
+    set_use_time_currency_policy(_policy())
+
+    async def payment_state(**_kwargs: Any) -> ValidatorResult:
+        await asyncio.sleep(0)
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1"},
+        policy=_policy(),
+    )
+    decision = await enforce_pending_use_time_facts_at_use_async(
+        kwargs={"payment_id": "pay_1", "payment_version": "1"}
+    )
+    assert decision.decision == "allowed"
+
+
+def test_validator_missing_and_timeout() -> None:
+    set_use_time_currency_policy(_policy())
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1"},
+        policy=_policy(),
+    )
+    with pytest.raises(UseTimeCurrencyError) as exc:
+        enforce_pending_use_time_facts_at_use(
+            kwargs={"payment_id": "pay_1", "payment_version": "1"}
+        )
+    assert exc.value.reason == "validator_missing"
+
+
+async def test_async_validator_timeout() -> None:
+    set_use_time_currency_policy(_policy())
+
+    async def payment_state(**_kwargs: Any) -> ValidatorResult:
+        await asyncio.sleep(1.0)
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state, timeout_seconds=0.01)
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1"},
+        policy=_policy(),
+    )
+    with pytest.raises(UseTimeCurrencyError) as exc:
+        await enforce_pending_use_time_facts_at_use_async(
+            kwargs={"payment_id": "pay_1", "payment_version": "1"}
+        )
+    assert exc.value.reason == "validator_timeout"
+
+
+def test_ledgered_blocks_before_body_and_maybe_crossed() -> None:
+    set_use_time_currency_policy(_policy())
+    state = {"refundable": True, "version": "1"}
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(
+            current=bool(state["refundable"]),
+            value=state["refundable"],
+            revision=str(state["version"]),
+        )
+
+    register_use_time_validator("payment_state", payment_state)
+    events: list[str] = []
+    storage = InMemoryLedgerStorage()
+
+    def refund_payment(payment_id: str, payment_version: str) -> str:
+        events.append("body")
+        with side_effect():
+            return payment_id
+
+    wrapped = apply_use_time_currency(
+        ledger_sync(storage=storage, transition_binding=_binding())(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+    )
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    with execution_scope(TransitionScope(run_id="r", thread_id="t")):
+        assert wrapped(
+            payment_id="pay_1",
+            payment_version="1",
+            request_id="utc-ok",
+        ) == "pay_1"
+        assert "body" in events
+
+        state["refundable"] = False
+        events.clear()
+        use_time_facts.capture(
+            name="payment.refundable",
+            subject_type="payment",
+            subject_id="pay_1",
+            value=True,
+            revision="1",
+            require_value=True,
+        )
+        with pytest.raises(UseTimeCurrencyError):
+            wrapped(
+                payment_id="pay_1",
+                payment_version="1",
+                request_id="utc-deny",
+            )
+        assert "body" not in events
+        entry = storage.get("utc-deny")
+        assert entry is None or entry.side_effect_boundary != SideEffectBoundary.MAYBE_CROSSED
+
+
+async def test_async_ledgered_parity() -> None:
+    set_use_time_currency_policy(_policy())
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+    storage = InMemoryLedgerStorage()
+
+    async def refund_payment(payment_id: str, payment_version: str) -> str:
+        return payment_id
+
+    wrapped = apply_use_time_currency(
+        ledger(storage=storage, transition_binding=_binding())(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+    )
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    with execution_scope(TransitionScope(run_id="r", thread_id="t")):
+        assert (
+            await wrapped(
+                payment_id="pay_1",
+                payment_version="1",
+                request_id="utc-async",
+            )
+            == "pay_1"
+        )
+
+
+def test_completed_return_skips_use() -> None:
+    set_use_time_currency_policy(_policy())
+    calls = {"n": 0}
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        calls["n"] += 1
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+    storage = InMemoryLedgerStorage()
+
+    def refund_payment(payment_id: str, payment_version: str) -> str:
+        return payment_id
+
+    wrapped = apply_use_time_currency(
+        ledger_sync(storage=storage, transition_binding=_binding())(refund_payment),
+        _policy(),
+        tool_name="refund_payment",
+    )
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    with execution_scope(TransitionScope(run_id="r", thread_id="t")):
+        assert wrapped(
+            payment_id="pay_1", payment_version="1", request_id="utc-ret"
+        ) == "pay_1"
+        first_calls = calls["n"]
+        assert (
+            wrapped(payment_id="pay_1", payment_version="1", request_id="utc-ret")
+            == "pay_1"
+        )
+        # RETURN must not re-run use-phase validators.
+        assert calls["n"] == first_calls
+
+
+def test_use_boundary_token_skips_double_call() -> None:
+    set_use_time_currency_policy(_policy())
+    calls = {"n": 0}
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        calls["n"] += 1
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1"},
+        policy=_policy(),
+    )
+    enforce_use_boundary(kwargs={"payment_id": "pay_1", "payment_version": "1"})
+    assert calls["n"] == 1
+    enforce_use_boundary(
+        skip_if_token_valid=True,
+        kwargs={"payment_id": "pay_1", "payment_version": "1"},
+    )
+    assert calls["n"] == 1
+
+
+def test_fingerprint_excludes_raw_values() -> None:
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value="SECRET_VALUE",
+        revision="1",
+        require_value=True,
+        validator="payment_state",
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "payment_version": "1"},
+        policy=_policy(),
+    )
+    fp = "|".join(use_time_fingerprint(get_pending_use_time_facts()))
+    assert "SECRET_VALUE" not in fp
+    assert value_digest("SECRET_VALUE") not in fp or "payment.refundable" in fp
+
+
+def test_omitted_config_unchanged() -> None:
+    cfg = load_config_from_string(
+        """
+profile: development
+tools:
+  refund_payment:
+    side_effect_class: keyed_mutate
+"""
+    )
+    assert cfg.use_time_currency is None
+
+
+def test_config_rejects_unknown_keys_and_negative_max_age() -> None:
+    with pytest.raises(ConfigError, match="unsupported"):
+        load_config_from_string(
+            """
+use_time_currency:
+  enabled: true
+  extra: true
+  tools:
+    refund_payment:
+      facts:
+        - name: payment.refundable
+          subject: {type: payment, id_from: payment_id}
+          validator: payment_state
+"""
+        )
+    with pytest.raises(ConfigError, match="max_age_seconds"):
+        load_config_from_string(
+            """
+use_time_currency:
+  enabled: true
+  tools:
+    refund_payment:
+      facts:
+        - name: payment.refundable
+          subject: {type: payment, id_from: payment_id}
+          validator: payment_state
+          max_age_seconds: -1
+"""
+        )
+    with pytest.raises(ConfigError, match="subject.type"):
+        load_config_from_string(
+            """
+use_time_currency:
+  enabled: true
+  tools:
+    refund_payment:
+      facts:
+        - name: payment.refundable
+          subject: {id_from: payment_id}
+          validator: payment_state
+"""
+        )
+
+
+def test_production_requires_missing_policy_error() -> None:
+    from mycelium.config import ToolConfig, _parse_use_time_currency
+    from mycelium.transition import SideEffectClass
+
+    tools = {
+        "refund_payment": ToolConfig(
+            name="refund_payment",
+            side_effect_class=SideEffectClass.KEYED_MUTATE,
+        )
+    }
+    with pytest.raises(ConfigError, match="missing_policy"):
+        _parse_use_time_currency(
+            {
+                "use_time_currency": {
+                    "enabled": True,
+                    "missing_policy": "warn",
+                    "tools": {
+                        "refund_payment": {
+                            "facts": [
+                                {
+                                    "name": "payment.refundable",
+                                    "subject": {
+                                        "type": "payment",
+                                        "id_from": "payment_id",
+                                    },
+                                    "validator": "payment_state",
+                                }
+                            ]
+                        }
+                    },
+                }
+            },
+            profile="production",
+            tools=tools,
+        )
+
+
+def test_provider_precondition_recorded() -> None:
+    policy = UseTimeCurrencyPolicy(
+        enabled=True,
+        missing_policy="error",
+        policy_version="test",
+        tools={
+            "refund_payment": UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name="payment.refundable",
+                        subject_type="payment",
+                        id_from="payment_id",
+                        validator="payment_state",
+                        require={"value": True},
+                        provider_precondition="if_match",
+                    ),
+                )
+            )
+        },
+    )
+    set_use_time_currency_policy(policy)
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        require_value=True,
+    )
+    authorize_use_time_facts(
+        "refund_payment",
+        (),
+        {"payment_id": "pay_1", "if_match": "etag-1"},
+        policy=policy,
+    )
+    decision = enforce_pending_use_time_facts_at_use(
+        kwargs={"payment_id": "pay_1", "if_match": "etag-1"}
+    )
+    assert decision.provider_precondition == "if_match"
+    assert decision.provider_precondition_present is True
+    assert get_use_time_decisions()

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -112,6 +112,25 @@ def _positional_policy() -> UseTimeCurrencyPolicy:
     )
 
 
+def _nested_policy(tool: str, fact_name: str, validator: str) -> UseTimeCurrencyPolicy:
+    return UseTimeCurrencyPolicy(
+        policy_version="test",
+        tools={
+            tool: UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name=fact_name,
+                        subject_type="resource",
+                        id_from="resource_id",
+                        validator=validator,
+                        require={"value": True},
+                    ),
+                )
+            )
+        },
+    )
+
+
 def test_capture_rejects_model_mapping_subject() -> None:
     with pytest.raises(UseTimeCurrencyError, match="host-controlled"):
         use_time_facts.capture(
@@ -854,6 +873,138 @@ def test_async_nonledger_wrapper_preserves_positional_args_at_use() -> None:
         "payment_id": "pay_1",
         "expected_state": "ready",
     }
+
+
+def test_nested_sync_wrapper_restores_outer_facts_for_final_boundary() -> None:
+    storage = InMemoryLedgerStorage()
+    outer_current = {"value": True}
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+    outer_restored: list[bool] = []
+
+    def outer_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=outer_current["value"], value=outer_current["value"])
+
+    def inner_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True)
+
+    register_use_time_validator("outer_state", outer_state)
+    register_use_time_validator("inner_state", inner_state)
+
+    def inner_tool(resource_id: str) -> str:
+        return resource_id
+
+    inner = apply_use_time_currency(
+        inner_tool,
+        _nested_policy("inner_tool", "inner.current", "inner_state"),
+        tool_name="inner_tool",
+    )
+
+    @ledger_sync(storage=storage, transition_binding=_binding())
+    def outer_tool(resource_id: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        assert inner("inner-1") == "inner-1"
+        outer_restored.append(
+            any(fact.name == "outer.current" for fact in get_pending_use_time_facts())
+        )
+        outer_current["value"] = False
+        with side_effect():
+            provider_calls.append(resource_id)
+
+    outer = apply_use_time_currency(
+        outer_tool,
+        _nested_policy("outer_tool", "outer.current", "outer_state"),
+        tool_name="outer_tool",
+    )
+    use_time_facts.capture(
+        name="outer.current",
+        subject_type="resource",
+        subject_id="outer-1",
+        value=True,
+        require_value=True,
+    )
+    use_time_facts.capture(
+        name="inner.current",
+        subject_type="resource",
+        subject_id="inner-1",
+        value=True,
+        require_value=True,
+    )
+    with pytest.raises(UseTimeCurrencyError):
+        outer("outer-1", request_id="nested-sync")
+    assert outer_restored == [True]
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_nested_async_wrapper_restores_outer_facts_for_final_boundary() -> None:
+    storage = InMemoryLedgerStorage()
+    outer_current = {"value": True}
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+    outer_restored: list[bool] = []
+
+    async def outer_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=outer_current["value"], value=outer_current["value"])
+
+    async def inner_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True)
+
+    register_use_time_validator("outer_state", outer_state)
+    register_use_time_validator("inner_state", inner_state)
+
+    async def inner_tool(resource_id: str) -> str:
+        return resource_id
+
+    inner = apply_use_time_currency(
+        inner_tool,
+        _nested_policy("inner_tool", "inner.current", "inner_state"),
+        tool_name="inner_tool",
+    )
+
+    @ledger(storage=storage, transition_binding=_binding())
+    async def outer_tool(resource_id: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        assert await inner("inner-1") == "inner-1"
+        outer_restored.append(
+            any(fact.name == "outer.current" for fact in get_pending_use_time_facts())
+        )
+        outer_current["value"] = False
+        async with side_effect_async():
+            provider_calls.append(resource_id)
+
+    outer = apply_use_time_currency(
+        outer_tool,
+        _nested_policy("outer_tool", "outer.current", "outer_state"),
+        tool_name="outer_tool",
+    )
+    use_time_facts.capture(
+        name="outer.current",
+        subject_type="resource",
+        subject_id="outer-1",
+        value=True,
+        require_value=True,
+    )
+    use_time_facts.capture(
+        name="inner.current",
+        subject_type="resource",
+        subject_id="inner-1",
+        value=True,
+        require_value=True,
+    )
+
+    async def run() -> None:
+        with pytest.raises(UseTimeCurrencyError):
+            await outer("outer-1", request_id="nested-async")
+
+    asyncio.run(run())
+    assert outer_restored == [True]
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
 
 
 def test_fingerprint_excludes_raw_values() -> None:

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -34,6 +34,7 @@ from mycelium.transition import (
 from mycelium.use_time_currency import (
     UseTimeCurrencyError,
     UseTimeCurrencyPolicy,
+    UseTimeFact,
     UseTimeFactSpec,
     UseTimeToolPolicy,
     ValidatorResult,
@@ -44,6 +45,7 @@ from mycelium.use_time_currency import (
     enforce_use_boundary,
     get_pending_use_time_facts,
     get_use_time_decisions,
+    register_fact_for_use,
     register_use_time_validator,
     reset_use_time_currency_state,
     set_use_time_clock,
@@ -1005,6 +1007,135 @@ def test_nested_async_wrapper_restores_outer_facts_for_final_boundary() -> None:
     assert outer_restored == [True]
     assert provider_calls == []
     assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+@pytest.mark.parametrize(
+    "captured",
+    [
+        {"revision": "rev-1"},
+        {"value": True},
+    ],
+)
+def test_missing_validator_evidence_denies_before_provider(
+    captured: dict[str, Any],
+) -> None:
+    storage = InMemoryLedgerStorage()
+    provider_calls: list[str] = []
+
+    def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True)
+
+    register_use_time_validator("payment_state", payment_state)
+    policy = UseTimeCurrencyPolicy(
+        policy_version="test",
+        tools={
+            "apply_payment": UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name="payment.current",
+                        subject_type="payment",
+                        id_from="payment_id",
+                        validator="payment_state",
+                    ),
+                )
+            )
+        },
+    )
+
+    @ledger_sync(storage=storage, transition_binding=_binding())
+    def apply_payment(payment_id: str) -> None:
+        with side_effect():
+            provider_calls.append(payment_id)
+
+    wrapped = apply_use_time_currency(
+        apply_payment, policy, tool_name="apply_payment"
+    )
+    use_time_facts.capture(
+        name="payment.current",
+        subject_type="payment",
+        subject_id="pay-1",
+        **captured,
+    )
+    with pytest.raises(UseTimeCurrencyError) as exc:
+        wrapped("pay-1", request_id="missing-evidence")
+    assert exc.value.reason == "unverifiable"
+    assert provider_calls == []
+    entry = storage.get("missing-evidence")
+    assert entry is None or entry.side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_scoped_pending_facts_are_all_revalidated() -> None:
+    def scoped_state(*, fact: UseTimeFact, **_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=fact.tenant != "tenant-stale")
+
+    register_use_time_validator("scoped_state", scoped_state)
+    observed = datetime.now(UTC)
+    register_fact_for_use(
+        UseTimeFact(
+            name="resource.current",
+            subject_type="resource",
+            subject_id="shared-id",
+            observed_at=observed,
+            tenant="tenant-stale",
+            account="account-1",
+            validator="scoped_state",
+        )
+    )
+    register_fact_for_use(
+        UseTimeFact(
+            name="resource.current",
+            subject_type="resource",
+            subject_id="shared-id",
+            observed_at=observed,
+            tenant="tenant-current",
+            account="account-1",
+            validator="scoped_state",
+        )
+    )
+    assert len(get_pending_use_time_facts()) == 2
+    with pytest.raises(UseTimeCurrencyError) as exc:
+        enforce_pending_use_time_facts_at_use()
+    assert exc.value.reason == "condition_false"
+
+
+def test_captured_fact_lookup_selects_exact_scope() -> None:
+    policy = UseTimeCurrencyPolicy(
+        policy_version="test",
+        tools={
+            "read_resource": UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name="resource.current",
+                        subject_type="resource",
+                        id_from="resource_id",
+                        tenant_from="tenant_id",
+                        account_from="account_id",
+                        validator="scoped_state",
+                    ),
+                )
+            )
+        },
+    )
+    for tenant in ("tenant-1", "tenant-2"):
+        use_time_facts.capture(
+            name="resource.current",
+            subject_type="resource",
+            subject_id="shared-id",
+            tenant=tenant,
+            account="account-1",
+        )
+    bound = authorize_use_time_facts(
+        "read_resource",
+        (),
+        {
+            "resource_id": "shared-id",
+            "tenant_id": "tenant-1",
+            "account_id": "account-1",
+        },
+        policy=policy,
+    )
+    assert len(bound) == 1
+    assert bound[0].tenant == "tenant-1"
 
 
 def test_fingerprint_excludes_raw_values() -> None:

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -181,7 +181,7 @@ def test_max_age_boundary_stale() -> None:
         revision="1",
         max_age_seconds=30,
         require_value=True,
-        observed_at=datetime.fromtimestamp(1_000.0, tz=UTC),
+        observed_at=datetime.fromtimestamp(1_000.0, tz=timezone.utc),
     )
     authorize_use_time_facts(
         "refund_payment",
@@ -214,7 +214,7 @@ def test_max_age_just_under_allows() -> None:
         revision="1",
         max_age_seconds=30,
         require_value=True,
-        observed_at=datetime.fromtimestamp(1_000.0, tz=UTC),
+        observed_at=datetime.fromtimestamp(1_000.0, tz=timezone.utc),
     )
     authorize_use_time_facts(
         "refund_payment",
@@ -743,7 +743,7 @@ def test_async_boundary_denies_expired_authority_with_async_validator() -> None:
         BoundAuthority(
             authority_id="auth-1",
             authority_kind="destructive_grant",
-            expires_at=datetime.fromtimestamp(1_010.0, tz=UTC),
+            expires_at=datetime.fromtimestamp(1_010.0, tz=timezone.utc),
             tool="refund_payment",
         )
     )
@@ -1090,7 +1090,7 @@ def test_scoped_pending_facts_are_all_revalidated() -> None:
         return ValidatorResult(current=fact.tenant != "tenant-stale")
 
     register_use_time_validator("scoped_state", scoped_state)
-    observed = datetime.now(UTC)
+    observed = datetime.now(timezone.utc)
     register_fact_for_use(
         UseTimeFact(
             name="resource.current",

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -93,6 +93,25 @@ def _policy() -> UseTimeCurrencyPolicy:
     )
 
 
+def _positional_policy() -> UseTimeCurrencyPolicy:
+    return UseTimeCurrencyPolicy(
+        policy_version="test",
+        tools={
+            "apply_payment": UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name="payment.state",
+                        subject_type="payment",
+                        id_from="payment_id",
+                        validator="payment_state",
+                        compare_to_arg="expected_state",
+                    ),
+                )
+            )
+        },
+    )
+
+
 def test_capture_rejects_model_mapping_subject() -> None:
     with pytest.raises(UseTimeCurrencyError, match="host-controlled"):
         use_time_facts.capture(
@@ -716,6 +735,125 @@ def test_async_boundary_denies_expired_authority_with_async_validator() -> None:
     assert provider_calls == []
     assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
     reset_authority_window_state()
+
+
+def test_sync_ledger_preserves_positional_args_at_each_use_boundary() -> None:
+    storage = InMemoryLedgerStorage()
+    observed: list[dict[str, Any]] = []
+
+    def payment_state(**kwargs: Any) -> ValidatorResult:
+        observed.append(kwargs)
+        return ValidatorResult(current=True, value="ready")
+
+    register_use_time_validator("payment_state", payment_state)
+
+    @ledger_sync(storage=storage, transition_binding=_binding())
+    def apply_payment(payment_id: str, expected_state: str) -> str:
+        with side_effect():
+            return payment_id
+
+    wrapped = apply_use_time_currency(
+        apply_payment, _positional_policy(), tool_name="apply_payment"
+    )
+    use_time_facts.capture(
+        name="payment.state",
+        subject_type="payment",
+        subject_id="pay_1",
+        value="ready",
+    )
+    assert wrapped("pay_1", "ready", request_id="positional-sync") == "pay_1"
+    assert len(observed) == 2
+    assert all(item["kwargs"]["payment_id"] == "pay_1" for item in observed)
+    assert all(item["kwargs"]["expected_state"] == "ready" for item in observed)
+
+
+def test_async_ledger_preserves_positional_args_at_each_use_boundary() -> None:
+    storage = InMemoryLedgerStorage()
+    observed: list[dict[str, Any]] = []
+
+    async def payment_state(**kwargs: Any) -> ValidatorResult:
+        observed.append(kwargs)
+        return ValidatorResult(current=True, value="ready")
+
+    register_use_time_validator("payment_state", payment_state)
+
+    @ledger(storage=storage, transition_binding=_binding())
+    async def apply_payment(payment_id: str, expected_state: str) -> str:
+        async with side_effect_async():
+            return payment_id
+
+    wrapped = apply_use_time_currency(
+        apply_payment, _positional_policy(), tool_name="apply_payment"
+    )
+    use_time_facts.capture(
+        name="payment.state",
+        subject_type="payment",
+        subject_id="pay_1",
+        value="ready",
+    )
+    assert (
+        asyncio.run(wrapped("pay_1", "ready", request_id="positional-async"))
+        == "pay_1"
+    )
+    assert len(observed) == 2
+    assert all(item["kwargs"]["payment_id"] == "pay_1" for item in observed)
+    assert all(item["kwargs"]["expected_state"] == "ready" for item in observed)
+
+
+def test_nonledger_wrappers_preserve_positional_args_at_use() -> None:
+    observed: list[dict[str, Any]] = []
+
+    def payment_state(**kwargs: Any) -> ValidatorResult:
+        observed.append(kwargs)
+        return ValidatorResult(current=True, value="ready")
+
+    register_use_time_validator("payment_state", payment_state)
+
+    def apply_payment(payment_id: str, expected_state: str) -> str:
+        return payment_id
+
+    wrapped = apply_use_time_currency(
+        apply_payment, _positional_policy(), tool_name="apply_payment"
+    )
+    use_time_facts.capture(
+        name="payment.state",
+        subject_type="payment",
+        subject_id="pay_1",
+        value="ready",
+    )
+    assert wrapped("pay_1", "ready") == "pay_1"
+    assert observed[0]["kwargs"] == {
+        "payment_id": "pay_1",
+        "expected_state": "ready",
+    }
+
+
+def test_async_nonledger_wrapper_preserves_positional_args_at_use() -> None:
+    observed: list[dict[str, Any]] = []
+
+    async def payment_state(**kwargs: Any) -> ValidatorResult:
+        observed.append(kwargs)
+        return ValidatorResult(current=True, value="ready")
+
+    register_use_time_validator("payment_state", payment_state)
+
+    async def apply_payment(payment_id: str, expected_state: str) -> str:
+        return payment_id
+
+    wrapped = apply_use_time_currency(
+        apply_payment, _positional_policy(), tool_name="apply_payment"
+    )
+    use_time_facts.capture(
+        name="payment.state",
+        subject_type="payment",
+        subject_id="pay_1",
+        value="ready",
+    )
+    assert asyncio.run(wrapped("pay_1", "ready")) == "pay_1"
+    assert observed[0]["kwargs"] == {
+        "payment_id": "pay_1",
+        "expected_state": "ready",
+    }
 
 
 def test_fingerprint_excludes_raw_values() -> None:

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -14,6 +14,14 @@ from mycelium.action_ledger import (
     ledger,
     ledger_sync,
     side_effect,
+    side_effect_async,
+)
+from mycelium.authority_window import (
+    AuthorityExpiredError,
+    BoundAuthority,
+    register_authority_for_use,
+    reset_authority_window_state,
+    set_authority_clock,
 )
 from mycelium.config import ConfigError, load_config_from_string
 from mycelium.transition import (
@@ -589,7 +597,7 @@ def test_async_boundary_denies_fact_changed_after_body_start() -> None:
     provider_calls: list[str] = []
     request_ids: list[str] = []
 
-    def payment_state(**_kwargs: Any) -> ValidatorResult:
+    async def payment_state(**_kwargs: Any) -> ValidatorResult:
         return ValidatorResult(current=state["current"], value=state["current"], revision="1")
 
     register_use_time_validator("payment_state", payment_state)
@@ -600,7 +608,7 @@ def test_async_boundary_denies_fact_changed_after_body_start() -> None:
         assert active is not None
         request_ids.append(active.request_id)
         state["current"] = False
-        with side_effect():
+        async with side_effect_async():
             provider_calls.append(payment_id)
 
     wrapped = apply_use_time_currency(refund_payment, _policy(), tool_name="refund_payment")
@@ -622,6 +630,92 @@ def test_async_boundary_denies_fact_changed_after_body_start() -> None:
     asyncio.run(run())
     assert provider_calls == []
     assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_async_boundary_allows_current_fact_with_async_validator() -> None:
+    storage = InMemoryLedgerStorage()
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+
+    async def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+
+    @ledger(storage=storage, transition_binding=_binding())
+    async def refund_payment(payment_id: str, payment_version: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        async with side_effect_async():
+            provider_calls.append(payment_id)
+
+    wrapped = apply_use_time_currency(refund_payment, _policy(), tool_name="refund_payment")
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+    asyncio.run(
+        wrapped(payment_id="pay_1", payment_version="1", request_id="boundary-allow")
+    )
+    assert provider_calls == ["pay_1"]
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.CROSSED.value
+
+
+def test_async_boundary_denies_expired_authority_with_async_validator() -> None:
+    reset_authority_window_state()
+    storage = InMemoryLedgerStorage()
+    clock = {"now": 1_000.0}
+    provider_calls: list[str] = []
+    request_ids: list[str] = []
+    set_authority_clock(lambda: clock["now"])
+
+    async def payment_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True, revision="1")
+
+    register_use_time_validator("payment_state", payment_state)
+    register_authority_for_use(
+        BoundAuthority(
+            authority_id="auth-1",
+            authority_kind="destructive_grant",
+            expires_at=datetime.fromtimestamp(1_010.0, tz=UTC),
+            tool="refund_payment",
+        )
+    )
+
+    @ledger(storage=storage, transition_binding=_binding())
+    async def refund_payment(payment_id: str, payment_version: str) -> None:
+        active = get_active_transition()
+        assert active is not None
+        request_ids.append(active.request_id)
+        clock["now"] = 1_020.0
+        async with side_effect_async():
+            provider_calls.append(payment_id)
+
+    wrapped = apply_use_time_currency(refund_payment, _policy(), tool_name="refund_payment")
+    use_time_facts.capture(
+        name="payment.refundable",
+        subject_type="payment",
+        subject_id="pay_1",
+        value=True,
+        revision="1",
+        require_value=True,
+    )
+
+    async def run() -> None:
+        with pytest.raises(AuthorityExpiredError):
+            await wrapped(
+                payment_id="pay_1", payment_version="1", request_id="boundary-expired"
+            )
+
+    asyncio.run(run())
+    assert provider_calls == []
+    assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+    reset_authority_window_state()
 
 
 def test_fingerprint_excludes_raw_values() -> None:

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -87,7 +87,6 @@ def _policy() -> UseTimeCurrencyPolicy:
                         require={"value": True},
                         revision_from="payment_version",
                         max_age_seconds=30,
-                        bind_request_id=True,
                     ),
                 )
             )
@@ -126,6 +125,27 @@ def _nested_policy(tool: str, fact_name: str, validator: str) -> UseTimeCurrency
                         id_from="resource_id",
                         validator=validator,
                         require={"value": True},
+                    ),
+                )
+            )
+        },
+    )
+
+
+def _context_policy(tool: str) -> UseTimeCurrencyPolicy:
+    return UseTimeCurrencyPolicy(
+        policy_version="test",
+        tools={
+            tool: UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name="resource.current",
+                        subject_type="resource",
+                        id_from="resource_id",
+                        validator="resource_state",
+                        bind_request_id=True,
+                        bind_run_id=True,
+                        bind_thread_id=True,
                     ),
                 )
             )
@@ -1325,6 +1345,69 @@ def test_async_final_boundary_revalidates_distinct_same_fact_requirements() -> N
     assert calls == {"first": 2, "second": 2}
     assert provider_calls == []
     assert storage.get(request_ids[0]).side_effect_boundary == SideEffectBoundary.NOT_CROSSED.value
+
+
+def test_sync_context_binding_rejects_mismatch_before_body() -> None:
+    body_calls: list[str] = []
+
+    def resource_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True)
+
+    register_use_time_validator("resource_state", resource_state)
+
+    def update_resource(resource_id: str, **_kwargs: Any) -> str:
+        body_calls.append(resource_id)
+        return resource_id
+
+    wrapped = apply_use_time_currency(
+        update_resource, _context_policy("update_resource"), tool_name="update_resource"
+    )
+    use_time_facts.capture(
+        name="resource.current",
+        subject_type="resource",
+        subject_id="resource-1",
+        request_id="request-1",
+        run_id="run-1",
+        thread_id="thread-1",
+    )
+    with execution_scope(TransitionScope(run_id="run-2", thread_id="thread-1")):
+        with pytest.raises(UseTimeCurrencyError) as exc:
+            wrapped("resource-1", request_id="request-1")
+    assert exc.value.reason == "subject_mismatch"
+    assert body_calls == []
+
+
+def test_async_context_binding_rejects_missing_capture_before_body() -> None:
+    body_calls: list[str] = []
+
+    async def resource_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True)
+
+    register_use_time_validator("resource_state", resource_state)
+
+    async def update_resource(resource_id: str, **_kwargs: Any) -> str:
+        body_calls.append(resource_id)
+        return resource_id
+
+    wrapped = apply_use_time_currency(
+        update_resource, _context_policy("update_resource"), tool_name="update_resource"
+    )
+    use_time_facts.capture(
+        name="resource.current",
+        subject_type="resource",
+        subject_id="resource-1",
+        request_id="request-1",
+        run_id="run-1",
+    )
+
+    async def run() -> None:
+        with execution_scope(TransitionScope(run_id="run-1", thread_id="thread-1")):
+            with pytest.raises(UseTimeCurrencyError) as exc:
+                await wrapped("resource-1", request_id="request-1")
+        assert exc.value.reason == "missing"
+
+    asyncio.run(run())
+    assert body_calls == []
 
 
 def test_fingerprint_excludes_raw_values() -> None:

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -1138,6 +1138,69 @@ def test_captured_fact_lookup_selects_exact_scope() -> None:
     assert bound[0].tenant == "tenant-1"
 
 
+def test_recapture_replaces_older_scoped_observation_across_metadata() -> None:
+    policy = UseTimeCurrencyPolicy(
+        policy_version="current-policy",
+        tools={
+            "read_resource": UseTimeToolPolicy(
+                facts=(
+                    UseTimeFactSpec(
+                        name="resource.current",
+                        subject_type="resource",
+                        id_from="resource_id",
+                        tenant_from="tenant_id",
+                        account_from="account_id",
+                        validator="resource_state",
+                    ),
+                )
+            )
+        },
+    )
+
+    def resource_state(**_kwargs: Any) -> ValidatorResult:
+        return ValidatorResult(current=True, value=True)
+
+    register_use_time_validator("resource_state", resource_state)
+    use_time_facts.capture(
+        name="resource.current",
+        subject_type="resource",
+        subject_id="shared-id",
+        tenant="tenant-1",
+        account="account-1",
+        value=False,
+        request_id="old-request",
+        run_id="old-run",
+        thread_id="old-thread",
+        tool="old-tool",
+        policy_version="old-policy",
+    )
+    use_time_facts.capture(
+        name="resource.current",
+        subject_type="resource",
+        subject_id="shared-id",
+        tenant="tenant-1",
+        account="account-1",
+        value=True,
+        request_id="new-request",
+        run_id="new-run",
+        thread_id="new-thread",
+        tool="new-tool",
+        policy_version="current-policy",
+    )
+    authorize_use_time_facts(
+        "read_resource",
+        (),
+        {
+            "resource_id": "shared-id",
+            "tenant_id": "tenant-1",
+            "account_id": "account-1",
+        },
+        policy=policy,
+    )
+    decision = enforce_pending_use_time_facts_at_use()
+    assert decision.decision == "allowed"
+
+
 def test_fingerprint_excludes_raw_values() -> None:
     use_time_facts.capture(
         name="payment.refundable",

--- a/sdk/tests/test_verify.py
+++ b/sdk/tests/test_verify.py
@@ -457,6 +457,9 @@ def test_cli_smoke_each_scenario(tmp_path: Path) -> None:
         "reconcile",
         "secret-in-args",
         "entity-guard",
+        "destructive-confirm",
+        "authority-window",
+        "use-time-currency",
     ):
         code = main(
             [
@@ -668,6 +671,9 @@ def test_all_order_sqlite(tmp_path: Path, scenario: str) -> None:
         "reconcile",
         "secret-in-args",
         "entity-guard",
+        "destructive-confirm",
+        "authority-window",
+        "use-time-currency",
     ]
     assert all(item.status == VerificationStatus.PASS for item in report.scenarios)
     assert report.empirically_verified is True

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.32.0"
+version = "1.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Ship the five-item side-effect guardrails batch: secret-in-args (AF-010), entity guard, destructive confirm (AF-011), authority-window expiry, and use-time currency (AF-012).
- Revalidate authority and use-time facts unconditionally at the final side-effect boundary; fail closed on stale/changed/missing/unverifiable facts and incomplete scoped evidence.
- Compare configured request/run/thread bindings against the current trusted dispatch/execution scope at USE (including after `dispatch_scope` switches), not only authorize-time call kwargs.

## Test plan
- [x] Focused `tests/test_use_time_currency.py` (+ authority/destructive/langgraph/verify)
- [x] Full pytest suite
- [x] Ruff
- [x] README documentation checks (no pinned badge / hardcoded version banners)
- [ ] CI green on this PR

**Note:** Do not publish/tag/release from this PR until explicitly authorized. Package version remains `1.33.0` in pyproject (no further bump).