### PR TITLE
fix(sdk): clarify budget metering and scoped state queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+- Budget accounting now warns when `record_usage(steps=...)` is combined with
+  the step meter that `check()` and `@budget_guard` enable by default, preventing
+  silent double metering. `get_state()` now matches `remaining_budget()` by
+  resolving the active execution scope when no key is passed, and the runway
+  contract explicitly distinguishes a missing scope from a hard-blocked run.
+
 - Deterministic simulation proof (effect-commit Change 4). New
   `mycelium.verify.invariants` module (`InvariantViolation`,
   `committed_effect_ids`, `check_at_most_one_committed`,

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1219,11 +1219,19 @@ without token metadata.
 Custom providers only: `wrap_llm_callable` / `instrument_llm` /
 `register_llm_budget_adapter` / manual `check("llm")` + `record_usage()`.
 Official LangGraph/LangChain integrations do not need those calls.
+`check()` and `@budget_guard` reserve one step automatically. Use
+`record_usage()` for observed token/USD usage without passing `steps`; combining
+the default check/decorator behavior with `record_usage(steps=...)` double-meters
+the run and emits a warning. A fully manual host that owns step accounting may
+use `check(..., increment_steps=False)` before reporting steps explicitly.
 Soft warn (`warn_at`) → `warnings.warn` once per dimension; the step **still
 runs**. Hard → `LedgerHardBlockError` only at the declared ceiling (never kill
 mid-flight). Operator: `mycelium budget status|release` (`clear` /
 `allow-once` / `abort-run`). Status exposes deterministic `remaining_budget`
-(pitch word: runway).
+(pitch word: runway). `get_state()` and `remaining_budget()` both resolve the
+active execution scope when called without a key. Outside that scope, pass the
+run key explicitly; `remaining_budget() is None` means no scope was resolvable,
+not that the run was hard-blocked.
 
 ```bash
 mycelium loops status --stuck --config mycelium.yaml

--- a/sdk/mycelium/budget_guard.py
+++ b/sdk/mycelium/budget_guard.py
@@ -714,8 +714,17 @@ class BudgetGuard:
     def ceilings(self) -> BudgetCeilings:
         return self._ceilings
 
-    def get_state(self, scope_key: str) -> BudgetRunState | None:
-        return self._storage.get(scope_key)
+    def get_state(
+        self,
+        scope_key: str | None = None,
+        *,
+        kwargs: dict[str, Any] | None = None,
+    ) -> BudgetRunState | None:
+        """Return state for an explicit or currently active execution scope."""
+        key = scope_key or resolve_loop_scope_key(kwargs=kwargs)
+        if key is None:
+            return None
+        return self._storage.get(key)
 
     def remaining_budget(
         self,
@@ -723,6 +732,13 @@ class BudgetGuard:
         *,
         kwargs: dict[str, Any] | None = None,
     ) -> RemainingBudget | None:
+        """Return runway for an explicit or currently active execution scope.
+
+        A hard-blocked run still has a deterministic snapshot (normally zero
+        in the blocked dimension). ``None`` means no scope key could be
+        resolved, not that the run is blocked. Pass ``scope_key`` when querying
+        after leaving ``execution_scope``.
+        """
         key = scope_key or resolve_loop_scope_key(kwargs=kwargs)
         if key is None:
             return None
@@ -874,8 +890,10 @@ class BudgetGuard:
         """Atomically add host-reported usage and gate for the next step.
 
         Prefer ``check()`` to reserve steps before work; use ``record_usage``
-        after the host observes token/USD spend. ``steps`` defaults to 0 so
-        double-counting with ``check(increment_steps=True)`` is avoided.
+        after the host observes token/USD spend. ``check()`` and the budget
+        decorators auto-meter one step by default. Passing ``steps`` here is
+        supported for fully manual integrations, but warns because combining
+        it with the default check/decorator behavior double-counts steps.
         """
         global _SCOPE_MISSING_WARNED
 
@@ -900,6 +918,15 @@ class BudgetGuard:
         add_steps = int(steps)
         if add_in < 0 or add_out < 0 or add_usd < 0 or add_steps < 0:
             raise ValueError("usage deltas must be non-negative")
+        if add_steps:
+            warnings.warn(
+                "BudgetGuard.record_usage(steps=...) adds host-reported steps, "
+                "but check() and @budget_guard auto-meter one step by default. "
+                "Use steps=0, or use check(increment_steps=False) in a fully "
+                "manual integration, to avoid double metering.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         outcome: dict[str, Any] = {"exc": None, "state": None}
 

--- a/sdk/tests/test_budget_guard.py
+++ b/sdk/tests/test_budget_guard.py
@@ -147,6 +147,39 @@ def test_llm_check_and_record_usage_usd() -> None:
             guard.check(KIND_LLM)
 
 
+def test_record_usage_steps_warns_about_double_metering() -> None:
+    guard = BudgetGuard(InMemoryBudgetGuardStorage(), max_steps=10, warn_at=1.0)
+    with execution_scope(_scope("double-meter")):
+        guard.check(KIND_TOOL)
+        with pytest.warns(UserWarning, match="auto-meter one step"):
+            state = guard.record_usage(steps=1)
+    assert state.steps == 2
+
+
+def test_state_queries_resolve_scope_and_preserve_blocked_runway() -> None:
+    guard = BudgetGuard(InMemoryBudgetGuardStorage(), max_steps=1, warn_at=1.0)
+    with execution_scope(_scope("query-blocked")):
+        guard.check(KIND_TOOL)
+        with pytest.raises(LedgerHardBlockError):
+            guard.check(KIND_TOOL)
+
+        state = guard.get_state()
+        remaining = guard.remaining_budget()
+        assert state is not None
+        assert state.hard_blocked
+        assert remaining is not None
+        assert remaining.steps == 0
+
+    assert guard.get_state() is None
+    assert guard.remaining_budget() is None
+    explicit_state = guard.get_state("query-blocked")
+    assert explicit_state is not None
+    assert explicit_state.to_dict() == state.to_dict()
+    explicit_remaining = guard.remaining_budget("query-blocked")
+    assert explicit_remaining is not None
+    assert explicit_remaining.steps == 0
+
+
 def test_missing_meter_fail_closed() -> None:
     guard = BudgetGuard(
         InMemoryBudgetGuardStorage(),


### PR DESCRIPTION
## Intent

Fix BudgetGuard so explicit host-reported steps warn about silent double metering, document that guard checks and decorators auto-meter steps, align get_state with remaining_budget scope resolution, and make hard-blocked remaining-budget behavior clear and test-covered without guessing a last run outside execution scope.

## What Changed

- Warn when host-reported `record_usage(steps=...)` may double-meter steps already counted by `check()` or `@budget_guard`.
- Make `get_state()` resolve the active execution scope like `remaining_budget()`, while returning `None` outside a resolvable scope unless an explicit key is supplied.
- Document and test scoped state queries, explicit step metering, and deterministic zero runway for hard-blocked runs.

## Risk Assessment

✅ Low: The change is well-bounded, preserves existing metering behavior, adds behavior-level regression coverage, and satisfies the documented scope-resolution and hard-blocked runway requirements.

## Testing

No baseline validation output was supplied; after resolving local interpreter setup with an ephemeral Python 3.11 environment, the targeted warning, decorator metering, scope resolution, and hard-block runway tests passed, and an API transcript confirmed that blocked runway remains zero while only an unresolved out-of-scope query returns null. No visual artifact was captured because this is a Python API/documentation change with no rendered UI.

<details>
<summary>Evidence: BudgetGuard public API behavior transcript</summary>

```text
{
  "decorated_tool_result": "tool completed",
  "explicit_step_warning": "BudgetGuard.record_usage(steps=...) adds host-reported steps, but check() and @budget_guard auto-meter one step by default. Use steps=0, or use check(increment_steps=False) in a fully manual integration, to avoid double metering.",
  "hard_block_error": "BudgetGuard: run 'run-blocked' exceeded max_steps. Release with: mycelium budget release run-blocked --verified clear|allow-once|abort-run --by \u2026 --reason \u2026",
  "inside_scope": {
    "blocked_dimension": "max_steps",
    "hard_blocked": true,
    "remaining_steps": 0,
    "state_key": "run-blocked"
  },
  "outside_scope_with_explicit_key": {
    "hard_blocked": true,
    "remaining_steps": 0,
    "state_key": "run-blocked"
  },
  "outside_scope_without_key": {
    "remaining_budget": null,
    "state": null
  },
  "steps_after_decorator_plus_host_report": 2
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"47fb557607c5ab45efe56f6ac01eef56e8ce178c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python -m pytest ...` (setup attempt: no `python` executable)</code>
- <code>`python3 -m pytest -q tests/test_budget_guard.py::test_record_usage_steps_warns_about_double_metering tests/test_budget_guard.py::test_state_queries_resolve_scope_and_preserve_blocked_runway tests/test_budget_guard.py::test_max_steps_soft_warn_allows_then_hard` (setup attempt: system Python 3.9 is below the required 3.10)</code>
- <code>`python3.11 -m pytest -q ...` (setup attempt: pytest unavailable in that interpreter)</code>
- `uv run --python 3.11 --with pytest --with pytest-asyncio pytest -q tests/test_budget_guard.py::test_record_usage_steps_warns_about_double_metering tests/test_budget_guard.py::test_state_queries_resolve_scope_and_preserve_blocked_runway tests/test_budget_guard.py::test_max_steps_soft_warn_allows_then_hard`
- <code>Executed the public BudgetGuard API under Python 3.11 with a decorated tool, explicit `record_usage(steps=1)`, a hard-blocked run, scoped queries, out-of-scope queries, and explicit-key queries; captured the resulting JSON transcript.</code>
- `python3 -m json.tool /var/folders/9d/l9xvxbb94fs4fmj3wb0lw3100000gn/T/no-mistakes-evidence/01M0EJC28Q68EBQTZT3RJ6XF1J/budget_guard_api_transcript.json`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
