### PR TITLE
docs: add security policy and private vulnerability reporting (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ or `'mycelium-runtime[postgres]'`. See the
 - **Full API reference:** [sdk/README.md](sdk/README.md)
 - **Doctor vs Verify:** `mycelium doctor` inspects configuration; `mycelium verify` runs synthetic failure scenarios. Neither proves a real provider is correct.
 - **Release policy & checklist:** [sdk/docs/RELEASE.md](sdk/docs/RELEASE.md) (batch; calm over velocity)
+- **Security policy & private reporting:** [SECURITY.md](SECURITY.md)
 - **PyPI:** https://pypi.org/project/mycelium-runtime/
 
 ## Release process

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,113 @@
+# Security policy
+
+Mycelium is a reliability and safety boundary around **consequential tool
+execution** (payments, outbound email, API mutations, and similar side
+effects). Security-sensitive reports deserve a **private** path — not a public
+issue comment thread.
+
+## Supported versions
+
+Security fixes ship on the **latest published** [`mycelium-runtime`](https://pypi.org/project/mycelium-runtime/)
+release (see PyPI for the current version).
+
+| Status | Policy |
+|--------|--------|
+| **Latest PyPI release** | Receives security fixes as PATCH releases when applicable. |
+| **Previous minor line** | May receive backported fixes at maintainer discretion; ask if you are pinned. |
+| **Older releases** | Unsupported — upgrade to the latest release before requesting a fix. |
+
+Release cadence and semver rules: [`sdk/docs/RELEASE.md`](sdk/docs/RELEASE.md).
+Security issues may justify an out-of-band PATCH even when the normal batch
+cadence would wait.
+
+## Reporting a vulnerability
+
+**Do not** open a public GitHub issue for an exploitable or suspected
+exploitable vulnerability.
+
+### Preferred: GitHub private vulnerability reporting
+
+Use the repository's private advisory form (maintainers only see the report
+until disclosure is coordinated):
+
+**https://github.com/mycelium-labs/mycelium/security/advisories/new**
+
+This is the preferred channel. It keeps reproduction details, credentials, and
+customer impact out of public view.
+
+### What to include
+
+Please provide as much of the following as you can:
+
+1. **Summary** — what can go wrong, and under what configuration (YAML profile,
+   storage backend, side-effect class, guard modules enabled).
+2. **Impact** — duplicate side effects, bypass of a guard, data exposure,
+   privilege escalation, or denial of service.
+3. **Reproduction** — minimal steps, version or commit, and synthetic fixtures
+   only (see below).
+4. **Proof-of-concept** — if you have one, attach it to the private advisory
+   rather than pasting it in a public forum.
+
+### What not to include
+
+- Live production credentials, API keys, or session tokens
+- Real customer data, payment instruments, or PII from production systems
+- Unredacted logs from production deployments
+
+Use `mycelium verify` scenarios, in-memory/file ledger storage, and synthetic
+destinations when demonstrating a boundary failure. See
+[`sdk/docs/FAILURE_AND_THREAT_MODEL.md`](sdk/docs/FAILURE_AND_THREAT_MODEL.md)
+for scope boundaries.
+
+## Response expectations
+
+| Milestone | Target |
+|-----------|--------|
+| **Initial acknowledgement** | Within **3 business days** of a well-formed private report. |
+| **Triage / severity assessment** | Within **10 business days** when possible. |
+| **Fix or mitigation plan** | Communicated in the private advisory thread; timeline depends on severity and complexity. |
+
+We may ask clarifying questions. Silence on a public issue does not mean a
+report was ignored — use the private advisory path above.
+
+## Coordinated disclosure
+
+We prefer coordinated disclosure:
+
+1. Report privately and allow reasonable time to investigate and ship a fix.
+2. Do not disclose exploit details publicly until we agree on timing, or until
+   **90 days** have passed with no good-faith progress (whichever comes first,
+   unless a shorter window is required to protect users).
+3. We will credit reporters who wish to be named when we publish an advisory;
+   tell us your preference.
+
+## Operator actions are not authenticated via GitHub
+
+Mycelium's CLI supports operator workflows such as
+`mycelium transitions release` (documented in the SDK README). The `--by`
+field and similar audit stamps record **who the host asserts** performed an
+action; they are **not** an authentication or authorization mechanism.
+
+**GitHub issue comments, PR reviews, and discussion threads are not a valid
+channel to authorize operator release, destructive grants, or production
+configuration changes.** Attackers must not be able to social-engineer a
+release by commenting on a public thread. Hosts must enforce release authority
+through their own identity, access control, and runbooks.
+
+If you find a way to bypass ledger gates, reconciliation, or guard predicates
+without proper host authorization, report it privately using the advisory form
+above.
+
+## Security-related documentation
+
+- Failure and threat model (ledger core guarantees and limits):
+  [`sdk/docs/FAILURE_AND_THREAT_MODEL.md`](sdk/docs/FAILURE_AND_THREAT_MODEL.md)
+- Release and hotfix policy:
+  [`sdk/docs/RELEASE.md`](sdk/docs/RELEASE.md)
+
+## Questions that are not vulnerabilities
+
+Configuration questions, feature requests, and general reliability discussions
+belong in [GitHub Discussions](https://github.com/mycelium-labs/mycelium/discussions)
+or a public issue when no exploit is involved. When in doubt, start with a
+private advisory — we can always reclassify a report as a bug or docs fix.


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` with supported-version policy, private reporting via GitHub Security Advisories, report contents, response timelines, coordinated disclosure, and explicit guidance that public GitHub threads are not an operator-release auth channel.
- Links the policy from the root README Docs section.
- Enables GitHub **private vulnerability reporting** on the repository (repo setting).

Closes #86.

## Test plan
- [x] `SECURITY.md` present at repository root (GitHub Security tab will surface it after merge).
- [x] Private advisory form: https://github.com/mycelium-labs/mycelium/security/advisories/new
- [x] README links to `SECURITY.md`.