### PR TITLE
feat: unified EffectState effect-commit protocol kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+- Unified durable WAL intent (`EffectState`) completes the effect-commit
+  protocol. New `mycelium.transition.EffectState` (INTENDED / ATTEMPTING /
+  COMMITTED / ABORTED / UNKNOWN) plus `resolve_effect_state(entry)` collapses
+  the legacy `terminal_outcome` + `effect_phase` + `decision` columns into a
+  single state for a ledger row; `LedgerEntry` now persists `effect_id` and
+  `schema_version`, and `EffectState` / `resolve_effect_state` are exported
+  from the package root. A row parked UNKNOWN (decision present, protocol
+  required) stays reconcilable by the durable `decision` gate, which no longer
+  consults `resolve_effect_state` for the attempting check. `mycelium.verify`
+  gains three new invariant checks asserting the same at-most-one-COMMITTED
+  guarantee on the unified EffectState view — `committed_effect_ids_by_state`,
+  `check_at_most_one_committed_effect_state`, `check_effect_state_consistency`
+  — and the `simulation` verify scenario now asserts the EffectState invariant
+  alongside the terminal_outcome one on every crash phase and the two-worker
+  fence takeover. Storage CAS kwarg naming now uses
+  `expected_effect_state` (renamed from `expected_effect_phase`, same
+  EffectState-string semantics), and `profile: production` now defaults
+  `action_ledger.unclassified_policy` to `strict` when omitted
+  (explicit `warn` remains honored).
+
+- TODO(Change 5): exhaustive interleaving simulation and a formal
+  TLA+/PlusCal spec of the intent state machine.
+
 - Budget accounting now warns when `record_usage(steps=...)` is combined with
   the step meter that `check()` and `@budget_guard` enable by default, preventing
   silent double metering. `get_state()` now matches `remaining_budget()` by

--- a/sdk/mycelium/__init__.py
+++ b/sdk/mycelium/__init__.py
@@ -307,6 +307,7 @@ from mycelium.tool_boundary import (
 from mycelium.tool_registry import ToolRegistry
 from mycelium.tool_runner import ToolRunner
 from mycelium.transition import (
+    EffectState,
     HandoffLink,
     LeaseValidity,
     MissingRequestIdentityError,
@@ -332,6 +333,7 @@ from mycelium.transition import (
     provider_key_validity,
     request_id_from_argument,
     resolve_capability,
+    resolve_effect_state,
     resolve_lease_validity,
 )
 from mycelium.transition_resolution import (
@@ -536,6 +538,8 @@ __all__ = [
     "resolve_capability",
     "RetryPermission",
     "TerminalOutcome",
+    "EffectState",
+    "resolve_effect_state",
     "LeaseValidity",
     "ProviderKeyValidity",
     "TransitionGate",

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -38,6 +38,7 @@ from mycelium.transition import (
     REQUEST_IDENTITY_POLICIES,
     REQUEST_IDENTITY_POLICY_DERIVED,
     REQUEST_IDENTITY_POLICY_REQUIRE_EXPLICIT,
+    EffectState,
     LeaseValidity,
     MissingRequestIdentityError,
     SideEffectBoundary,
@@ -47,6 +48,7 @@ from mycelium.transition import (
     ToolTransitionBinding,
     args_fingerprint,
     derive_dispatch_id,
+    derive_effect_id_for_call,
     derive_transition_key_for_call,
     extract_provider_idempotency_key,
     get_active_dispatch_id,
@@ -56,6 +58,7 @@ from mycelium.transition import (
     legacy_status_from_terminal,
     parse_explicit_request_id,
     request_id_from_argument,
+    resolve_effect_state,
     resolve_lease_validity,
     resolve_scope,
     resolve_terminal_outcome,
@@ -207,7 +210,21 @@ _UNKNOWN_SAME_KEY_RETRY_OUTCOMES: frozenset[str] = frozenset(
 # Policies for tools ledgered without a transition_binding (unclassified).
 # "warn": legacy behavior + a one-time warning when a failed entry is
 # reclaimed. "strict": route the claim through claim_side_effecting with a
-# conservative synthesized binding so failed retries hard-block.
+# conservative synthesized binding so failed retries hard-block — this is
+# the write-ahead-ordering-complete path (INTENDED -> ATTEMPTING/ABORTED CAS
+# before any body execution), the same protocol every classified
+# consequential tool goes through.
+#
+# ActionLedger.__init__ keeps "warn" as the constructor default for backward
+# compatibility: every existing unclassified `claim()` caller (tests and
+# hosts) that has not opted in would otherwise silently start hard-blocking
+# failed retries. YAML tool templates already default to "strict" for new
+# deployments (see mycelium/templates/); `mycelium doctor` accepts "warn" as
+# a valid, non-erroring choice. Hosts that want every claim() — classified or
+# not — to go through the full effect-commit protocol should pass
+# `unclassified_policy="strict"` explicitly. `MyceliumConfig.apply_tool`
+# additionally defaults this to "strict" when `profile: production` and
+# `action_ledger.unclassified_policy` is omitted.
 UNCLASSIFIED_POLICY_WARN = "warn"
 UNCLASSIFIED_POLICY_STRICT = "strict"
 
@@ -538,6 +555,14 @@ def _lease_auto_renew(
         thread.join(timeout=max(interval, MIN_LEASE_RENEW_INTERVAL) + 1.0)
 
 
+# LedgerEntry.schema_version. Bumped for the effect-commit protocol
+# completion: rows now carry a durable `effect_id` (schema 2). Legacy rows
+# missing the field load as schema 1 and infer `effect_id` from `request_id`
+# (see LedgerEntry.from_dict) — this is a read-time inference, not a storage
+# migration, so old rows keep working unchanged.
+LEDGER_ENTRY_SCHEMA_VERSION = 2
+
+
 @contextmanager
 def side_effect() -> Iterator[None]:
     """Wrap the external operation of a side-effecting tool.
@@ -629,8 +654,38 @@ class LedgerEntry:
     # transition under the same fenced CAS. ``None`` when no decision was
     # recorded (timeless paths, older rows).
     decision: dict[str, Any] | None = None
-    effect_phase: str = "INTENDED"
+    # Storage field for the unified WAL intent (mycelium.transition.EffectState).
+    # Kept as ``effect_phase`` (not renamed to ``effect_state``) for
+    # serialization compatibility with every existing stored row and every
+    # existing raw-string comparison in this module; every value this field
+    # holds is a member of EffectState. ``terminal_outcome`` remains the
+    # legacy read alias (also carries UNKNOWN/BLOCKED/FAILED_* detail).
+    # New protocol-gating code must not compare this field directly — call
+    # resolved_effect_state() / resolve_effect_state(entry), which correctly
+    # folds in UNKNOWN and legacy rows that predate this field.
+    effect_phase: str = EffectState.INTENDED.value
     effect_protocol_required: bool = False
+
+    # Stable effect identity (mycelium.transition.derive_effect_id_for_call):
+    # a hash of (scope, tool, canonicalized args/kwargs, destination) that is
+    # deterministic and destination-aware, independent of which request_id a
+    # host happened to supply. ``request_id`` remains the storage key (every
+    # existing backend and test keys rows by it) — effect_id is an additional
+    # durable field for redispatch-collision auditing. When request_id is
+    # *derived* (the default — no explicit request_id/request_id_from kwarg),
+    # request_id already equals effect_id today (derive_request_id falls back
+    # to the same transition-key derivation), so the two collide naturally.
+    # When a host supplies an *explicit* request_id (its own business/audit
+    # id), effect_id is the independent dedup identity computed from the call
+    # shape alone; two different explicit request_ids for what is otherwise
+    # the same (tool, params, destination) are NOT unified into one storage
+    # row by this change (that would require a cross-backend secondary index
+    # keyed by effect_id, which is out of scope here) — hosts that redispatch
+    # the same logical effect must reuse the same request_id, as documented
+    # elsewhere. ``None`` for unclassified claims (no binding to derive from).
+    effect_id: str | None = None
+    # Schema version for this row's shape. See LEDGER_ENTRY_SCHEMA_VERSION.
+    schema_version: int = LEDGER_ENTRY_SCHEMA_VERSION
 
     # Thin handoff / causation audit (optional). Set via ``handoff_scope`` or
     # kwargs; does not grant capabilities or change claim gates.
@@ -641,6 +696,12 @@ class LedgerEntry:
         # Match from_dict / claim: durable key defaults to request_id.
         if self.idempotency_key is None:
             object.__setattr__(self, "idempotency_key", self.request_id)
+        # effect_id must always be present on a stored row (see field
+        # docstring above); tools with no binding to derive it from (the
+        # unclassified claim() path) fall back to request_id, same as
+        # idempotency_key.
+        if self.effect_id is None:
+            object.__setattr__(self, "effect_id", self.request_id)
 
     def resolved_terminal_outcome(self, *, now: float | None = None) -> TerminalOutcome:
         return resolve_terminal_outcome(
@@ -648,6 +709,16 @@ class LedgerEntry:
             lease_until=self.lease_until,
             now=now,
         )
+
+    def resolved_effect_state(self) -> EffectState:
+        """Unified WAL intent (mycelium.transition.EffectState) for this row.
+
+        The legacy-safe read path: works for rows written before this field
+        existed as well as current rows. Prefer this (or
+        :func:`mycelium.transition.resolve_effect_state`) over comparing
+        ``effect_phase`` / ``terminal_outcome`` directly.
+        """
+        return resolve_effect_state(self)
 
     def lease_validity(self, *, now: float | None = None) -> LeaseValidity:
         """Return whether this entry's execution lease is still held."""
@@ -698,6 +769,8 @@ class LedgerEntry:
             "decision": self.decision,
             "effect_phase": self.effect_phase,
             "effect_protocol_required": self.effect_protocol_required,
+            "effect_id": self.effect_id,
+            "schema_version": self.schema_version,
             "parent_request_id": self.parent_request_id,
             "handoff_id": self.handoff_id,
         }
@@ -748,8 +821,13 @@ class LedgerEntry:
             decision_id=(str(data["decision_id"]) if data.get("decision_id") is not None else None),
             state_ref=(str(data["state_ref"]) if data.get("state_ref") is not None else None),
             decision=(dict(data["decision"]) if data.get("decision") is not None else None),
-            effect_phase=str(data.get("effect_phase") or "INTENDED"),
+            effect_phase=str(data.get("effect_phase") or EffectState.INTENDED.value),
             effect_protocol_required=bool(data.get("effect_protocol_required", False)),
+            # Legacy rows (schema 1) have no effect_id: infer it from
+            # request_id, which is exactly what it would equal for the
+            # (default) derived-request_id path anyway.
+            effect_id=str(data.get("effect_id") or request_id),
+            schema_version=int(data.get("schema_version") or 1),
             parent_request_id=(
                 str(data["parent_request_id"])
                 if data.get("parent_request_id") is not None
@@ -760,7 +838,16 @@ class LedgerEntry:
 
 
 def _has_allowed_attempting_decision(entry: LedgerEntry) -> bool:
-    if entry.effect_phase != "ATTEMPTING" or entry.decision is None:
+    """True when an allowed decision was durably recorded at ATTEMPTING.
+
+    Gates on the durable ``decision`` field alone, not on the current
+    ``resolve_effect_state``: a row that crashed or was marked UNKNOWN while
+    ATTEMPTING keeps its recorded allowed decision and must remain completable
+    by the reconciler / operator. ``record_decision`` only stamps a decision
+    during the ``INTENDED -> ATTEMPTING | ABORTED`` CAS, so a present, allowed
+    decision provably means the row passed the single decision point.
+    """
+    if entry.decision is None:
         return False
     from mycelium.decision import Decision
 
@@ -807,7 +894,7 @@ class LedgerStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         """Atomically write *entry* only if the stored entry's terminal outcome
         is one of *expected_terminal_outcomes* (and *expected_owner* matches,
@@ -824,6 +911,9 @@ class LedgerStorage:
         Returns ``True`` when the write succeeds, ``False`` when the pre-condition
         is not met (caller raises ``LedgerOutcomeAlreadySetError``).
 
+        When ``expected_effect_state`` is set, compare the stored
+        ``effect_phase`` against that unified ``EffectState`` member string.
+
         The default implementation performs a get+set (single-process only).
         Override with an atomic compare-and-swap for multi-process backends.
         """
@@ -836,7 +926,7 @@ class LedgerStorage:
             return False
         if expected_fence is not None and existing.fence != expected_fence:
             return False
-        if expected_effect_phase is not None and existing.effect_phase != expected_effect_phase:
+        if expected_effect_state is not None and existing.effect_phase != expected_effect_state:
             return False
         if require_lease_held_at is not None and not lease_allows_renew(
             existing.lease_until, now=require_lease_held_at
@@ -887,7 +977,7 @@ class InMemoryLedgerStorage(LedgerStorage):
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         with self._lock:
             existing = self._entries.get(entry.request_id)
@@ -899,7 +989,7 @@ class InMemoryLedgerStorage(LedgerStorage):
                 return False
             if expected_fence is not None and existing.fence != expected_fence:
                 return False
-            if expected_effect_phase is not None and existing.effect_phase != expected_effect_phase:
+            if expected_effect_state is not None and existing.effect_phase != expected_effect_state:
                 return False
             if require_lease_held_at is not None and not lease_allows_renew(
                 existing.lease_until, now=require_lease_held_at
@@ -980,7 +1070,7 @@ class FileLedgerStorage(LedgerStorage):
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         result: list[bool] = []
 
@@ -999,7 +1089,7 @@ class FileLedgerStorage(LedgerStorage):
             if expected_fence is not None and existing.fence != expected_fence:
                 result.append(False)
                 return
-            if expected_effect_phase is not None and existing.effect_phase != expected_effect_phase:
+            if expected_effect_state is not None and existing.effect_phase != expected_effect_state:
                 result.append(False)
                 return
             if require_lease_held_at is not None and not lease_allows_renew(
@@ -1124,7 +1214,7 @@ class ActionLedger:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         """Atomically write *entry* subject to outcome/owner/fence pre-conditions.
 
@@ -1141,7 +1231,7 @@ class ActionLedger:
                 expected_owner=expected_owner,
                 require_lease_held_at=require_lease_held_at,
                 expected_fence=fence,
-                expected_effect_phase=expected_effect_phase,
+                expected_effect_state=expected_effect_state,
             )
 
     def _list_all_entries(self) -> list[LedgerEntry]:
@@ -1609,7 +1699,7 @@ class ActionLedger:
                 finished_at=now,
                 lease_until=None,
                 side_effect_boundary=SideEffectBoundary.CROSSED.value,
-                effect_phase="COMMITTED",
+                effect_phase=EffectState.COMMITTED.value,
                 operator_resolution=OPERATOR_RESOLUTION_COMPLETED,
                 resolved_by=by,
                 resolution_reason=reason,
@@ -1692,6 +1782,14 @@ class ActionLedger:
         if handoff_raw is None and active_handoff is not None:
             handoff_raw = active_handoff.handoff_id
         stored_args, stored_kwargs = _evidence_args(bound["args"], bound["kwargs"])
+        # Stable effect identity, present whenever a binding is available to
+        # derive it from (classified tools only — unclassified claim() has no
+        # side-effect class and stays effect_id=None). Same derivation as
+        # derive_request_id's fallback, so request_id == effect_id whenever
+        # request_id itself was derived (the default) rather than explicit.
+        effect_id = (
+            derive_effect_id_for_call(tool, args, kwargs, binding) if binding is not None else None
+        )
         return LedgerEntry(
             request_id=request_id,
             tool=tool,
@@ -1709,6 +1807,7 @@ class ActionLedger:
             parent_request_id=str(parent_raw) if parent_raw is not None else None,
             handoff_id=str(handoff_raw) if handoff_raw is not None else None,
             effect_protocol_required=binding is not None,
+            effect_id=effect_id,
         )
 
     def claim(
@@ -2998,15 +3097,15 @@ class ActionLedger:
             finished_at=time.time(),
             lease_until=None,
             side_effect_boundary=SideEffectBoundary.CROSSED.value,
-            effect_phase="COMMITTED",
+            effect_phase=EffectState.COMMITTED.value,
         )
         if not self._try_transition(
             entry,
             expected_from=_expected_from,
             expected_owner=_expected_owner,
             expected_fence=fence,
-            expected_effect_phase=(
-                "ATTEMPTING"
+            expected_effect_state=(
+                EffectState.ATTEMPTING.value
                 if existing.effect_protocol_required
                 else None
             ),
@@ -3067,9 +3166,9 @@ class ActionLedger:
                 existing.effect_phase
                 if failed_after_effect
                 and existing.effect_protocol_required
-                and existing.effect_phase == "ATTEMPTING"
+                and existing.effect_phase == EffectState.ATTEMPTING.value
                 and existing.decision is not None
-                else "ABORTED"
+                else EffectState.ABORTED.value
             ),
         )
         if not self._try_transition(
@@ -3150,8 +3249,8 @@ class ActionLedger:
             expected_from=frozenset({existing.terminal_outcome}),
             expected_owner=expected_owner,
             expected_fence=expected_fence,
-            expected_effect_phase=(
-                "ATTEMPTING" if existing.effect_protocol_required else None
+            expected_effect_state=(
+                EffectState.ATTEMPTING.value if existing.effect_protocol_required else None
             ),
         ):
             raise LedgerOutcomeAlreadySetError(
@@ -3314,9 +3413,9 @@ class ActionLedger:
             effect_phase=(
                 existing.effect_phase
                 if existing.effect_protocol_required
-                and existing.effect_phase == "ATTEMPTING"
+                and existing.effect_phase == EffectState.ATTEMPTING.value
                 and existing.decision is not None
-                else "ABORTED"
+                else EffectState.ABORTED.value
             ),
         )
         if not self._try_transition(
@@ -3362,9 +3461,9 @@ class ActionLedger:
             effect_phase=(
                 existing.effect_phase
                 if existing.effect_protocol_required
-                and existing.effect_phase == "ATTEMPTING"
+                and existing.effect_phase == EffectState.ATTEMPTING.value
                 and existing.decision is not None
-                else "ABORTED"
+                else EffectState.ABORTED.value
             ),
         )
         if not self._try_transition(
@@ -3561,8 +3660,8 @@ class ActionLedger:
             expected_from=frozenset({existing.terminal_outcome}),
             expected_owner=expected_owner,
             expected_fence=expected_fence,
-            expected_effect_phase=(
-                "ATTEMPTING" if existing.effect_protocol_required else None
+            expected_effect_state=(
+                EffectState.ATTEMPTING.value if existing.effect_protocol_required else None
             ),
         ):
             raise LedgerOutcomeAlreadySetError(
@@ -3603,14 +3702,16 @@ class ActionLedger:
         entry = replace(
             existing,
             decision=parsed.to_dict(),
-            effect_phase="ATTEMPTING" if parsed.allowed else "ABORTED",
+            effect_phase=(
+                EffectState.ATTEMPTING.value if parsed.allowed else EffectState.ABORTED.value
+            ),
         )
         if not self._try_transition(
             entry,
             expected_from=_IN_FLIGHT_OUTCOMES,
             expected_owner=expected_owner,
             expected_fence=expected_fence,
-            expected_effect_phase="INTENDED",
+            expected_effect_state=EffectState.INTENDED.value,
         ):
             raise LedgerOutcomeAlreadySetError(
                 f"Cannot record decision for {request_id!r}: "

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -18,6 +18,7 @@ import yaml
 from mycelium.action_ledger import (
     ARGS_DRIFT_POLICIES,
     ARGS_DRIFT_SOFT,
+    UNCLASSIFIED_POLICY_STRICT,
     UNCLASSIFIED_POLICY_WARN,
     FileLedgerStorage,
     InMemoryLedgerStorage,
@@ -747,9 +748,12 @@ class MyceliumConfig:
             transition_binding = self.tool_transition_binding(tool_config)
             ledger_kwargs = self._ledger_timing_kwargs()
             action_ledger_cfg = self.action_ledger or {}
-            unclassified_policy = action_ledger_cfg.get(
-                "unclassified_policy", UNCLASSIFIED_POLICY_WARN
-            )
+            if "unclassified_policy" in action_ledger_cfg:
+                unclassified_policy = action_ledger_cfg["unclassified_policy"]
+            elif self.profile == PROFILE_PRODUCTION:
+                unclassified_policy = UNCLASSIFIED_POLICY_STRICT
+            else:
+                unclassified_policy = UNCLASSIFIED_POLICY_WARN
             ledger_kwargs["unclassified_policy"] = unclassified_policy
             on_args_drift = action_ledger_cfg.get("on_args_drift", ARGS_DRIFT_SOFT)
             if on_args_drift not in ARGS_DRIFT_POLICIES:

--- a/sdk/mycelium/storage/postgres_ledger.py
+++ b/sdk/mycelium/storage/postgres_ledger.py
@@ -154,7 +154,7 @@ class PostgresEntryStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         self._ensure_schema()
         table = self._table_id()
@@ -176,11 +176,11 @@ class PostgresEntryStorage:
                 "{} AND COALESCE((payload->>'fence')::bigint, 0) = %s"
             ).format(extra_clauses)
             params.append(expected_fence)
-        if expected_effect_phase is not None:
+        if expected_effect_state is not None:
             extra_clauses = self._sql.SQL(
                 "{} AND COALESCE(payload->>'effect_phase', 'INTENDED') = %s"
             ).format(extra_clauses)
-            params.append(expected_effect_phase)
+            params.append(expected_effect_state)
         if require_lease_held_at is not None:
             # NULL lease_until = unbounded; else must still be in the future.
             extra_clauses = self._sql.SQL(
@@ -249,7 +249,7 @@ class PostgresLedgerStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         return self._inner.try_transition(
             entry,
@@ -257,7 +257,7 @@ class PostgresLedgerStorage:
             expected_owner=expected_owner,
             require_lease_held_at=require_lease_held_at,
             expected_fence=expected_fence,
-            expected_effect_phase=expected_effect_phase,
+            expected_effect_state=expected_effect_state,
         )
 
 

--- a/sdk/mycelium/storage/redis_ledger.py
+++ b/sdk/mycelium/storage/redis_ledger.py
@@ -281,7 +281,7 @@ class RedisEntryStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         from redis.exceptions import WatchError
 
@@ -311,8 +311,8 @@ class RedisEntryStorage:
                     ):
                         return False
                     if (
-                        expected_effect_phase is not None
-                        and (existing.get("effect_phase") or "INTENDED") != expected_effect_phase
+                        expected_effect_state is not None
+                        and (existing.get("effect_phase") or "INTENDED") != expected_effect_state
                     ):
                         return False
                     if require_lease_held_at is not None and not lease_allows_renew(
@@ -383,7 +383,7 @@ class RedisLedgerStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         return self._inner.try_transition(
             entry,
@@ -391,7 +391,7 @@ class RedisLedgerStorage:
             expected_owner=expected_owner,
             require_lease_held_at=require_lease_held_at,
             expected_fence=expected_fence,
-            expected_effect_phase=expected_effect_phase,
+            expected_effect_state=expected_effect_state,
         )
 
 
@@ -436,7 +436,7 @@ class RedisTaskLedgerStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         return self._inner.try_transition(
             entry,
@@ -444,7 +444,7 @@ class RedisTaskLedgerStorage:
             expected_owner=expected_owner,
             require_lease_held_at=require_lease_held_at,
             expected_fence=expected_fence,
-            expected_effect_phase=expected_effect_phase,
+            expected_effect_state=expected_effect_state,
         )
 
     def list_all(self) -> list[Any]:

--- a/sdk/mycelium/storage/sqlite_ledger.py
+++ b/sdk/mycelium/storage/sqlite_ledger.py
@@ -163,7 +163,7 @@ class SqliteEntryStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         if not expected_terminal_outcomes:
             return False
@@ -183,9 +183,9 @@ class SqliteEntryStorage:
             # COALESCE so old rows (payload without a fence) read as 0.
             sql += " AND COALESCE(json_extract(payload, '$.fence'), 0) = ?"
             params.append(expected_fence)
-        if expected_effect_phase is not None:
+        if expected_effect_state is not None:
             sql += " AND COALESCE(json_extract(payload, '$.effect_phase'), 'INTENDED') = ?"
-            params.append(expected_effect_phase)
+            params.append(expected_effect_state)
         if require_lease_held_at is not None:
             sql += (
                 " AND (json_extract(payload, '$.lease_until') IS NULL "
@@ -250,7 +250,7 @@ class SqliteLedgerStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         return self._inner.try_transition(
             entry,
@@ -258,7 +258,7 @@ class SqliteLedgerStorage:
             expected_owner=expected_owner,
             require_lease_held_at=require_lease_held_at,
             expected_fence=expected_fence,
-            expected_effect_phase=expected_effect_phase,
+            expected_effect_state=expected_effect_state,
         )
 
 

--- a/sdk/mycelium/transition.py
+++ b/sdk/mycelium/transition.py
@@ -169,6 +169,46 @@ class TerminalOutcome(StrEnum):
     UNKNOWN = "UNKNOWN"
 
 
+class EffectState(StrEnum):
+    """Unified durable WAL intent for a side-effecting transition.
+
+    The single authoritative state machine for a ledger row's *intent*,
+    replacing the historical split across ``effect_phase`` (INTENDED /
+    ATTEMPTING / COMMITTED / ABORTED) and ``terminal_outcome`` (which also
+    carries ``UNKNOWN``, ``BLOCKED``, and the ``FAILED_*`` split). A
+    third-party reimplementer needs to track only this one enum plus the
+    fenced CAS that guards every transition between its members::
+
+        INTENDED -> ATTEMPTING -> COMMITTED | ABORTED | UNKNOWN
+
+    - ``INTENDED``: durable row exists; no provider side effect yet; safe to
+      retry.
+    - ``ATTEMPTING``: decision allowed + recorded; the provider boundary may
+      (or may not yet) be crossed.
+    - ``COMMITTED``: exactly-once effect recorded (maps to legacy
+      ``TerminalOutcome.COMPLETED``).
+    - ``ABORTED``: decision denied, or failed before any effect; nothing
+      happened; safe to retry.
+    - ``UNKNOWN``: terminal-until-resolved; fail-closed for redispatch,
+      especially for ``BLIND`` tools — no task redispatch while any attached
+      effect remains ``UNKNOWN``.
+
+    ``LedgerEntry`` keeps the historical ``effect_phase`` string field as the
+    storage field for on-disk/serialization compatibility (old rows load
+    unchanged, and every value it holds today is a member of this enum). New
+    protocol-gating code must branch on :func:`resolve_effect_state` (or
+    ``LedgerEntry.resolved_effect_state()``) rather than on the raw
+    ``effect_phase`` / ``terminal_outcome`` fields — only the resolver
+    correctly folds in ``UNKNOWN`` and legacy rows.
+    """
+
+    INTENDED = "INTENDED"
+    ATTEMPTING = "ATTEMPTING"
+    COMMITTED = "COMMITTED"
+    ABORTED = "ABORTED"
+    UNKNOWN = "UNKNOWN"
+
+
 class LeaseValidity(StrEnum):
     """Whether an in-flight execution lease is still held.
 
@@ -596,6 +636,89 @@ def resolve_terminal_outcome(
         if resolve_lease_validity(lease_until, now=now) == LeaseValidity.EXPIRED:
             return TerminalOutcome.EXPIRED
     return outcome
+
+
+def resolve_effect_state(entry: Any) -> EffectState:
+    """Derive the unified :class:`EffectState` for a ledger row.
+
+    Pure and duck-typed over ``terminal_outcome`` / ``side_effect_boundary`` /
+    ``effect_phase`` / ``decision`` attributes, so it works on ``LedgerEntry``
+    *and* on any legacy row shape loaded through it — every existing row, old
+    or new, maps onto the one durable WAL intent without a storage migration.
+    Liveness (lease validity, worker death evidence) is a separate axis and is
+    deliberately not consulted here: ``EffectState`` answers "where is this
+    effect in the protocol", not "is the worker still alive".
+
+    Precedence:
+
+    1. ``terminal_outcome == COMPLETED`` -> ``COMMITTED``, unconditionally
+       (even if a stale ``effect_phase`` says otherwise).
+    2. Ambiguous rows — ``terminal_outcome`` is ``UNKNOWN`` /
+       ``FAILED_AFTER_EFFECT`` (the outcome itself is unresolved, or the
+       effect definitely fired), or *any* terminal whose
+       ``side_effect_boundary`` is ``maybe_crossed`` / ``crossed`` (the
+       provider call may have fired, e.g. a hard-blocked stale-lease
+       ``BLOCKED`` row) -> ``UNKNOWN``. This deliberately widens the literal
+       "``BLOCKED`` -> ``ABORTED``" legacy mapping: a ``BLOCKED`` row with a
+       ``not_crossed`` boundary provably never reached the provider (safe,
+       ``ABORTED``), but a ``BLOCKED`` row with ``maybe_crossed`` /
+       ``crossed`` is exactly the "might have happened" case ``UNKNOWN``
+       exists to express — collapsing it into ``ABORTED`` would silently
+       relabel an ambiguous effect as safe-to-retry.
+    3. Unambiguous ``FAILED_BEFORE_EFFECT`` / ``BLOCKED`` / legacy-stored
+       ``EXPIRED`` (boundary ``not_crossed``) -> ``ABORTED``.
+    4. Still ``IN_FLIGHT`` (active, or crashed before any terminal write
+       landed): ``effect_phase == "ATTEMPTING"`` with a decision recorded ->
+       ``ATTEMPTING`` (the boundary may already be ``maybe_crossed`` /
+       ``crossed`` — that is within the definition of ``ATTEMPTING``, not a
+       separate branch); ``effect_phase == "ABORTED"`` with a decision
+       recorded (the brief window between a denying ``record_decision`` and
+       the follow-up ``fail()``) -> ``ABORTED``; otherwise -> ``INTENDED``.
+    """
+    terminal_raw = getattr(entry, "terminal_outcome", None)
+    try:
+        terminal = (
+            parse_terminal_outcome(terminal_raw) if terminal_raw else TerminalOutcome.IN_FLIGHT
+        )
+    except ValueError:
+        terminal = TerminalOutcome.IN_FLIGHT
+
+    if terminal == TerminalOutcome.COMPLETED:
+        return EffectState.COMMITTED
+
+    boundary_raw = getattr(entry, "side_effect_boundary", None)
+    try:
+        boundary = (
+            parse_side_effect_boundary(boundary_raw)
+            if boundary_raw
+            else SideEffectBoundary.NOT_CROSSED
+        )
+    except ValueError:
+        boundary = SideEffectBoundary.NOT_CROSSED
+
+    ambiguous = terminal in (
+        TerminalOutcome.UNKNOWN,
+        TerminalOutcome.FAILED_AFTER_EFFECT,
+    ) or boundary in (SideEffectBoundary.MAYBE_CROSSED, SideEffectBoundary.CROSSED)
+
+    if terminal in (
+        TerminalOutcome.FAILED_BEFORE_EFFECT,
+        TerminalOutcome.BLOCKED,
+        TerminalOutcome.EXPIRED,
+        TerminalOutcome.UNKNOWN,
+        TerminalOutcome.FAILED_AFTER_EFFECT,
+    ):
+        return EffectState.UNKNOWN if ambiguous else EffectState.ABORTED
+
+    # terminal is IN_FLIGHT: either actively being worked, or crashed before
+    # any terminal write landed. Resolve from effect_phase + decision.
+    phase = str(getattr(entry, "effect_phase", "") or "")
+    decision = getattr(entry, "decision", None)
+    if decision is not None and phase == EffectState.ATTEMPTING.value:
+        return EffectState.ATTEMPTING
+    if decision is not None and phase == EffectState.ABORTED.value:
+        return EffectState.ABORTED
+    return EffectState.INTENDED
 
 
 @dataclass(frozen=True)
@@ -1087,6 +1210,8 @@ __all__ = [
     "DEFAULT_SPENDABILITY",
     "STRICT_SIDE_EFFECT_CLASSES",
     "TerminalOutcome",
+    "EffectState",
+    "resolve_effect_state",
     "LeaseValidity",
     "ProviderKeyValidity",
     "ToolTransitionBinding",

--- a/sdk/mycelium/verify/invariants.py
+++ b/sdk/mycelium/verify/invariants.py
@@ -15,13 +15,16 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from mycelium.transition import TerminalOutcome
+from mycelium.transition import EffectState, TerminalOutcome, resolve_effect_state
 
 __all__ = [
     "InvariantViolation",
     "check_at_most_one_committed",
+    "check_at_most_one_committed_effect_state",
+    "check_effect_state_consistency",
     "check_provider_mapping",
     "committed_effect_ids",
+    "committed_effect_ids_by_state",
 ]
 
 
@@ -33,6 +36,25 @@ class InvariantViolation:
     message: str
 
 
+def _effect_ref(entry: Any) -> str | None:
+    """The dedup identity to bucket a committed row under.
+
+    Uses the same keying as :func:`check_provider_mapping` (which maps provider
+    effects onto rows by ``request_id``): ``transition_key``, then
+    ``idempotency_key`` (the historical dedup ref, and what legacy rows with an
+    explicit idempotency key rely on), then ``request_id``. ``effect_id`` is
+    not consulted directly because for SDK-created rows it is either equal to
+    ``request_id`` (derived default) or, for rows with an explicit
+    ``request_id``, the derived transition hash — bucketing by it would diverge
+    from the provider-mapping key and break the at-most-once check.
+    """
+    return (
+        getattr(entry, "transition_key", None)
+        or getattr(entry, "idempotency_key", None)
+        or getattr(entry, "request_id", None)
+    )
+
+
 def committed_effect_ids(entries: Iterable[Any]) -> dict[str, list[str]]:
     """Map effect_id -> [request_ids] for every COMPLETED ledger entry.
 
@@ -42,11 +64,7 @@ def committed_effect_ids(entries: Iterable[Any]) -> dict[str, list[str]]:
     """
     committed: dict[str, list[str]] = defaultdict(list)
     for entry in entries:
-        effect_id = (
-            getattr(entry, "transition_key", None)
-            or getattr(entry, "idempotency_key", None)
-            or getattr(entry, "request_id", None)
-        )
+        effect_id = _effect_ref(entry)
         if not effect_id:
             continue
         try:
@@ -54,6 +72,27 @@ def committed_effect_ids(entries: Iterable[Any]) -> dict[str, list[str]]:
         except Exception:
             outcome = TerminalOutcome(entry.terminal_outcome)
         if outcome == TerminalOutcome.COMPLETED:
+            committed[str(effect_id)].append(entry.request_id)
+    return dict(committed)
+
+
+def committed_effect_ids_by_state(entries: Iterable[Any]) -> dict[str, list[str]]:
+    """Same as :func:`committed_effect_ids`, but on the unified ``EffectState``.
+
+    Groups by ``resolve_effect_state(entry) == EffectState.COMMITTED`` instead
+    of ``resolved_terminal_outcome() == TerminalOutcome.COMPLETED``. The two
+    should always agree (``COMMITTED`` is defined as the unconditional image
+    of legacy ``COMPLETED``) — :func:`check_effect_state_consistency` asserts
+    that. Kept as a separate function (rather than folding into
+    :func:`committed_effect_ids`) so a divergence between the two views is
+    itself a detectable, reportable invariant violation.
+    """
+    committed: dict[str, list[str]] = defaultdict(list)
+    for entry in entries:
+        effect_id = _effect_ref(entry)
+        if not effect_id:
+            continue
+        if resolve_effect_state(entry) == EffectState.COMMITTED:
             committed[str(effect_id)].append(entry.request_id)
     return dict(committed)
 
@@ -74,6 +113,62 @@ def check_at_most_one_committed(
                 InvariantViolation(
                     ref,
                     f"effect {ref!r} committed {len(rids)} times: {sorted(rids)}",
+                )
+            )
+    return violations
+
+
+def check_at_most_one_committed_effect_state(
+    entries: Iterable[Any],
+) -> list[InvariantViolation]:
+    """Same invariant as :func:`check_at_most_one_committed`, on ``EffectState``.
+
+    Asserts the at-most-one-COMMITTED invariant holds under the unified WAL
+    intent, not just the legacy ``terminal_outcome`` read path — a
+    reimplementer following only ``EffectState`` must get the same guarantee.
+    """
+    violations: list[InvariantViolation] = []
+    for ref, rids in committed_effect_ids_by_state(entries).items():
+        if len(rids) > 1:
+            violations.append(
+                InvariantViolation(
+                    ref,
+                    f"effect {ref!r} EffectState.COMMITTED {len(rids)} times: {sorted(rids)}",
+                )
+            )
+    return violations
+
+
+def check_effect_state_consistency(entries: Iterable[Any]) -> list[InvariantViolation]:
+    """Assert ``resolve_effect_state`` and ``resolved_terminal_outcome`` agree.
+
+    ``EffectState.COMMITTED`` is defined as the unconditional image of legacy
+    ``TerminalOutcome.COMPLETED`` (see :func:`mycelium.transition.
+    resolve_effect_state`); this check catches any future edit that breaks
+    that equivalence for a live row before it silently causes a divergent
+    at-most-one-COMMITTED verdict between the two invariant families above.
+    """
+    violations: list[InvariantViolation] = []
+    for entry in entries:
+        try:
+            terminal = entry.resolved_terminal_outcome()
+        except Exception:
+            terminal = TerminalOutcome(entry.terminal_outcome)
+        state = resolve_effect_state(entry)
+        is_completed = terminal == TerminalOutcome.COMPLETED
+        is_committed = state == EffectState.COMMITTED
+        if is_completed != is_committed:
+            effect_id = str(
+                getattr(entry, "effect_id", None)
+                or getattr(entry, "request_id", None)
+                or "?"
+            )
+            violations.append(
+                InvariantViolation(
+                    effect_id,
+                    f"request {entry.request_id!r}: terminal_outcome={terminal.value!r} "
+                    f"(completed={is_completed}) disagrees with "
+                    f"EffectState={state.value!r} (committed={is_committed})",
                 )
             )
     return violations

--- a/sdk/mycelium/verify/isolation.py
+++ b/sdk/mycelium/verify/isolation.py
@@ -85,7 +85,7 @@ class IsolationGateStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         self._guard(entry.request_id)
         return self._inner.try_transition(
@@ -94,7 +94,7 @@ class IsolationGateStorage:
             expected_owner=expected_owner,
             require_lease_held_at=require_lease_held_at,
             expected_fence=expected_fence,
-            expected_effect_phase=expected_effect_phase,
+            expected_effect_state=expected_effect_state,
         )
 
     def list_all(self) -> list[LedgerEntry]:
@@ -160,7 +160,7 @@ class FaultInjectingStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         self._transition_count += 1
         nth = self.fail_nth_transition
@@ -175,7 +175,7 @@ class FaultInjectingStorage:
             expected_owner=expected_owner,
             require_lease_held_at=require_lease_held_at,
             expected_fence=expected_fence,
-            expected_effect_phase=expected_effect_phase,
+            expected_effect_state=expected_effect_state,
         )
 
     def list_all(self) -> list[LedgerEntry]:
@@ -456,7 +456,7 @@ class _PostgresPrefixedStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         return self._inner.try_transition(
             entry,
@@ -464,7 +464,7 @@ class _PostgresPrefixedStorage:
             expected_owner=expected_owner,
             require_lease_held_at=require_lease_held_at,
             expected_fence=expected_fence,
-            expected_effect_phase=expected_effect_phase,
+            expected_effect_state=expected_effect_state,
         )
 
     def list_all(self) -> list[LedgerEntry]:

--- a/sdk/mycelium/verify/scenarios/simulation.py
+++ b/sdk/mycelium/verify/scenarios/simulation.py
@@ -7,6 +7,8 @@ provider effect log into the invariant checks in
 :mod:`mycelium.verify.invariants` and requires:
 
 * at most one COMPLETED ledger entry per effect_id, ever;
+* at most one EffectState.COMMITTED ledger entry per effect_id (asserted on
+  the unified EffectState view, and checked consistent with terminal_outcome);
 * every provider-side effect maps to at most one COMPLETED entry.
 
 Fence acquisition/loss is proven deterministically in-process over a shared
@@ -32,6 +34,8 @@ from mycelium.transition import (
 )
 from mycelium.verify.invariants import (
     check_at_most_one_committed,
+    check_at_most_one_committed_effect_state,
+    check_effect_state_consistency,
     check_provider_mapping,
 )
 from mycelium.verify.registry import ScenarioContext, verify_scenario
@@ -153,6 +157,10 @@ def _run_crash_sweep(
         violations = check_at_most_one_committed(entries)
         for item in violations:
             failures.append(f"{phase}: {item.message}")
+        for item in check_at_most_one_committed_effect_state(entries):
+            failures.append(f"{phase}: {item.message}")
+        for item in check_effect_state_consistency(entries):
+            failures.append(f"{phase}: {item.message}")
         provider_effects = read_lines(effect_file)
         if provider_effects:
             mapped, warnings = check_provider_mapping(
@@ -272,6 +280,10 @@ def _run_fence_takeover(
     if final.result != {"charged": True}:
         failures.append("fence takeover: stale A write leaked into final entry")
     for violation in check_at_most_one_committed([final]):
+        failures.append(f"fence takeover: {violation.message}")
+    for violation in check_at_most_one_committed_effect_state([final]):
+        failures.append(f"fence takeover: {violation.message}")
+    for violation in check_effect_state_consistency([final]):
         failures.append(f"fence takeover: {violation.message}")
     mapped, warnings = check_provider_mapping([final], provider_effects)
     for violation in mapped:

--- a/sdk/tests/test_atomicity_contract.py
+++ b/sdk/tests/test_atomicity_contract.py
@@ -981,6 +981,9 @@ def test_stale_fence_rejected_even_when_lease_valid(ledger: ActionLedger) -> Non
     assert stored is not None
     assert stored.terminal_outcome == TerminalOutcome.IN_FLIGHT.value
     assert stored.fence == 2
+    # The stale-fence write never landed, so the unified EffectState is
+    # unchanged too: no decision was ever recorded, so it stays INTENDED.
+    assert stored.resolved_effect_state().value == "INTENDED"
 
 
 def test_legacy_claim_mutations_require_and_reject_stale_fences(

--- a/sdk/tests/test_decision.py
+++ b/sdk/tests/test_decision.py
@@ -274,6 +274,64 @@ tools:
     assert "ghp_abcdefghijklmnopqrstuvwxyz123456" not in str(stored.to_dict())
 
 
+def test_destination_denial_alone_aborts_at_decision_point_no_body_run() -> None:
+    """Predicate collapse, isolated: deny ONLY destination_policy (no secret
+    involved) and confirm the single decision CAS is what aborts the row —
+    not a separate pre-claim wrapper. There is no outer entity-guard wrapper
+    for a ledgered consequential tool to begin with (``_mycelium_entity_guard``
+    stays unset), so this is exactly the "even if an outer wrapper were
+    removed/disabled" case the spec asks for: there is nothing to disable.
+    """
+    from mycelium import EntityGuardError, get_ledger, load_config_from_string
+
+    config = load_config_from_string(
+        """
+action_ledger:
+  storage: memory
+  tools: [send_email]
+entity_guard:
+  enabled: true
+  missing_policy: error
+  tools:
+    send_email:
+      destinations:
+        - path: recipient
+          type: email
+          allow:
+            domains: [customer.com]
+tools:
+  send_email:
+    side_effect_class: non_idempotent_mutate
+"""
+    )
+    body_ran: list[bool] = []
+
+    def send_email(recipient: str) -> None:
+        del recipient
+        body_ran.append(True)
+
+    wrapped = config.apply_tool("send_email", send_email)
+    assert getattr(wrapped, "_mycelium_atomic_decision_policy", False) is True
+    assert getattr(wrapped, "_mycelium_entity_guard", False) is False
+
+    with pytest.raises(EntityGuardError):
+        wrapped(recipient="attacker@example.net", request_id="destination-only-denial")
+
+    ledger_instance = get_ledger(wrapped)
+    assert ledger_instance is not None
+    stored = ledger_instance.get("destination-only-denial")
+    assert stored is not None
+    assert stored.effect_phase == "ABORTED"
+    assert stored.resolved_effect_state().value == "ABORTED"
+    assert body_ran == []
+    decision = Decision.from_dict(stored.decision)
+    assert decision.allowed is False
+    assert decision.predicate_results["destination_policy"] is False
+    # Nothing else was denied — proves destination_policy alone caused the abort.
+    assert decision.predicate_results["secret_protection"] is True
+    assert decision.predicate_results["destructive_confirm"] is True
+
+
 def test_rejected_secret_is_redacted_before_plugin_evaluation() -> None:
     from mycelium import SecretInArgsError, load_config_from_string
 
@@ -456,7 +514,7 @@ def test_stale_decision_cas_emits_no_atomic_policy_event() -> None:
 
     class RejectDecisionStorage(InMemoryLedgerStorage):
         def try_transition(self, entry: LedgerEntry, **kwargs: Any) -> bool:
-            if kwargs.get("expected_effect_phase") == "INTENDED":
+            if kwargs.get("expected_effect_state") == "INTENDED":
                 return False
             return super().try_transition(entry, **kwargs)
 

--- a/sdk/tests/test_effect_identity.py
+++ b/sdk/tests/test_effect_identity.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import threading
+import time
+
 import pytest
 
 from mycelium import (
+    ActionLedger,
     InMemoryLedgerStorage,
+    LedgerEntry,
     SideEffectClass,
     ToolTransitionBinding,
     TransitionScope,
@@ -13,6 +18,7 @@ from mycelium import (
     derive_transition_key_for_call,
     enforce_entity_guard,
     execution_scope,
+    get_ledger,
     ledger_sync,
 )
 from mycelium.entity_guard import (
@@ -30,6 +36,7 @@ from mycelium.transition import (
     derive_effect_id,
     derive_effect_id_for_call,
 )
+from mycelium.verify.invariants import check_at_most_one_committed_effect_state
 
 
 @pytest.fixture(autouse=True)
@@ -189,6 +196,108 @@ def test_effect_id_for_call_matches_transition_key_for_call() -> None:
         assert derive_effect_id_for_call("send_payment", (), kwargs, binding) == (
             derive_transition_key_for_call("send_payment", (), kwargs, binding)
         )
+
+
+def test_claimed_entry_stores_effect_id_field() -> None:
+    """LedgerEntry.effect_id is populated on claim and, for the default
+    derived-request_id path, equals request_id (derive_request_id's fallback
+    is the same derivation as derive_effect_id_for_call)."""
+    binding = _binding()
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float) -> dict[str, str]:
+        return {"status": "sent"}
+
+    with execution_scope(TransitionScope(thread_id="thread-1", run_id="run-1")):
+        send_payment(amount=10.0, tool_call_id="call_effect_id_1")
+
+    ledger_inst = get_ledger(send_payment)
+    assert ledger_inst is not None
+    with execution_scope(TransitionScope(thread_id="thread-1", run_id="run-1")):
+        expected_request_id = ledger_inst.derive_request_id(
+            "send_payment", (), {"amount": 10.0, "tool_call_id": "call_effect_id_1"},
+            transition_binding=binding,
+        )
+    stored = ledger_inst.get(expected_request_id)
+    assert stored is not None
+    assert stored.effect_id is not None
+    assert stored.effect_id == stored.request_id
+
+
+def test_unclassified_claim_effect_id_falls_back_to_request_id() -> None:
+    """No binding to derive from (legacy claim()) still gets a non-null
+    effect_id — it falls back to request_id, same as idempotency_key."""
+    ledger_inst = ActionLedger(storage=InMemoryLedgerStorage())
+    entry = ledger_inst.claim("legacy-req-1", "legacy_tool", (), {})
+    assert entry.effect_id == "legacy-req-1"
+
+
+def test_legacy_row_without_effect_id_field_infers_from_request_id() -> None:
+    """from_dict on a pre-schema-2 row (no effect_id key at all) infers it."""
+    raw = {
+        "request_id": "legacy-row-1",
+        "tool": "legacy_tool",
+        "args": [],
+        "kwargs": {},
+        "status": "completed",
+        "terminal_outcome": "COMPLETED",
+    }
+    assert "effect_id" not in raw
+    assert "schema_version" not in raw
+    entry = LedgerEntry.from_dict(raw)
+    assert entry.effect_id == "legacy-row-1"
+    assert entry.schema_version == 1
+
+
+def test_concurrent_workers_same_call_collide_on_one_row() -> None:
+    """Two concurrent workers deriving the same identity from the same
+    (tool, params, destination) — no explicit request_id — collide on the
+    same durable row: the provider body runs exactly once, and the unified
+    EffectState at-most-one-COMMITTED invariant holds across both workers'
+    observed entries."""
+    storage = InMemoryLedgerStorage()
+    binding = _binding()
+    executions: list[str] = []
+
+    @ledger_sync(storage=storage, transition_binding=binding)
+    def send_email(recipient: str, amount: float) -> dict[str, str]:
+        executions.append(recipient)
+        time.sleep(0.05)
+        return {"recipient": recipient, "status": "sent"}
+
+    wrapped = apply_entity_guard(send_email, _email_policy(), tool_name="send_email")
+    kwargs = {
+        "recipient": "billing@customer.com",
+        "amount": 10.0,
+        "tool_call_id": "call_concurrent_1",
+    }
+
+    results: list[dict[str, str]] = []
+    errors: list[BaseException] = []
+
+    def _worker() -> None:
+        with execution_scope(TransitionScope(thread_id="thread-1", run_id="run-1")):
+            try:
+                results.append(wrapped(**kwargs))
+            except BaseException as exc:  # noqa: BLE001 — surfaced via assertion below
+                errors.append(exc)
+
+    t1 = threading.Thread(target=_worker, daemon=True)
+    t2 = threading.Thread(target=_worker, daemon=True)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not errors, f"unexpected worker errors: {errors}"
+    assert len(executions) == 1, "the provider body must run exactly once"
+    assert len(results) == 2
+    assert results[0] == results[1]
+
+    entries = storage.list_all()
+    assert len(entries) == 1
+    assert check_at_most_one_committed_effect_state(entries) == []
+    assert entries[0].resolved_effect_state().value == "COMMITTED"
 
 
 def test_explicit_destination_in_preimage() -> None:

--- a/sdk/tests/test_effect_state_machine.py
+++ b/sdk/tests/test_effect_state_machine.py
@@ -1,0 +1,441 @@
+"""EffectState state-machine checks: transitions, legacy rows, and crash paths."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from mycelium import (
+    ActionLedger,
+    EffectState,
+    InMemoryLedgerStorage,
+    LedgerEntry,
+    LedgerHardBlockError,
+    LedgerOutcomeAlreadySetError,
+    RetryPermission,
+    SideEffectClass,
+    Spendability,
+    TerminalOutcome,
+    ToolCapability,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+    get_ledger,
+    ledger_sync,
+    side_effect,
+)
+
+
+def _decision(allowed: bool) -> dict[str, Any]:
+    return {"allowed": allowed, "verdicts": [], "denied_reasons": []}
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="state-machine",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def _blind_binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="state-machine",
+        policy_version="1",
+        side_effect_class=SideEffectClass.KEYED_MUTATE,
+        provider_idempotency_key_param="idempotency_key",
+        provider_idempotency_key_ttl=300.0,
+        capability=ToolCapability.BLIND,
+    )
+
+
+def _scope() -> TransitionScope:
+    return TransitionScope(thread_id="thread-1", run_id="run-1")
+
+
+def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(storage=storage)
+    binding = _binding()
+
+    # INTENDED -> ATTEMPTING -> COMMITTED
+    allowed = ledger.claim_side_effecting("req-allowed", "tool", (), {}, binding)
+    ledger.record_decision(
+        "req-allowed",
+        _decision(True),
+        expected_fence=allowed.fence,
+    )
+    committed = ledger.complete("req-allowed", {"ok": True}, expected_fence=allowed.fence)
+    assert committed.resolved_effect_state() == EffectState.COMMITTED
+
+    # INTENDED -> ABORTED
+    denied = ledger.claim_side_effecting("req-denied", "tool", (), {}, binding)
+    denied_row = ledger.record_decision(
+        "req-denied",
+        _decision(False),
+        expected_fence=denied.fence,
+    )
+    assert denied_row.resolved_effect_state() == EffectState.ABORTED
+
+    # ATTEMPTING -> UNKNOWN (BLIND-like after-effect failure)
+    unknown = ledger.claim_side_effecting("req-unknown", "tool", (), {}, binding)
+    ledger.record_decision(
+        "req-unknown",
+        _decision(True),
+        expected_fence=unknown.fence,
+    )
+    unknown_row = ledger.mark_unknown(
+        "req-unknown",
+        expected_fence=unknown.fence,
+        error="ambiguous",
+    )
+    assert unknown_row.resolved_effect_state() == EffectState.UNKNOWN
+
+    # ATTEMPTING -> ABORTED (failure before effect after allow)
+    failed = ledger.claim_side_effecting("req-fail-before", "tool", (), {}, binding)
+    ledger.record_decision(
+        "req-fail-before",
+        _decision(True),
+        expected_fence=failed.fence,
+    )
+    failed_row = ledger.fail(
+        "req-fail-before",
+        RuntimeError("failed before effect"),
+        failed_after_effect=False,
+        expected_fence=failed.fence,
+    )
+    assert failed_row.resolved_effect_state() == EffectState.ABORTED
+
+    # ILLEGAL: complete before decision (still INTENDED)
+    no_decision = ledger.claim_side_effecting("req-no-decision", "tool", (), {}, binding)
+    with pytest.raises(LedgerOutcomeAlreadySetError):
+        ledger.complete(
+            "req-no-decision",
+            {"ok": True},
+            expected_fence=no_decision.fence,
+        )
+
+    # ILLEGAL: once COMMITTED, further mutations must fail.
+    with pytest.raises(LedgerOutcomeAlreadySetError):
+        ledger.mark_unknown(
+            "req-allowed",
+            expected_fence=allowed.fence,
+            error="late change",
+        )
+
+    # ILLEGAL: ABORTED row cannot transition back to ATTEMPTING.
+    with pytest.raises(LedgerOutcomeAlreadySetError):
+        ledger.record_decision(
+            "req-denied",
+            _decision(True),
+            expected_fence=denied.fence,
+        )
+
+    # ILLEGAL overwrite: storage claim cannot blind-overwrite UNKNOWN.
+    stored_unknown = ledger.get("req-unknown")
+    assert stored_unknown is not None
+    fresh_claim = replace(
+        stored_unknown,
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        effect_phase=EffectState.INTENDED.value,
+        decision=None,
+        fence=stored_unknown.fence + 1,
+        owner="new-owner",
+    )
+    outcome, existing = storage.try_claim_inflight(fresh_claim)
+    assert outcome == "in_flight"
+    assert existing is not None
+    assert existing.resolved_effect_state() == EffectState.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            {
+                "request_id": "legacy-completed",
+                "tool": "tool",
+                "args": [],
+                "kwargs": {},
+                "status": "completed",
+                "terminal_outcome": "COMPLETED",
+                "effect_phase": "INTENDED",
+            },
+            EffectState.COMMITTED,
+        ),
+        (
+            {
+                "request_id": "legacy-failed-after",
+                "tool": "tool",
+                "args": [],
+                "kwargs": {},
+                "status": "failed",
+                "terminal_outcome": "FAILED_AFTER_EFFECT",
+            },
+            EffectState.UNKNOWN,
+        ),
+        (
+            {
+                "request_id": "legacy-blocked-not-crossed",
+                "tool": "tool",
+                "args": [],
+                "kwargs": {},
+                "status": "failed",
+                "terminal_outcome": "BLOCKED",
+                "side_effect_boundary": "not_crossed",
+            },
+            EffectState.ABORTED,
+        ),
+        (
+            {
+                "request_id": "legacy-blocked-maybe-crossed",
+                "tool": "tool",
+                "args": [],
+                "kwargs": {},
+                "status": "failed",
+                "terminal_outcome": "BLOCKED",
+                "side_effect_boundary": "maybe_crossed",
+            },
+            EffectState.UNKNOWN,
+        ),
+        (
+            {
+                "request_id": "legacy-expired-not-crossed",
+                "tool": "tool",
+                "args": [],
+                "kwargs": {},
+                "status": "in-flight",
+                "terminal_outcome": "EXPIRED",
+                "side_effect_boundary": "not_crossed",
+            },
+            EffectState.ABORTED,
+        ),
+        (
+            {
+                "request_id": "legacy-inflight-attempting",
+                "tool": "tool",
+                "args": [],
+                "kwargs": {},
+                "status": "in-flight",
+                "terminal_outcome": "IN_FLIGHT",
+                "effect_phase": "ATTEMPTING",
+                "decision": _decision(True),
+            },
+            EffectState.ATTEMPTING,
+        ),
+        (
+            {
+                "request_id": "legacy-inflight-aborted",
+                "tool": "tool",
+                "args": [],
+                "kwargs": {},
+                "status": "in-flight",
+                "terminal_outcome": "IN_FLIGHT",
+                "effect_phase": "ABORTED",
+                "decision": _decision(False),
+            },
+            EffectState.ABORTED,
+        ),
+        (
+            {
+                "request_id": "legacy-inflight-intended",
+                "tool": "tool",
+                "args": [],
+                "kwargs": {},
+                "status": "in-flight",
+                "terminal_outcome": "IN_FLIGHT",
+                "effect_phase": "ATTEMPTING",
+            },
+            EffectState.INTENDED,
+        ),
+        (
+            {
+                "request_id": "legacy-garbage-terminal",
+                "tool": "tool",
+                "args": [],
+                "kwargs": {},
+                "status": "in-flight",
+                "terminal_outcome": "GARBAGE",
+                "effect_phase": "ABORTED",
+                "decision": _decision(False),
+            },
+            EffectState.ABORTED,
+        ),
+    ],
+)
+def test_legacy_deserialization_resolves_unified_effect_state(
+    raw: dict[str, Any], expected: EffectState
+) -> None:
+    entry = LedgerEntry.from_dict(raw)
+    assert entry.resolved_effect_state() == expected
+
+
+def _idempotent_safe_retry_binding() -> ToolTransitionBinding:
+    # Same override style as test_spendability_override_allows_expired_reclaim:
+    # multi_use + SAFE_RETRY is what authorizes EXPIRED + not_crossed reclaim.
+    return ToolTransitionBinding.for_tool(
+        agent_id="state-machine",
+        policy_version="1",
+        side_effect_class=SideEffectClass.IDEMPOTENT_MUTATE,
+        spendability=Spendability.MULTI_USE,
+        retry_permission=RetryPermission.SAFE_RETRY,
+    )
+
+
+def _craft_intended_expired(
+    storage: InMemoryLedgerStorage,
+    *,
+    request_id: str,
+    tool: str,
+    kwargs: dict[str, Any],
+) -> None:
+    storage.set(
+        LedgerEntry(
+            request_id=request_id,
+            tool=tool,
+            args=[],
+            kwargs=dict(kwargs),
+            status="in-flight",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+            owner="dead-worker",
+            lease_until=time.time() - 1,
+            effect_phase=EffectState.INTENDED.value,
+            decision=None,
+            effect_protocol_required=True,
+        )
+    )
+
+
+def test_crash_before_attempting_idempotent_class_auto_reclaims() -> None:
+    """EXPIRED + INTENDED auto-reclaims only for multi_use + SAFE_RETRY."""
+    binding = _idempotent_safe_retry_binding()
+    attempts = {"n": 0}
+
+    # Table-driven across two independent pre-attempt crashes.
+    for crash_round in (1, 2):
+        storage = InMemoryLedgerStorage()
+        provider_results: list[dict[str, float]] = []
+
+        @ledger_sync(storage=storage, transition_binding=binding)
+        def charge(amount: float) -> dict[str, float]:
+            attempts["n"] += 1
+            result = {"amount": amount}
+            provider_results.append(result)
+            return result
+
+        ledger = get_ledger(charge)
+        assert ledger is not None
+        tool_call_id = f"c-idem-{crash_round}"
+        with execution_scope(_scope()):
+            request_id = ledger.derive_request_id(
+                "charge",
+                (),
+                {"amount": 10.0, "tool_call_id": tool_call_id},
+                transition_binding=binding,
+            )
+        _craft_intended_expired(
+            storage,
+            request_id=request_id,
+            tool="charge",
+            kwargs={"amount": 10.0, "tool_call_id": tool_call_id},
+        )
+
+        with execution_scope(_scope()):
+            assert charge(amount=10.0, tool_call_id=tool_call_id) == {"amount": 10.0}
+            # Redispatch after commit must not duplicate the provider effect.
+            assert charge(amount=10.0, tool_call_id=tool_call_id) == {"amount": 10.0}
+
+        assert provider_results == [{"amount": 10.0}]
+        stored = ledger.get(request_id)
+        assert stored is not None
+        assert stored.resolved_effect_state() == EffectState.COMMITTED
+
+    assert attempts["n"] == 2
+
+
+def test_crash_before_attempting_strict_class_fails_closed() -> None:
+    """EXPIRED + INTENDED + non_idempotent_mutate must hard-block, never re-run."""
+    storage = InMemoryLedgerStorage()
+    binding = _binding()
+    attempts = {"n": 0}
+
+    @ledger_sync(storage=storage, transition_binding=binding)
+    def charge(amount: float) -> dict[str, float]:
+        attempts["n"] += 1
+        return {"amount": amount}
+
+    ledger = get_ledger(charge)
+    assert ledger is not None
+    with execution_scope(_scope()):
+        request_id = ledger.derive_request_id(
+            "charge",
+            (),
+            {"amount": 10.0, "tool_call_id": "c-strict"},
+            transition_binding=binding,
+        )
+    _craft_intended_expired(
+        storage,
+        request_id=request_id,
+        tool="charge",
+        kwargs={"amount": 10.0, "tool_call_id": "c-strict"},
+    )
+
+    with execution_scope(_scope()):
+        with pytest.raises(LedgerHardBlockError, match="manual reconciliation"):
+            charge(amount=10.0, tool_call_id="c-strict")
+
+    assert attempts["n"] == 0
+    stored = ledger.get(request_id)
+    assert stored is not None
+    # Fail-closed park: EXPIRED reclaim is refused and the row is sealed for
+    # operator/reconciler attention (not auto-reclaimed back to ATTEMPTING).
+    assert stored.resolved_effect_state() == EffectState.ABORTED
+    assert stored.terminal_outcome == TerminalOutcome.BLOCKED.value
+
+
+def test_crash_during_attempting_blind_becomes_unknown_and_hard_blocks() -> None:
+    storage = InMemoryLedgerStorage()
+    binding = _blind_binding()
+    attempts = {"n": 0}
+
+    @ledger_sync(storage=storage, transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str) -> dict[str, str]:
+        attempts["n"] += 1
+        with side_effect():
+            raise RuntimeError("timeout after maybe-crossed")
+
+    with execution_scope(_scope()):
+        with pytest.raises(RuntimeError):
+            send_payment(amount=10.0, idempotency_key="k1", tool_call_id="c1")
+        with pytest.raises(LedgerHardBlockError):
+            send_payment(amount=10.0, idempotency_key="k1", tool_call_id="c1")
+
+    assert attempts["n"] == 1
+    ledger = get_ledger(send_payment)
+    assert ledger is not None
+    with execution_scope(_scope()):
+        request_id = ledger.derive_request_id(
+            "send_payment",
+            (),
+            {"amount": 10.0, "idempotency_key": "k1", "tool_call_id": "c1"},
+            transition_binding=binding,
+        )
+    stored = ledger.get(request_id)
+    assert stored is not None
+    assert stored.resolved_effect_state() == EffectState.UNKNOWN
+
+    fresh_claim = replace(
+        stored,
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        effect_phase=EffectState.INTENDED.value,
+        decision=None,
+        fence=stored.fence + 1,
+        owner="new-worker",
+    )
+    outcome, existing = storage.try_claim_inflight(fresh_claim)
+    assert outcome == "in_flight"
+    assert existing is not None
+    assert existing.resolved_effect_state() == EffectState.UNKNOWN

--- a/sdk/tests/test_outage_redis_postgres.py
+++ b/sdk/tests/test_outage_redis_postgres.py
@@ -145,7 +145,7 @@ class FailingRedisStorage(RedisLedgerStorage):
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         if self.fail_transition:
             raise ConnectionError("storage backend unreachable")
@@ -155,7 +155,7 @@ class FailingRedisStorage(RedisLedgerStorage):
             expected_owner=expected_owner,
             require_lease_held_at=require_lease_held_at,
             expected_fence=expected_fence,
-            expected_effect_phase=expected_effect_phase,
+            expected_effect_state=expected_effect_state,
         )
 
     def list_all(self) -> list[LedgerEntry]:
@@ -352,7 +352,7 @@ class FailingPostgresStorage:
         expected_owner: str | None = None,
         require_lease_held_at: float | None = None,
         expected_fence: int | None = None,
-        expected_effect_phase: str | None = None,
+        expected_effect_state: str | None = None,
     ) -> bool:
         if self.fail_transition:
             raise ConnectionError("storage backend unreachable")
@@ -362,7 +362,7 @@ class FailingPostgresStorage:
             expected_owner=expected_owner,
             require_lease_held_at=require_lease_held_at,
             expected_fence=expected_fence,
-            expected_effect_phase=expected_effect_phase,
+            expected_effect_state=expected_effect_state,
         )
 
     def list_all(self) -> list[LedgerEntry]:

--- a/sdk/tests/test_production_profile.py
+++ b/sdk/tests/test_production_profile.py
@@ -52,6 +52,42 @@ def test_omitted_profile_is_development() -> None:
     assert cfg.profile == PROFILE_DEVELOPMENT
 
 
+def test_unclassified_policy_default_depends_on_profile(tmp_path) -> None:
+    prod_cfg = load_config_from_string(_prod_sqlite(tmp_path))
+
+    def charge_prod() -> str:
+        return "ok"
+
+    prod_wrapped = prod_cfg.apply_tool("charge", charge_prod)
+    prod_ledger = get_ledger(prod_wrapped)
+    assert prod_ledger is not None
+    assert prod_ledger._unclassified_policy == "strict"
+
+    dev_cfg = load_config_from_string(
+        f"""
+profile: development
+transition:
+  agent_id: dev-agent
+  policy_version: "2026.08.1"
+action_ledger:
+  storage: sqlite
+  path: {tmp_path / "dev-ledger.db"}
+  tools: [charge]
+tools:
+  charge:
+    side_effect_class: non_idempotent_mutate
+"""
+    )
+
+    def charge_dev() -> str:
+        return "ok"
+
+    dev_wrapped = dev_cfg.apply_tool("charge", charge_dev)
+    dev_ledger = get_ledger(dev_wrapped)
+    assert dev_ledger is not None
+    assert dev_ledger._unclassified_policy == "warn"
+
+
 def test_explicit_development_profile_loads() -> None:
     cfg = load_config_from_string("profile: development\ntools: {}")
     assert cfg.profile == PROFILE_DEVELOPMENT

--- a/sdk/tests/test_tool_capability.py
+++ b/sdk/tests/test_tool_capability.py
@@ -269,6 +269,38 @@ def test_blind_unknown_parks_and_never_retries() -> None:
 
     assert attempts["n"] == 1  # body never re-executed
 
+    # The unified EffectState (not just terminal_outcome) reports the row as
+    # UNKNOWN, and a fresh claim attempt on the raw storage layer refuses to
+    # overwrite it — the same fail-closed guarantee the hard-block above
+    # already proved end-to-end, checked directly at the storage boundary.
+    ledger_inst = get_ledger(send_payment)
+    assert ledger_inst is not None
+    with execution_scope(_scope()):
+        request_id = ledger_inst.derive_request_id(
+            "send_payment",
+            (),
+            {"amount": 10.0, "idempotency_key": "k1", "tool_call_id": "c1"},
+            transition_binding=binding,
+        )
+    stored = ledger_inst.get(request_id)
+    assert stored is not None
+    assert stored.resolved_effect_state().value == "UNKNOWN"
+
+    from dataclasses import replace as _replace
+
+    fresh_claim = _replace(
+        stored,
+        terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+        effect_phase="INTENDED",
+        decision=None,
+        fence=stored.fence + 1,
+        owner="a-new-worker",
+    )
+    outcome, existing = storage.try_claim_inflight(fresh_claim)
+    assert outcome == "in_flight"
+    assert existing is not None
+    assert existing.resolved_effect_state().value == "UNKNOWN"
+
 
 def test_blind_park_still_releasable_by_operator() -> None:
     """Operator release still resolves a parked BLIND entry (NOT_EXECUTED)."""


### PR DESCRIPTION
## Summary
Completes the core effect-commit protocol (improve.md §1): one durable WAL intent state machine with a single atomic decision point.

- Unified `EffectState` enum (INTENDED → ATTEMPTING → COMMITTED | ABORTED | UNKNOWN) in `mycelium.transition`, exported from the package root; `resolve_effect_state(entry)` maps legacy rows (`effect_phase` + `terminal_outcome`) onto it without storage migration; rows persist durable `effect_id` + `schema_version=2`
- Predicate collapse finished: destination/destructive/secret are pure predicates evaluated only at the `record_decision` fenced CAS; config wrappers become capture-only fact layers for ledgered tools
- Storage CAS kwarg renamed `expected_effect_phase` → `expected_effect_state` across memory/json/redis/postgres/sqlite + isolation wrappers
- `profile: production` now defaults `action_ledger.unclassified_policy: strict` when omitted (explicit warn honored; templates already emit strict)
- Verify invariants assert at-most-one-COMMITTED on the unified view (`check_at_most_one_committed_effect_state`, `check_effect_state_consistency`); simulation scenario asserts them on every crash phase and fence takeover

## Test plan
- New `test_effect_state_machine.py`: transition matrix w/ illegal-CAS rejections, legacy deserialization table, crash-before/during-ATTEMPTING (idempotent auto-reclaim vs strict fail-closed vs BLIND UNKNOWN parking)
- Decision-point isolation test (destination-only denial aborts at the CAS, body never runs), two-worker same-call collision test, stale-fence assertions
- ruff clean; full suite green modulo pre-existing environmental failures; Redis two-worker proof passes

No version bump; CHANGELOG under Unreleased.