### PR TITLE
feat: effect_id-authoritative dedup, provider-key propagation, Change 5 simulation + spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+- Effect identity is now authoritative via the derived `effect_id` secondary
+  index: duplicate claims with different explicit `request_id` values but the
+  same logical effect converge on one durable row and deduplicate there.
+
+- Opt-in provider-key injection shipped for effect identity reuse:
+  `propagate_effect_id_as_provider_key` can populate the provider idempotency
+  key from the derived effect identity when a tool declares a provider-key
+  parameter.
+
+- Change 5 delivered: a deterministic in-process
+  `state-machine-exhaustive` verify scenario now exercises crash/resume,
+  stale-fence takeover, BLIND UNKNOWN parking, and claim-race interleavings,
+  with a companion formal spec artifact at `sdk/docs/spec/effect_state.tla`.
+
 - Unified durable WAL intent (`EffectState`) completes the effect-commit
   protocol. New `mycelium.transition.EffectState` (INTENDED / ATTEMPTING /
   COMMITTED / ABORTED / UNKNOWN) plus `resolve_effect_state(entry)` collapses
@@ -24,9 +38,6 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
   EffectState-string semantics), and `profile: production` now defaults
   `action_ledger.unclassified_policy` to `strict` when omitted
   (explicit `warn` remains honored).
-
-- TODO(Change 5): exhaustive interleaving simulation and a formal
-  TLA+/PlusCal spec of the intent state machine.
 
 - Budget accounting now warns when `record_usage(steps=...)` is combined with
   the step meter that `check()` and `@budget_guard` enable by default, preventing

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -749,9 +749,13 @@ Seven fields decide whether an unresolved prior execution is merely **wasteful**
 | 2 | `capability` | Whether recovery is intrinsically safe, can query the outcome, or is blind (`idempotent` / `queryable` / `blind`) |
 | 3 | `spendability` | How many times the same intent may spend (`multi_use` / `single_use` / `non_replayable`) |
 | 4 | `side_effect_boundary` | Whether the external call was crossed (`not_crossed` / `maybe_crossed` / `crossed`) |
-| 5 | `terminal_outcome` | Where the prior attempt ended (`IN_FLIGHT`, `COMPLETED`, `UNKNOWN`, `EXPIRED`, …) |
+| 5 | `terminal_outcome` | Legacy resolution field (`IN_FLIGHT`, `COMPLETED`, `UNKNOWN`, `EXPIRED`, …) used for backward compatibility |
 | 6 | `external_operation_ref` | Provider handle for read-only reconcile (id or idempotency key) |
 | 7 | `retry_permission` | Whether automatic retry is allowed (and same-key enforcement when opted in) |
+
+Primary intent is the unified `EffectState` machine (`INTENDED -> ATTEMPTING ->
+COMMITTED|ABORTED|UNKNOWN`); legacy `effect_phase` and `terminal_outcome` are
+compatibility fields that fold into that single state.
 
 **Invariant:** for a given tool class, the fields that class **requires** must already be **supported and recorded** on the transition before a redispatch is treated as a safe retry. Reads need a lighter set (class + terminal + lease). Payment / write / email / subagent need spendability, boundary, terminal outcome, and usually an external receipt/ref — without them, a second dispatch is an **unsupported second transition**, not a retry.
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -580,6 +580,11 @@ For `keyed_mutate` tools, use the same string as the provider idempotency key
 when the provider allows it (`Idempotency-Key: charge-order:ORD-123`). That
 keeps ledger identity and provider dedupe aligned.
 
+Explicit `request_id` can be an audit/business ticket, but consequential
+dedupe is authoritative on the derived `effect_id` (tool + canonicalized
+params + destination shape). Re-dispatches of the same logical effect must
+preserve that shape; changing it intentionally creates a new effect.
+
 | Inputs | → | What happens |
 |--------|---|--------------|
 | Same explicit `request_id` + same tool/scope/args | → | Same transition — return stored result or poll |

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -33,8 +33,10 @@ Mycelium's core promise is narrow and specific (AF-002 flagship):
 "Prevent" means: at most one tool body run per transition, plus exactly one
 extra run per **provably not executed** verdict (an operator release
 `--verified not-executed` or a reconciler returning `NOT_EXECUTED`). The
-tool's *outcome* is decided by the transition state machine, never by
-blindly re-running the body. Provider adapters (e.g. Gmail sent-log) are
+tool's *outcome* is decided by the unified `EffectState` state machine
+(`INTENDED -> ATTEMPTING -> COMMITTED|ABORTED|UNKNOWN`), with
+`effect_phase`/`terminal_outcome` kept as compatibility storage views, never
+by blindly re-running the body. Provider adapters (e.g. Gmail sent-log) are
 demos of the `Reconciler` contract, not a separate product promise.
 
 This document is **explicitly out of scope** for:

--- a/sdk/docs/spec/README.md
+++ b/sdk/docs/spec/README.md
@@ -1,0 +1,43 @@
+# EffectState spec notes
+
+This folder contains a lightweight TLA+ model of the one-row effect protocol in
+`sdk/docs/spec/effect_state.tla`.
+
+What it models:
+- One durable row with unified `EffectState` (`INTENDED`, `ATTEMPTING`,
+  `COMMITTED`, `ABORTED`, `UNKNOWN`), plus fencing metadata (`owner`, `fence`).
+- The legal protocol edges: `INTENDED -> ATTEMPTING -> COMMITTED|ABORTED|UNKNOWN`.
+- CAS-guarded stale writes as no-op transitions (`StaleFenceWrite`) to model
+  rejected stale owner/fence mutations.
+- Safety invariants:
+  - `TypeOK` (well-typed state)
+  - `AtMostOneCommitted` (`committed_count <= 1`)
+
+Action mapping to runtime methods:
+- `Claim` -> `ActionLedger.claim_side_effecting` (claim/reclaim fence bump)
+- `RecordDecisionAllow` / `RecordDecisionDeny` -> `ActionLedger.record_decision`
+  with expected owner/fence and expected intent `INTENDED`
+- `Complete` -> `ActionLedger.complete` with expected owner/fence and
+  `ATTEMPTING` precondition
+- `FailBeforeEffect` -> `ActionLedger.fail(... failed_after_effect=False)`
+- `FailAfterEffect` / `MarkUnknown` ->
+  `ActionLedger.fail(... failed_after_effect=True)` /
+  `ActionLedger.mark_unknown`
+- `StaleFenceWrite` -> rejected stale `complete` / `fail` /
+  `record_decision` CAS attempts
+
+Test mapping in this repo:
+- Transition matrix seed: `sdk/tests/test_effect_state_machine.py`
+- Deterministic exhaustive interleavings:
+  `sdk/mycelium/verify/scenarios/state_machine_exhaustive.py`
+- Verify simulation invariant sweep:
+  `sdk/mycelium/verify/scenarios/simulation.py`
+
+Optional manual TLC run (not in CI):
+1. Install TLA+ tools locally (or use the Toolbox CLI).
+2. From this directory run:
+   - `tlc -simulate effect_state.tla`
+   - optionally add depth/seed flags for repeatable traces.
+
+This spec artifact is documentation and model-checking support only; CI does not
+execute TLC.

--- a/sdk/docs/spec/effect_state.tla
+++ b/sdk/docs/spec/effect_state.tla
@@ -1,0 +1,117 @@
+---- MODULE effect_state ----
+EXTENDS Naturals
+
+\* One-row model of the durable intent protocol.
+CONSTANT Owners
+
+VARIABLES effect_state, fence, owner, decision_allowed, committed_count
+
+States == {"INTENDED", "ATTEMPTING", "COMMITTED", "ABORTED", "UNKNOWN"}
+
+Init ==
+  /\ effect_state = "INTENDED"
+  /\ fence = 0
+  /\ owner = "none"
+  /\ decision_allowed = FALSE
+  /\ committed_count = 0
+
+\* ActionLedger.claim_side_effecting()
+\* CAS preconditions: expected_owner/expected_fence match prior row on reclaim.
+Claim(o) ==
+  /\ o \in Owners
+  /\ effect_state \in {"INTENDED", "ABORTED", "UNKNOWN"}
+  /\ fence' = fence + 1
+  /\ owner' = o
+  /\ effect_state' = "INTENDED"
+  /\ decision_allowed' = FALSE
+  /\ committed_count' = committed_count
+
+\* ActionLedger.record_decision(allowed=TRUE|FALSE)
+\* CAS preconditions: expected_owner = owner, expected_fence = fence,
+\* expected_effect_state = INTENDED.
+RecordDecisionAllow(o, f) ==
+  /\ o = owner
+  /\ f = fence
+  /\ effect_state = "INTENDED"
+  /\ effect_state' = "ATTEMPTING"
+  /\ decision_allowed' = TRUE
+  /\ UNCHANGED <<fence, owner, committed_count>>
+
+RecordDecisionDeny(o, f) ==
+  /\ o = owner
+  /\ f = fence
+  /\ effect_state = "INTENDED"
+  /\ effect_state' = "ABORTED"
+  /\ decision_allowed' = FALSE
+  /\ UNCHANGED <<fence, owner, committed_count>>
+
+\* ActionLedger.complete()
+\* CAS preconditions: expected_owner = owner, expected_fence = fence,
+\* expected_effect_state = ATTEMPTING.
+Complete(o, f) ==
+  /\ o = owner
+  /\ f = fence
+  /\ effect_state = "ATTEMPTING"
+  /\ decision_allowed = TRUE
+  /\ effect_state' = "COMMITTED"
+  /\ committed_count' = committed_count + 1
+  /\ UNCHANGED <<fence, owner, decision_allowed>>
+
+\* ActionLedger.fail(... failed_after_effect=False)
+\* CAS preconditions: expected_owner = owner, expected_fence = fence.
+FailBeforeEffect(o, f) ==
+  /\ o = owner
+  /\ f = fence
+  /\ effect_state \in {"INTENDED", "ATTEMPTING"}
+  /\ effect_state' = "ABORTED"
+  /\ UNCHANGED <<fence, owner, decision_allowed, committed_count>>
+
+\* ActionLedger.fail(... failed_after_effect=True) / mark_unknown()
+\* CAS preconditions: expected_owner = owner, expected_fence = fence.
+FailAfterEffect(o, f) ==
+  /\ o = owner
+  /\ f = fence
+  /\ effect_state = "ATTEMPTING"
+  /\ effect_state' = "UNKNOWN"
+  /\ UNCHANGED <<fence, owner, decision_allowed, committed_count>>
+
+MarkUnknown(o, f) ==
+  /\ o = owner
+  /\ f = fence
+  /\ effect_state \in {"INTENDED", "ATTEMPTING"}
+  /\ effect_state' = "UNKNOWN"
+  /\ UNCHANGED <<fence, owner, decision_allowed, committed_count>>
+
+\* Stale-fence write rejected by CAS (no state change).
+\* Models rejected complete/fail/record_decision from superseded owner/fence.
+StaleFenceWrite(staleOwner, staleFence) ==
+  /\ staleOwner # owner \/ staleFence # fence
+  /\ UNCHANGED <<effect_state, fence, owner, decision_allowed, committed_count>>
+
+Next ==
+  \E o \in Owners :
+      Claim(o)
+      \/ \E f \in Nat :
+           RecordDecisionAllow(o, f)
+           \/ RecordDecisionDeny(o, f)
+           \/ Complete(o, f)
+           \/ FailBeforeEffect(o, f)
+           \/ FailAfterEffect(o, f)
+           \/ MarkUnknown(o, f)
+           \/ StaleFenceWrite(o, f)
+
+TypeOK ==
+  /\ effect_state \in States
+  /\ fence \in Nat
+  /\ owner \in Owners \cup {"none"}
+  /\ decision_allowed \in BOOLEAN
+  /\ committed_count \in Nat
+
+AtMostOneCommitted ==
+  committed_count <= 1
+
+Spec == Init /\ [][Next]_<<effect_state, fence, owner, decision_allowed, committed_count>>
+
+THEOREM Spec => []TypeOK
+THEOREM Spec => []AtMostOneCommitted
+====

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -677,12 +677,10 @@ class LedgerEntry:
     # to the same transition-key derivation), so the two collide naturally.
     # When a host supplies an *explicit* request_id (its own business/audit
     # id), effect_id is the independent dedup identity computed from the call
-    # shape alone; two different explicit request_ids for what is otherwise
-    # the same (tool, params, destination) are NOT unified into one storage
-    # row by this change (that would require a cross-backend secondary index
-    # keyed by effect_id, which is out of scope here) — hosts that redispatch
-    # the same logical effect must reuse the same request_id, as documented
-    # elsewhere. ``None`` for unclassified claims (no binding to derive from).
+    # shape alone; claim-side storage enforces at-most-one row per effect_id,
+    # so logically identical explicit request_ids route through the same
+    # canonical row. ``None`` for unclassified claims (no binding to derive
+    # from).
     effect_id: str | None = None
     # Schema version for this row's shape. See LEDGER_ENTRY_SCHEMA_VERSION.
     schema_version: int = LEDGER_ENTRY_SCHEMA_VERSION
@@ -868,6 +866,10 @@ class LedgerStorage:
         """Persist entry, replacing any existing entry with the same request_id."""
         raise NotImplementedError
 
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        """Return the entry for effect_id, or None if not found."""
+        raise NotImplementedError
+
     def try_claim_inflight(
         self,
         entry: LedgerEntry,
@@ -950,6 +952,7 @@ class InMemoryLedgerStorage(LedgerStorage):
 
     def __init__(self) -> None:
         self._entries: dict[str, LedgerEntry] = {}
+        self._effect_index: dict[str, str] = {}
         self._lock = threading.RLock()
 
     def get(self, request_id: str) -> LedgerEntry | None:
@@ -958,7 +961,28 @@ class InMemoryLedgerStorage(LedgerStorage):
 
     def set(self, entry: LedgerEntry) -> None:
         with self._lock:
+            prior = self._entries.get(entry.request_id)
+            if prior is not None and prior.effect_id is not None:
+                mapped = self._effect_index.get(prior.effect_id)
+                if mapped == entry.request_id:
+                    self._effect_index.pop(prior.effect_id, None)
             self._entries[entry.request_id] = entry
+            if entry.effect_id is not None:
+                self._effect_index[entry.effect_id] = entry.request_id
+
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        with self._lock:
+            request_id = self._effect_index.get(effect_id)
+            if request_id is not None:
+                existing = self._entries.get(request_id)
+                if existing is not None:
+                    return existing
+                self._effect_index.pop(effect_id, None)
+            for candidate in self._entries.values():
+                if candidate.effect_id == effect_id:
+                    self._effect_index[effect_id] = candidate.request_id
+                    return candidate
+            return None
 
     def try_claim_inflight(
         self,
@@ -967,6 +991,14 @@ class InMemoryLedgerStorage(LedgerStorage):
         lease_ttl: float = DEFAULT_LEASE_TTL,
     ) -> tuple[str, LedgerEntry | None]:
         with self._lock:
+            if entry.effect_id is not None:
+                canonical = self.get_by_effect_id(entry.effect_id)
+                if canonical is not None and canonical.request_id != entry.request_id:
+                    now = time.time()
+                    outcome = claim_inflight_outcome(canonical, now=now)
+                    if outcome == "completed":
+                        return "completed", canonical
+                    return "in_flight", canonical
             return default_try_claim_inflight(self, entry, lease_ttl=lease_ttl)
 
     def try_transition(
@@ -1035,6 +1067,17 @@ class FileLedgerStorage(LedgerStorage):
         with self._lock:
             self._file.read_modify_write(mutate)
 
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        def read(data: dict[str, dict[str, Any]]) -> LedgerEntry | None:
+            for raw in data.values():
+                candidate = LedgerEntry.from_dict(raw)
+                if candidate.effect_id == effect_id:
+                    return candidate
+            return None
+
+        with self._lock:
+            return self._file.read_modify_write_no_save(read)
+
     def try_claim_inflight(
         self,
         entry: LedgerEntry,
@@ -1044,6 +1087,20 @@ class FileLedgerStorage(LedgerStorage):
         outcome: list[tuple[str, LedgerEntry | None]] = []
 
         def mutate(data: dict[str, dict[str, Any]]) -> None:
+            if entry.effect_id is not None:
+                for raw in data.values():
+                    candidate = LedgerEntry.from_dict(raw)
+                    if candidate.effect_id != entry.effect_id:
+                        continue
+                    if candidate.request_id == entry.request_id:
+                        break
+                    now = time.time()
+                    effect_outcome = claim_inflight_outcome(candidate, now=now)
+                    if effect_outcome == "completed":
+                        outcome.append(("completed", candidate))
+                    else:
+                        outcome.append(("in_flight", candidate))
+                    return
             raw = data.get(entry.request_id)
             existing = LedgerEntry.from_dict(raw) if raw is not None else None
             now = time.time()
@@ -1237,6 +1294,16 @@ class ActionLedger:
     def _list_all_entries(self) -> list[LedgerEntry]:
         with _storage_errors("list_all"):
             return self._storage.list_all()
+
+    def _get_entry_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        getter = getattr(self._storage, "get_by_effect_id", None)
+        if callable(getter):
+            with _storage_errors("get_by_effect_id"):
+                return getter(effect_id)
+        for entry in self._list_all_entries():
+            if entry.effect_id == effect_id:
+                return entry
+        return None
 
     def _enforce_args_drift(
         self,
@@ -1758,6 +1825,7 @@ class ActionLedger:
         *,
         binding: ToolTransitionBinding | None = None,
         _provider_key_first_attempt_at: float | None = None,
+        effect_id: str | None = None,
     ) -> LedgerEntry:
         bound = _bind_args(args, kwargs)
         boundary = (
@@ -1787,9 +1855,9 @@ class ActionLedger:
         # side-effect class and stays effect_id=None). Same derivation as
         # derive_request_id's fallback, so request_id == effect_id whenever
         # request_id itself was derived (the default) rather than explicit.
-        effect_id = (
-            derive_effect_id_for_call(tool, args, kwargs, binding) if binding is not None else None
-        )
+        resolved_effect_id = effect_id
+        if resolved_effect_id is None and binding is not None:
+            resolved_effect_id = derive_effect_id_for_call(tool, args, kwargs, binding)
         return LedgerEntry(
             request_id=request_id,
             tool=tool,
@@ -1807,7 +1875,7 @@ class ActionLedger:
             parent_request_id=str(parent_raw) if parent_raw is not None else None,
             handoff_id=str(handoff_raw) if handoff_raw is not None else None,
             effect_protocol_required=binding is not None,
-            effect_id=effect_id,
+            effect_id=resolved_effect_id,
         )
 
     def claim(
@@ -2578,14 +2646,30 @@ class ActionLedger:
         timeout = self._poll_timeout if poll_timeout is None else poll_timeout
         poll_deadline = time.time() + timeout if timeout is not None else None
         incoming_key = extract_provider_idempotency_key(kwargs, binding)
+        derived_effect_id = derive_effect_id_for_call(tool, args, kwargs, binding)
+        existing_for_effect = self._get_entry_by_effect_id(derived_effect_id)
+        if existing_for_effect is not None and existing_for_effect.request_id != request_id:
+            # Same logical effect under a different storage key: re-enter the
+            # normal claim loop as if the host had used the canonical id.
+            return self.claim_side_effecting(
+                existing_for_effect.request_id,
+                tool,
+                args,
+                kwargs,
+                binding,
+                lease_ttl=lease_ttl,
+                poll_interval=poll_interval,
+                poll_timeout=poll_timeout,
+            )
+        canonical_request_id = request_id
 
         while True:
-            existing = self.get(request_id)
+            existing = self.get(canonical_request_id)
             self._enforce_args_drift(
                 tool,
                 args,
                 kwargs,
-                request_id=request_id,
+                request_id=canonical_request_id,
                 existing=existing,
                 binding=binding,
             )
@@ -2596,19 +2680,19 @@ class ActionLedger:
                     incoming_provider_idempotency_key=incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
-                    self.repair_transition(request_id)
+                    self.repair_transition(canonical_request_id)
                     continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
                     entry = self._reconcile_or_hard_block(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                         if getattr(_reconcile_cas_lost, "val", False):
                             _reconcile_cas_lost.val = False
                             self._poll_side_effecting(
-                                request_id,
+                                canonical_request_id,
                                 tool=tool,
                                 interval=interval,
                                 poll_deadline=poll_deadline,
@@ -2617,7 +2701,7 @@ class ActionLedger:
                     return entry
                 if gate == TransitionGate.POLL:
                     self._poll_side_effecting(
-                        request_id,
+                        canonical_request_id,
                         tool=tool,
                         interval=interval,
                         poll_deadline=poll_deadline,
@@ -2625,13 +2709,13 @@ class ActionLedger:
                     continue
                 if gate == TransitionGate.ALLOW:
                     settled = self._prefer_settle_before_unknown_allow(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if settled is not None:
                         return settled
                     if existing.resolved_terminal_outcome() == TerminalOutcome.UNKNOWN:
                         reset = self._reset_unknown_for_same_key_retry(
-                            request_id,
+                            canonical_request_id,
                             tool,
                             args,
                             kwargs,
@@ -2643,18 +2727,20 @@ class ActionLedger:
                             return reset
                         if self._blind_never_retries(tool, binding, existing):
                             return self._raise_hard_block(
-                                request_id, tool, existing, binding=binding
+                                canonical_request_id, tool, existing, binding=binding
                             )
                         continue
                     if self._blind_never_retries(tool, binding, existing):
-                        return self._raise_hard_block(request_id, tool, existing, binding=binding)
+                        return self._raise_hard_block(
+                            canonical_request_id, tool, existing, binding=binding
+                        )
                     if self._reclaim_requires_death_signal and not has_worker_death_evidence(
                         existing,
                         now=time.time(),
                         presumed_dead_after=self._presumed_dead_after,
                     ):
                         self._poll_side_effecting(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
@@ -2667,36 +2753,38 @@ class ActionLedger:
                 else None
             )
             entry = self._new_inflight_entry(
-                request_id,
+                canonical_request_id,
                 tool,
                 args,
                 kwargs,
                 binding=binding,
                 _provider_key_first_attempt_at=_old_pkey_attempt,
+                effect_id=derived_effect_id,
             )
             outcome, existing = self._try_claim_inflight(entry, lease_ttl=ttl)
             if outcome == "completed" and existing is not None:
                 return existing
             if outcome == "in_flight" and existing is not None:
+                canonical_request_id = existing.request_id
                 gate = resolve_side_effect_gate(
                     existing,
                     binding,
                     incoming_provider_idempotency_key=incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
-                    self.repair_transition(request_id)
+                    self.repair_transition(canonical_request_id)
                     continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
                     entry = self._reconcile_or_hard_block(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                         if getattr(_reconcile_cas_lost, "val", False):
                             _reconcile_cas_lost.val = False
                             self._poll_side_effecting(
-                                request_id,
+                                canonical_request_id,
                                 tool=tool,
                                 interval=interval,
                                 poll_deadline=poll_deadline,
@@ -2707,7 +2795,7 @@ class ActionLedger:
                     tool, binding, existing
                 ):
                     self._poll_side_effecting(
-                        request_id,
+                        canonical_request_id,
                         tool=tool,
                         interval=interval,
                         poll_deadline=poll_deadline,
@@ -2720,31 +2808,31 @@ class ActionLedger:
                         presumed_dead_after=self._presumed_dead_after,
                     ):
                         self._poll_side_effecting(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
                         )
                         continue
                 self._poll_side_effecting(
-                    request_id,
+                    canonical_request_id,
                     tool=tool,
                     interval=interval,
                     poll_deadline=poll_deadline,
                 )
                 continue
             if outcome == "claimed":
-                claimed = self.get(request_id)
+                claimed = self.get(canonical_request_id)
                 return claimed if claimed is not None else entry
             if existing is not None:
                 entry = self._reconcile_or_hard_block(
-                    request_id, tool, args, kwargs, existing, binding
+                    canonical_request_id, tool, args, kwargs, existing, binding
                 )
                 if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                     if getattr(_reconcile_cas_lost, "val", False):
                         _reconcile_cas_lost.val = False
                         self._poll_side_effecting(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
@@ -2834,14 +2922,30 @@ class ActionLedger:
         timeout = self._poll_timeout if poll_timeout is None else poll_timeout
         poll_deadline = time.time() + timeout if timeout is not None else None
         incoming_key = extract_provider_idempotency_key(kwargs, binding)
+        derived_effect_id = derive_effect_id_for_call(tool, args, kwargs, binding)
+        existing_for_effect = self._get_entry_by_effect_id(derived_effect_id)
+        if existing_for_effect is not None and existing_for_effect.request_id != request_id:
+            # Same logical effect under a different storage key: re-enter the
+            # normal claim loop as if the host had used the canonical id.
+            return await self.claim_side_effecting_async(
+                existing_for_effect.request_id,
+                tool,
+                args,
+                kwargs,
+                binding,
+                lease_ttl=lease_ttl,
+                poll_interval=poll_interval,
+                poll_timeout=poll_timeout,
+            )
+        canonical_request_id = request_id
 
         while True:
-            existing = self.get(request_id)
+            existing = self.get(canonical_request_id)
             self._enforce_args_drift(
                 tool,
                 args,
                 kwargs,
-                request_id=request_id,
+                request_id=canonical_request_id,
                 existing=existing,
                 binding=binding,
             )
@@ -2852,19 +2956,19 @@ class ActionLedger:
                     incoming_provider_idempotency_key=incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
-                    self.repair_transition(request_id)
+                    self.repair_transition(canonical_request_id)
                     continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
                     entry = await self._reconcile_or_hard_block_async(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                         if getattr(_reconcile_cas_lost, "val", False):
                             _reconcile_cas_lost.val = False
                             await self._poll_side_effecting_async(
-                                request_id,
+                                canonical_request_id,
                                 tool=tool,
                                 interval=interval,
                                 poll_deadline=poll_deadline,
@@ -2873,7 +2977,7 @@ class ActionLedger:
                     return entry
                 if gate == TransitionGate.POLL:
                     await self._poll_side_effecting_async(
-                        request_id,
+                        canonical_request_id,
                         tool=tool,
                         interval=interval,
                         poll_deadline=poll_deadline,
@@ -2881,13 +2985,13 @@ class ActionLedger:
                     continue
                 if gate == TransitionGate.ALLOW:
                     settled = await self._prefer_settle_before_unknown_allow_async(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if settled is not None:
                         return settled
                     if existing.resolved_terminal_outcome() == TerminalOutcome.UNKNOWN:
                         reset = self._reset_unknown_for_same_key_retry(
-                            request_id,
+                            canonical_request_id,
                             tool,
                             args,
                             kwargs,
@@ -2899,18 +3003,20 @@ class ActionLedger:
                             return reset
                         if self._blind_never_retries(tool, binding, existing):
                             return self._raise_hard_block(
-                                request_id, tool, existing, binding=binding
+                                canonical_request_id, tool, existing, binding=binding
                             )
                         continue
                     if self._blind_never_retries(tool, binding, existing):
-                        return self._raise_hard_block(request_id, tool, existing, binding=binding)
+                        return self._raise_hard_block(
+                            canonical_request_id, tool, existing, binding=binding
+                        )
                     if self._reclaim_requires_death_signal and not has_worker_death_evidence(
                         existing,
                         now=time.time(),
                         presumed_dead_after=self._presumed_dead_after,
                     ):
                         await self._poll_side_effecting_async(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
@@ -2923,36 +3029,38 @@ class ActionLedger:
                 else None
             )
             entry = self._new_inflight_entry(
-                request_id,
+                canonical_request_id,
                 tool,
                 args,
                 kwargs,
                 binding=binding,
                 _provider_key_first_attempt_at=_old_pkey_attempt,
+                effect_id=derived_effect_id,
             )
             outcome, existing = self._try_claim_inflight(entry, lease_ttl=ttl)
             if outcome == "completed" and existing is not None:
                 return existing
             if outcome == "in_flight" and existing is not None:
+                canonical_request_id = existing.request_id
                 gate = resolve_side_effect_gate(
                     existing,
                     binding,
                     incoming_provider_idempotency_key=incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
-                    self.repair_transition(request_id)
+                    self.repair_transition(canonical_request_id)
                     continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
                     entry = await self._reconcile_or_hard_block_async(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                         if getattr(_reconcile_cas_lost, "val", False):
                             _reconcile_cas_lost.val = False
                             await self._poll_side_effecting_async(
-                                request_id,
+                                canonical_request_id,
                                 tool=tool,
                                 interval=interval,
                                 poll_deadline=poll_deadline,
@@ -2963,7 +3071,7 @@ class ActionLedger:
                     tool, binding, existing
                 ):
                     await self._poll_side_effecting_async(
-                        request_id,
+                        canonical_request_id,
                         tool=tool,
                         interval=interval,
                         poll_deadline=poll_deadline,
@@ -2976,31 +3084,31 @@ class ActionLedger:
                         presumed_dead_after=self._presumed_dead_after,
                     ):
                         await self._poll_side_effecting_async(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
                         )
                         continue
                 await self._poll_side_effecting_async(
-                    request_id,
+                    canonical_request_id,
                     tool=tool,
                     interval=interval,
                     poll_deadline=poll_deadline,
                 )
                 continue
             if outcome == "claimed":
-                claimed = self.get(request_id)
+                claimed = self.get(canonical_request_id)
                 return claimed if claimed is not None else entry
             if existing is not None:
                 entry = await self._reconcile_or_hard_block_async(
-                    request_id, tool, args, kwargs, existing, binding
+                    canonical_request_id, tool, args, kwargs, existing, binding
                 )
                 if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                     if getattr(_reconcile_cas_lost, "val", False):
                         _reconcile_cas_lost.val = False
                         await self._poll_side_effecting_async(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
@@ -4375,6 +4483,9 @@ def _run_ledgered(
                 request_id,
             )
         raise
+    # Effect-index may remap onto a canonical stored request_id; all subsequent
+    # decision / complete / fail writes must target that row.
+    request_id = existing.request_id
     if existing.is_terminal_completed():
         ledger._emit_outcome(
             request_id=request_id,
@@ -4741,6 +4852,9 @@ async def _run_ledgered_async(
                 request_id,
             )
         raise
+    # Effect-index may remap onto a canonical stored request_id; all subsequent
+    # decision / complete / fail writes must target that row.
+    request_id = existing.request_id
     if existing.is_terminal_completed():
         ledger._emit_outcome(
             request_id=request_id,

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -2674,10 +2674,18 @@ class ActionLedger:
                 binding=binding,
             )
             if existing is not None:
+                gate_incoming_key = incoming_key
+                if (
+                    gate_incoming_key is None
+                    and binding.propagate_effect_id_as_provider_key
+                    and binding.provider_idempotency_key_param is not None
+                    and existing.provider_idempotency_key is not None
+                ):
+                    gate_incoming_key = existing.provider_idempotency_key
                 gate = resolve_side_effect_gate(
                     existing,
                     binding,
-                    incoming_provider_idempotency_key=incoming_key,
+                    incoming_provider_idempotency_key=gate_incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
                     self.repair_transition(canonical_request_id)
@@ -2766,10 +2774,18 @@ class ActionLedger:
                 return existing
             if outcome == "in_flight" and existing is not None:
                 canonical_request_id = existing.request_id
+                gate_incoming_key = incoming_key
+                if (
+                    gate_incoming_key is None
+                    and binding.propagate_effect_id_as_provider_key
+                    and binding.provider_idempotency_key_param is not None
+                    and existing.provider_idempotency_key is not None
+                ):
+                    gate_incoming_key = existing.provider_idempotency_key
                 gate = resolve_side_effect_gate(
                     existing,
                     binding,
-                    incoming_provider_idempotency_key=incoming_key,
+                    incoming_provider_idempotency_key=gate_incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
                     self.repair_transition(canonical_request_id)
@@ -2950,10 +2966,18 @@ class ActionLedger:
                 binding=binding,
             )
             if existing is not None:
+                gate_incoming_key = incoming_key
+                if (
+                    gate_incoming_key is None
+                    and binding.propagate_effect_id_as_provider_key
+                    and binding.provider_idempotency_key_param is not None
+                    and existing.provider_idempotency_key is not None
+                ):
+                    gate_incoming_key = existing.provider_idempotency_key
                 gate = resolve_side_effect_gate(
                     existing,
                     binding,
-                    incoming_provider_idempotency_key=incoming_key,
+                    incoming_provider_idempotency_key=gate_incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
                     self.repair_transition(canonical_request_id)
@@ -3042,10 +3066,18 @@ class ActionLedger:
                 return existing
             if outcome == "in_flight" and existing is not None:
                 canonical_request_id = existing.request_id
+                gate_incoming_key = incoming_key
+                if (
+                    gate_incoming_key is None
+                    and binding.propagate_effect_id_as_provider_key
+                    and binding.provider_idempotency_key_param is not None
+                    and existing.provider_idempotency_key is not None
+                ):
+                    gate_incoming_key = existing.provider_idempotency_key
                 gate = resolve_side_effect_gate(
                     existing,
                     binding,
-                    incoming_provider_idempotency_key=incoming_key,
+                    incoming_provider_idempotency_key=gate_incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
                     self.repair_transition(canonical_request_id)
@@ -3363,6 +3395,72 @@ class ActionLedger:
         ):
             raise LedgerOutcomeAlreadySetError(
                 f"Cannot attach external operation ref to {request_id!r}: transition superseded"
+            )
+        return entry
+
+    def ensure_provider_idempotency_key(
+        self,
+        request_id: str,
+        provider_key: str,
+        *,
+        expected_owner: str | None = None,
+        expected_fence: int | None = None,
+    ) -> LedgerEntry:
+        """Persist a provider idempotency key with fenced CAS.
+
+        Used by effect-id propagation after the ATTEMPTING decision is recorded.
+        If a key is already present, it is reused verbatim and must match.
+        """
+        existing = self._get_entry(request_id)
+        if existing is None:
+            raise LedgerError(
+                f"Cannot set provider idempotency key on unknown request {request_id!r}"
+            )
+        if expected_fence is None:
+            raise LedgerError(
+                f"Setting provider idempotency key on {request_id!r} requires the claim fence"
+            )
+        if existing.effect_protocol_required and not _has_allowed_attempting_decision(existing):
+            raise LedgerOutcomeAlreadySetError(
+                f"Cannot set provider idempotency key on {request_id!r}: "
+                "no durable ATTEMPTING decision"
+            )
+        if existing.provider_idempotency_key is not None:
+            if existing.provider_idempotency_key != provider_key:
+                raise LedgerHardBlockError(
+                    f"Provider idempotency key mismatch for {request_id!r}: "
+                    f"stored={existing.provider_idempotency_key!r} "
+                    f"incoming={provider_key!r}"
+                )
+            return existing
+        pkey_first_attempt = existing.provider_key_first_attempt_at
+        if pkey_first_attempt is None:
+            pkey_first_attempt = time.time()
+        entry = replace(
+            existing,
+            provider_idempotency_key=provider_key,
+            provider_key_first_attempt_at=pkey_first_attempt,
+        )
+        if not self._try_transition(
+            entry,
+            expected_from=frozenset({existing.terminal_outcome}),
+            expected_owner=expected_owner,
+            expected_fence=expected_fence,
+            expected_effect_state=(
+                EffectState.ATTEMPTING.value if existing.effect_protocol_required else None
+            ),
+        ):
+            current = self._get_entry(request_id)
+            if current is not None and current.provider_idempotency_key is not None:
+                if current.provider_idempotency_key != provider_key:
+                    raise LedgerHardBlockError(
+                        f"Provider idempotency key mismatch for {request_id!r}: "
+                        f"stored={current.provider_idempotency_key!r} "
+                        f"incoming={provider_key!r}"
+                    )
+                return current
+            raise LedgerOutcomeAlreadySetError(
+                f"Cannot set provider idempotency key on {request_id!r}: transition superseded"
             )
         return entry
 
@@ -4176,6 +4274,49 @@ def _claim_kwargs(kwargs: dict[str, Any], clean_kwargs: dict[str, Any]) -> dict[
     return claim_kwargs
 
 
+def _inject_provider_key_from_effect_id(
+    *,
+    ledger: ActionLedger,
+    request_id: str,
+    clean_kwargs: dict[str, Any],
+    transition_binding: ToolTransitionBinding | None,
+    owner: str | None,
+    fence: int,
+) -> dict[str, Any]:
+    """Inject provider key into body kwargs when propagation is explicitly enabled."""
+    if transition_binding is None:
+        return clean_kwargs
+    if not transition_binding.propagate_effect_id_as_provider_key:
+        return clean_kwargs
+    param = transition_binding.provider_idempotency_key_param
+    if param is None:
+        return clean_kwargs
+    if param in clean_kwargs:
+        return clean_kwargs
+
+    entry = ledger.get(request_id)
+    if entry is None:
+        raise LedgerError(f"Cannot inject provider idempotency key for {request_id!r}")
+    provider_key = entry.provider_idempotency_key
+    if provider_key is None:
+        effect_id = entry.effect_id
+        if effect_id is None:
+            raise LedgerError(
+                f"Cannot inject provider idempotency key for {request_id!r}: missing effect_id"
+            )
+        provider_key = f"mycelium:{effect_id}"
+        stamped = ledger.ensure_provider_idempotency_key(
+            request_id,
+            provider_key,
+            expected_owner=owner,
+            expected_fence=fence,
+        )
+        provider_key = str(stamped.provider_idempotency_key)
+    injected = dict(clean_kwargs)
+    injected[param] = provider_key
+    return injected
+
+
 def _emit_tool_receipt(
     audit_emitter: AuditReceiptEmitter | None,
     ledger: ActionLedger,
@@ -4653,6 +4794,14 @@ def _run_ledgered(
         if policy_blocked is not None:
             raise policy_blocked
         _raise_denied_decision(request_id, decision)
+        exec_source_kwargs = _inject_provider_key_from_effect_id(
+            ledger=ledger,
+            request_id=request_id,
+            clean_kwargs=clean_kwargs,
+            transition_binding=transition_binding,
+            owner=owner,
+            fence=fence,
+        )
 
         ledger._emit_outcome(
             request_id=request_id,
@@ -4673,7 +4822,7 @@ def _run_ledgered(
         policy = get_active_secret_policy()
         extra = policy.secret_fields if policy is not None else frozenset()
         exec_args, exec_kwargs = resolve_declared_secret_fields(
-            func, args, clean_kwargs, extra_fields=extra
+            func, args, exec_source_kwargs, extra_fields=extra
         )
         with _lease_auto_renew(
             ledger,
@@ -5022,6 +5171,14 @@ async def _run_ledgered_async(
         if policy_blocked is not None:
             raise policy_blocked
         _raise_denied_decision(request_id, decision)
+        exec_source_kwargs = _inject_provider_key_from_effect_id(
+            ledger=ledger,
+            request_id=request_id,
+            clean_kwargs=clean_kwargs,
+            transition_binding=transition_binding,
+            owner=owner,
+            fence=fence,
+        )
 
         ledger._emit_outcome(
             request_id=request_id,
@@ -5042,7 +5199,7 @@ async def _run_ledgered_async(
         policy = get_active_secret_policy()
         extra = policy.secret_fields if policy is not None else frozenset()
         exec_args, exec_kwargs = resolve_declared_secret_fields(
-            func, args, clean_kwargs, extra_fields=extra
+            func, args, exec_source_kwargs, extra_fields=extra
         )
         with _lease_auto_renew(
             ledger,

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -358,6 +358,7 @@ class ToolConfig:
     spendability: Spendability | None = None
     capability: ToolCapability | None = None
     provider_idempotency_key_param: str | None = None
+    propagate_effect_id_as_provider_key: bool = False
     provider_idempotency_key_ttl: float | None = None
     request_id_from: str | None = None
     callable_path: str | None = None
@@ -1747,6 +1748,9 @@ class MyceliumConfig:
             provider_idempotency_key_param=(
                 tool_config.provider_idempotency_key_param
             ),
+            propagate_effect_id_as_provider_key=(
+                tool_config.propagate_effect_id_as_provider_key
+            ),
             provider_idempotency_key_ttl=(
                 tool_config.provider_idempotency_key_ttl
             ),
@@ -2229,6 +2233,15 @@ def _parse_tool_config(
             )
         provider_idempotency_key_param = value
 
+    propagate_effect_id_as_provider_key = False
+    if "propagate_effect_id_as_provider_key" in raw:
+        value = raw["propagate_effect_id_as_provider_key"]
+        if not isinstance(value, bool):
+            raise ConfigError(
+                f"tool '{name}': propagate_effect_id_as_provider_key must be a bool"
+            )
+        propagate_effect_id_as_provider_key = value
+
     provider_idempotency_key_ttl: float | None = None
     if "provider_idempotency_key_ttl" in raw:
         value = raw["provider_idempotency_key_ttl"]
@@ -2367,6 +2380,7 @@ def _parse_tool_config(
         spendability=spendability,
         capability=capability,
         provider_idempotency_key_param=provider_idempotency_key_param,
+        propagate_effect_id_as_provider_key=propagate_effect_id_as_provider_key,
         provider_idempotency_key_ttl=provider_idempotency_key_ttl,
         request_id_from=request_id_from,
         callable_path=callable_path,
@@ -2476,6 +2490,9 @@ def _apply_action_ledger_tools(
             side_effect_boundary=existing.side_effect_boundary,
             spendability=existing.spendability,
             provider_idempotency_key_param=existing.provider_idempotency_key_param,
+            propagate_effect_id_as_provider_key=(
+                existing.propagate_effect_id_as_provider_key
+            ),
             provider_idempotency_key_ttl=existing.provider_idempotency_key_ttl,
             request_id_from=existing.request_id_from,
             callable_path=existing.callable_path,

--- a/sdk/mycelium/proofs/langgraph_7417_redis.py
+++ b/sdk/mycelium/proofs/langgraph_7417_redis.py
@@ -146,7 +146,7 @@ def _worker_b(payload: dict[str, Any]) -> None:
 
     url = payload["url"]
     keys = payload["keys"]
-    request_id = payload["request_id"]
+    request_id = payload.get("request_id_b") or payload["request_id"]
     client = redis.Redis.from_url(url, decode_responses=True)
     try:
         deadline = time.time() + float(payload["ready_timeout"])
@@ -197,6 +197,7 @@ def prove_two_worker_redis_redispatch(
     lease_ttl: float = 30.0,
     poll_timeout: float = 10.0,
     ready_timeout: float = 5.0,
+    request_id_b: str | None = None,
 ) -> dict[str, Any]:
     """Run the two-worker Redis proof. Raises ``AssertionError`` on failure.
 
@@ -206,6 +207,8 @@ def prove_two_worker_redis_redispatch(
     import json
 
     import redis
+
+    from mycelium import RedisLedgerStorage
 
     url = url or resolve_redis_url()
     if not redis_reachable(url):
@@ -220,6 +223,7 @@ def prove_two_worker_redis_redispatch(
         "url": url,
         "keys": keys,
         "request_id": request_id,
+        "request_id_b": request_id_b,
         "work_seconds": work_seconds,
         "lease_ttl": lease_ttl,
         "poll_timeout": poll_timeout,
@@ -264,6 +268,10 @@ def prove_two_worker_redis_redispatch(
         assert body["terminal_outcome"] == "COMPLETED"
         assert proc_a.exitcode == 0, f"worker A exit {proc_a.exitcode}"
         assert proc_b.exitcode == 0, f"worker B exit {proc_b.exitcode}"
+        storage = RedisLedgerStorage(url, prefix=keys["prefix"], in_flight_ttl=3600.0)
+        rows = storage.list_all()
+        assert len(rows) == 1, f"expected a single ledger row, got {len(rows)}"
+        assert rows[0].request_id == request_id
 
         return {
             "url": url,

--- a/sdk/mycelium/storage/postgres_ledger.py
+++ b/sdk/mycelium/storage/postgres_ledger.py
@@ -68,8 +68,16 @@ class PostgresEntryStorage:
         query = self._sql.SQL(
             "CREATE TABLE IF NOT EXISTS {} (request_id TEXT PRIMARY KEY, payload JSONB NOT NULL)"
         ).format(self._table_id())
+        effect_index = self._sql.SQL(
+            "CREATE UNIQUE INDEX IF NOT EXISTS {} ON {} "
+            "((COALESCE(payload->>'effect_id', request_id)))"
+        ).format(
+            self._sql.Identifier(f"{self._table}_effect_id_idx"),
+            self._table_id(),
+        )
         with self._psycopg.connect(self._dsn) as conn:
             conn.execute(query)
+            conn.execute(effect_index)
             conn.commit()
         self._schema_ready = True
 
@@ -95,6 +103,17 @@ class PostgresEntryStorage:
             conn.execute(query, (entry.request_id, json.dumps(payload)))
             conn.commit()
 
+    def get_by_effect_id(self, effect_id: str) -> E | None:
+        self._ensure_schema()
+        query = self._sql.SQL(
+            "SELECT payload FROM {} WHERE COALESCE(payload->>'effect_id', request_id) = %s"
+        ).format(self._table_id())
+        with self._psycopg.connect(self._dsn) as conn:
+            row = conn.execute(query, (effect_id,)).fetchone()
+        if row is None:
+            return None
+        return self._from_dict(_payload_dict(row[0]))
+
     def try_claim_inflight(
         self,
         entry: E,
@@ -108,6 +127,10 @@ class PostgresEntryStorage:
         insert_query = self._sql.SQL(
             "INSERT INTO {} (request_id, payload) VALUES (%s, %s::jsonb) "
             "ON CONFLICT (request_id) DO NOTHING RETURNING request_id"
+        ).format(self._table_id())
+        select_by_effect_for_update = self._sql.SQL(
+            "SELECT request_id, payload FROM {} "
+            "WHERE COALESCE(payload->>'effect_id', request_id) = %s FOR UPDATE"
         ).format(self._table_id())
         select_for_update = self._sql.SQL(
             "SELECT payload FROM {} WHERE request_id = %s FOR UPDATE"
@@ -124,6 +147,22 @@ class PostgresEntryStorage:
                 ).fetchone()
                 if inserted is not None:
                     return "claimed", None
+
+                effect_id = str(getattr(entry, "effect_id", "") or "")
+                if effect_id:
+                    effect_row = conn.execute(
+                        select_by_effect_for_update,
+                        (effect_id,),
+                    ).fetchone()
+                    if effect_row is not None:
+                        canonical = self._from_dict(_payload_dict(effect_row[1]))
+                        # Same request_id: fall through to the request-keyed
+                        # reclaim path (EXPIRED/FAILED must be reclaimable).
+                        if canonical.request_id != entry.request_id:
+                            outcome = claim_inflight_outcome(canonical, now=now)
+                            if outcome == "completed":
+                                return "completed", canonical
+                            return "in_flight", canonical
 
                 row = conn.execute(select_for_update, (entry.request_id,)).fetchone()
                 if row is None:
@@ -229,6 +268,9 @@ class PostgresLedgerStorage:
 
     def set(self, entry: Any) -> None:
         self._inner.set(entry)
+
+    def get_by_effect_id(self, effect_id: str) -> Any:
+        return self._inner.get_by_effect_id(effect_id)
 
     def try_claim_inflight(
         self,

--- a/sdk/mycelium/storage/redis_ledger.py
+++ b/sdk/mycelium/storage/redis_ledger.py
@@ -54,6 +54,39 @@ class RedisEntryStorage:
         base = self._prefix.rstrip(":")
         return f"{base}-tomb:{request_id}"
 
+    def _effect_key(self, effect_id: str) -> str:
+        if self._prefix.startswith("mycelium:action:"):
+            return f"mycelium:effect:{effect_id}"
+        # Sibling namespace so list_all(prefix*) never treats effect maps as entries.
+        base = self._prefix.rstrip(":")
+        return f"{base}-effect:{effect_id}"
+
+    def _mapped_target_exists(self, pipe: Any, request_id: str) -> bool:
+        """True when the mapped request still has a primary or tombstone row."""
+        return (
+            pipe.get(self._key(request_id)) is not None
+            or pipe.get(self._tombstone_key(request_id)) is not None
+        )
+
+    def _live_effect_owner(
+        self,
+        pipe: Any,
+        effect_key: str,
+        *,
+        entry_request_id: str,
+    ) -> str | None:
+        """Return a live foreign owner for *effect_key*, or ``None`` if free/stale.
+
+        Stale mappings (pointing at a vanished request_id) are treated as absent
+        so a later ``MULTI`` can overwrite them; they are not blocking.
+        """
+        mapped = pipe.get(effect_key)
+        if mapped in (None, entry_request_id):
+            return None
+        if self._mapped_target_exists(pipe, mapped):
+            return mapped
+        return None
+
     @staticmethod
     def _fence_from_payload(raw: str | None) -> int:
         if raw is None:
@@ -132,29 +165,56 @@ class RedisEntryStorage:
             return self._from_dict(json.loads(raw))
         return self._restore_from_tombstone(request_id)
 
+    def get_by_effect_id(self, effect_id: str) -> E | None:
+        effect_key = self._effect_key(effect_id)
+        request_id = self._client.get(effect_key)
+        if not request_id:
+            return None
+        entry = self.get(request_id)
+        if entry is not None:
+            return entry
+        # Stale mapping: entry row (and tombstone) are gone — drop the pointer.
+        self._client.delete(effect_key)
+        return None
+
     def set(self, entry: E) -> None:
         from redis.exceptions import WatchError
 
         payload = json.dumps(entry.to_dict(), default=str)
         key = self._key(entry.request_id)
         tomb_key = self._tombstone_key(entry.request_id)
+        effect_id = str(getattr(entry, "effect_id", "") or "")
+        effect_key = self._effect_key(effect_id) if effect_id else None
         incoming_fence = int(getattr(entry, "fence", 0) or 0)
         for _ in range(32):
             try:
                 with self._client.pipeline(transaction=True) as pipe:
-                    pipe.watch(key, tomb_key)
+                    watch_keys = [key, tomb_key]
+                    if effect_key is not None:
+                        watch_keys.append(effect_key)
+                    pipe.watch(*watch_keys)
                     stored_fence = max(
                         self._fence_from_payload(pipe.get(key)),
                         self._fence_from_payload(pipe.get(tomb_key)),
                     )
                     if stored_fence > incoming_fence:
                         return
+                    if effect_key is not None:
+                        foreign = self._live_effect_owner(
+                            pipe, effect_key, entry_request_id=entry.request_id
+                        )
+                        if foreign is not None:
+                            raise RuntimeError(
+                                f"effect_id {effect_id!r} already mapped to request {foreign!r}"
+                            )
                     pipe.multi()
                     if entry.status == "in-flight" and self._in_flight_ttl:
                         pipe.set(key, payload, ex=int(self._in_flight_ttl))
                     else:
                         pipe.set(key, payload)
                     pipe.set(tomb_key, payload)
+                    if effect_key is not None:
+                        pipe.set(effect_key, entry.request_id)
                     pipe.execute()
                     return
             except WatchError:
@@ -193,6 +253,14 @@ class RedisEntryStorage:
                 leased = with_lease(entry, now=time.time(), lease_ttl=lease_ttl)
                 if self._try_initial_claim(key, leased, ttl):
                     return "claimed", None
+                effect_id = str(getattr(entry, "effect_id", "") or "")
+                if effect_id:
+                    collided = self.get_by_effect_id(effect_id)
+                    if collided is not None and collided.request_id != entry.request_id:
+                        collided_outcome = claim_inflight_outcome(collided, now=time.time())
+                        if collided_outcome == "completed":
+                            return "completed", collided
+                        return "in_flight", collided
                 continue
 
             existing = self._from_dict(json.loads(existing_raw))
@@ -213,18 +281,31 @@ class RedisEntryStorage:
         from redis.exceptions import WatchError
 
         tomb_key = self._tombstone_key(entry.request_id)
+        effect_id = str(getattr(entry, "effect_id", "") or "")
+        effect_key = self._effect_key(effect_id) if effect_id else None
         payload = json.dumps(entry.to_dict(), default=str)
         try:
             with self._client.pipeline(transaction=True) as pipe:
-                pipe.watch(key, tomb_key)
+                watch_keys = [key, tomb_key]
+                if effect_key is not None:
+                    watch_keys.append(effect_key)
+                pipe.watch(*watch_keys)
                 if pipe.get(key) is not None or pipe.get(tomb_key) is not None:
                     return False
+                if effect_key is not None:
+                    foreign = self._live_effect_owner(
+                        pipe, effect_key, entry_request_id=entry.request_id
+                    )
+                    if foreign is not None:
+                        return False
                 pipe.multi()
                 if ttl > 0:
                     pipe.set(key, payload, ex=ttl)
                 else:
                     pipe.set(key, payload)
                 pipe.set(tomb_key, payload)
+                if effect_key is not None:
+                    pipe.set(effect_key, entry.request_id)
                 pipe.execute()
                 return True
         except WatchError:
@@ -245,9 +326,14 @@ class RedisEntryStorage:
         from mycelium.storage._helpers import claim_inflight_outcome, with_lease
 
         now = time.time()
+        effect_id = str(getattr(entry, "effect_id", "") or "")
+        effect_key = self._effect_key(effect_id) if effect_id else None
         try:
             with self._client.pipeline(transaction=True) as pipe:
-                pipe.watch(key)
+                watch_keys = [key]
+                if effect_key is not None:
+                    watch_keys.append(effect_key)
+                pipe.watch(*watch_keys)
                 raw = pipe.get(key)
                 if raw is None:
                     # Key evaporated under the watch — tombstone may still exist.
@@ -259,6 +345,12 @@ class RedisEntryStorage:
                 rerun = claim_inflight_outcome(current, now=time.time())
                 if rerun != "claimed":
                     return rerun, current
+                if effect_key is not None:
+                    foreign = self._live_effect_owner(
+                        pipe, effect_key, entry_request_id=entry.request_id
+                    )
+                    if foreign is not None:
+                        return "in_flight", current
                 # Reclaim: bump the fence past the superseded claim.
                 leased = with_lease(entry, now=now, lease_ttl=lease_ttl, prior=current)
                 payload = json.dumps(leased.to_dict(), default=str)
@@ -268,6 +360,8 @@ class RedisEntryStorage:
                 else:
                     pipe.set(key, payload)
                 pipe.set(self._tombstone_key(entry.request_id), payload)
+                if effect_key is not None:
+                    pipe.set(effect_key, entry.request_id)
                 pipe.execute()
                 return ("claimed", None)
         except WatchError:
@@ -288,11 +382,16 @@ class RedisEntryStorage:
         from mycelium.storage._helpers import lease_allows_renew
 
         key = self._key(entry.request_id)
+        effect_id = str(getattr(entry, "effect_id", "") or "")
+        effect_key = self._effect_key(effect_id) if effect_id else None
         payload = json.dumps(entry.to_dict(), default=str)
         for _ in range(32):
             try:
                 with self._client.pipeline(transaction=True) as pipe:
-                    pipe.watch(key)
+                    watch_keys = [key]
+                    if effect_key is not None:
+                        watch_keys.append(effect_key)
+                    pipe.watch(*watch_keys)
                     raw = pipe.get(key)
                     if raw is None:
                         # TTL eviction mid-transition: restore history, then retry.
@@ -320,9 +419,17 @@ class RedisEntryStorage:
                         now=require_lease_held_at,
                     ):
                         return False
+                    if effect_key is not None:
+                        foreign = self._live_effect_owner(
+                            pipe, effect_key, entry_request_id=entry.request_id
+                        )
+                        if foreign is not None:
+                            return False
                     pipe.multi()
                     pipe.set(key, payload)
                     pipe.set(self._tombstone_key(entry.request_id), payload)
+                    if effect_key is not None:
+                        pipe.set(effect_key, entry.request_id)
                     pipe.execute()
                     return True
             except WatchError:
@@ -363,6 +470,9 @@ class RedisLedgerStorage:
 
     def set(self, entry: Any) -> None:
         self._inner.set(entry)
+
+    def get_by_effect_id(self, effect_id: str) -> Any:
+        return self._inner.get_by_effect_id(effect_id)
 
     def try_claim_inflight(
         self,

--- a/sdk/mycelium/storage/sqlite_ledger.py
+++ b/sdk/mycelium/storage/sqlite_ledger.py
@@ -72,6 +72,10 @@ class SqliteEntryStorage:
             f"CREATE TABLE IF NOT EXISTS {self._table} ("
             "request_id TEXT PRIMARY KEY, payload TEXT NOT NULL)"
         )
+        conn.execute(
+            f"CREATE UNIQUE INDEX IF NOT EXISTS {self._table}_effect_id_idx "
+            f"ON {self._table} (COALESCE(json_extract(payload, '$.effect_id'), request_id))"
+        )
         conn.commit()
         self._schema_ready = True
 
@@ -98,6 +102,19 @@ class SqliteEntryStorage:
                     (entry.request_id, payload),
                 )
                 conn.commit()
+
+    def get_by_effect_id(self, effect_id: str) -> E | None:
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                row = conn.execute(
+                    f"SELECT payload FROM {self._table} "
+                    "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ?",
+                    (effect_id,),
+                ).fetchone()
+        if row is None:
+            return None
+        return self._from_dict(_payload_dict(row["payload"]))
 
     def try_claim_inflight(
         self,
@@ -126,8 +143,29 @@ class SqliteEntryStorage:
                         f"SELECT payload FROM {self._table} WHERE request_id = ?",
                         (entry.request_id,),
                     ).fetchone()
+                    effect_id = str(getattr(entry, "effect_id", "") or "")
+                    if effect_id:
+                        effect_row = conn.execute(
+                            f"SELECT payload FROM {self._table} "
+                            "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ?",
+                            (effect_id,),
+                        ).fetchone()
+                        if effect_row is not None:
+                            canonical = self._from_dict(
+                                _payload_dict(effect_row["payload"])
+                            )
+                            # Same request_id: fall through to the request-keyed
+                            # reclaim path (EXPIRED/FAILED must be reclaimable).
+                            if canonical.request_id != entry.request_id:
+                                effect_outcome = claim_inflight_outcome(
+                                    canonical, now=now
+                                )
+                                if effect_outcome == "completed":
+                                    conn.commit()
+                                    return "completed", canonical
+                                conn.commit()
+                                return "in_flight", canonical
                     if row is None:
-                        # Rare race: deleted between IGNORE miss and SELECT.
                         conn.execute(
                             f"INSERT INTO {self._table} (request_id, payload) VALUES (?, ?)",
                             (entry.request_id, fresh_payload),
@@ -230,6 +268,9 @@ class SqliteLedgerStorage:
 
     def set(self, entry: Any) -> None:
         self._inner.set(entry)
+
+    def get_by_effect_id(self, effect_id: str) -> Any:
+        return self._inner.get_by_effect_id(effect_id)
 
     def try_claim_inflight(
         self,

--- a/sdk/mycelium/transition.py
+++ b/sdk/mycelium/transition.py
@@ -750,6 +750,7 @@ class ToolTransitionBinding:
     capability: ToolCapability = ToolCapability.BLIND
     explicit_capability: ToolCapability | None = None
     provider_idempotency_key_param: str | None = None
+    propagate_effect_id_as_provider_key: bool = False
     provider_idempotency_key_ttl: float | None = None
     request_id_from: str | None = None
 
@@ -766,6 +767,7 @@ class ToolTransitionBinding:
         spendability: Spendability | None = None,
         capability: ToolCapability | None = None,
         provider_idempotency_key_param: str | None = None,
+        propagate_effect_id_as_provider_key: bool = False,
         provider_idempotency_key_ttl: float | None = None,
         request_id_from: str | None = None,
     ) -> ToolTransitionBinding:
@@ -817,6 +819,7 @@ class ToolTransitionBinding:
             capability=resolved_capability,
             explicit_capability=capability,
             provider_idempotency_key_param=provider_idempotency_key_param,
+            propagate_effect_id_as_provider_key=propagate_effect_id_as_provider_key,
             provider_idempotency_key_ttl=provider_idempotency_key_ttl,
             request_id_from=request_id_from,
         )

--- a/sdk/mycelium/verify/invariants.py
+++ b/sdk/mycelium/verify/invariants.py
@@ -21,6 +21,7 @@ __all__ = [
     "InvariantViolation",
     "check_at_most_one_committed",
     "check_at_most_one_committed_effect_state",
+    "check_no_duplicate_effect_ids",
     "check_effect_state_consistency",
     "check_provider_mapping",
     "committed_effect_ids",
@@ -134,6 +135,31 @@ def check_at_most_one_committed_effect_state(
                 InvariantViolation(
                     ref,
                     f"effect {ref!r} EffectState.COMMITTED {len(rids)} times: {sorted(rids)}",
+                )
+            )
+    return violations
+
+
+def check_no_duplicate_effect_ids(entries: Iterable[Any]) -> list[InvariantViolation]:
+    """Assert: each effect_id maps to at most one stored ledger row."""
+    by_effect: dict[str, list[str]] = defaultdict(list)
+    for entry in entries:
+        effect_id = str(
+            getattr(entry, "effect_id", None)
+            or getattr(entry, "request_id", None)
+            or ""
+        )
+        if not effect_id:
+            continue
+        by_effect[effect_id].append(str(getattr(entry, "request_id", "?")))
+    violations: list[InvariantViolation] = []
+    for effect_id, request_ids in by_effect.items():
+        unique_request_ids = sorted(set(request_ids))
+        if len(unique_request_ids) > 1:
+            violations.append(
+                InvariantViolation(
+                    effect_id,
+                    f"effect {effect_id!r} stored in multiple rows: {unique_request_ids}",
                 )
             )
     return violations

--- a/sdk/mycelium/verify/registry.py
+++ b/sdk/mycelium/verify/registry.py
@@ -22,6 +22,7 @@ SCENARIO_ORDER = (
     "destructive-confirm",
     "authority-window",
     "use-time-currency",
+    "state-machine-exhaustive",
     "simulation",
 )
 
@@ -88,6 +89,7 @@ def ensure_builtin_scenarios_registered() -> None:
         redispatch,
         secret_in_args,
         simulation,
+        state_machine_exhaustive,
         storage_outage,
         use_time_currency,
         worker_crash,

--- a/sdk/mycelium/verify/scenarios/simulation.py
+++ b/sdk/mycelium/verify/scenarios/simulation.py
@@ -36,6 +36,7 @@ from mycelium.verify.invariants import (
     check_at_most_one_committed,
     check_at_most_one_committed_effect_state,
     check_effect_state_consistency,
+    check_no_duplicate_effect_ids,
     check_provider_mapping,
 )
 from mycelium.verify.registry import ScenarioContext, verify_scenario
@@ -184,8 +185,9 @@ def _run_fence_takeover(
     decisions: list[str] = []
     provider_effects: list[tuple[str, str]] = []
     request_id = iso.track(iso.namespace.request_id("sim", "fence"))
+    redispatch_request_id = f"{request_id}:redispatch"
     binding = _idempotent_binding()
-    kwargs = {"request_id": request_id, "thread_id": "verify", "run_id": "verify"}
+    kwargs = {"thread_id": "verify", "run_id": "verify"}
 
     a = make_ledger(iso.open_storage(), binding=binding, lease_ttl=0.3)
     with execution_scope(TransitionScope(thread_id="verify", run_id="verify")):
@@ -196,7 +198,13 @@ def _run_fence_takeover(
 
     b = make_ledger(iso.open_storage(), binding=binding, lease_ttl=30.0)
     with execution_scope(TransitionScope(thread_id="verify", run_id="verify")):
-        entry_b = b.claim_side_effecting(request_id, SYNTHETIC_TOOL, (1,), kwargs, binding)
+        entry_b = b.claim_side_effecting(
+            redispatch_request_id,
+            SYNTHETIC_TOOL,
+            (1,),
+            kwargs,
+            binding,
+        )
     fence_b = entry_b.fence
     if fence_b <= fence_a:
         failures.append(f"fence takeover: B fence {fence_b} not above A fence {fence_a}")
@@ -279,6 +287,9 @@ def _run_fence_takeover(
         failures.append(f"fence takeover: final fence {final.fence} != B fence {fence_b}")
     if final.result != {"charged": True}:
         failures.append("fence takeover: stale A write leaked into final entry")
+    duplicate_effect_rows = check_no_duplicate_effect_ids(iso.open_fresh_client().list_all())
+    for violation in duplicate_effect_rows:
+        failures.append(f"fence takeover: {violation.message}")
     for violation in check_at_most_one_committed([final]):
         failures.append(f"fence takeover: {violation.message}")
     for violation in check_at_most_one_committed_effect_state([final]):

--- a/sdk/mycelium/verify/scenarios/state_machine_exhaustive.py
+++ b/sdk/mycelium/verify/scenarios/state_machine_exhaustive.py
@@ -1,0 +1,530 @@
+"""Deterministic exhaustive EffectState interleavings over in-memory storage."""
+
+from __future__ import annotations
+
+import threading
+import time
+import warnings
+from dataclasses import replace
+from typing import Any
+
+from mycelium import (
+    ActionLedger,
+    EffectState,
+    InMemoryLedgerStorage,
+    LedgerEntry,
+    LedgerHardBlockError,
+    LedgerOutcomeAlreadySetError,
+    RetryPermission,
+    SideEffectClass,
+    Spendability,
+    TerminalOutcome,
+    ToolCapability,
+    ToolTransitionBinding,
+    TransitionScope,
+    derive_effect_id_for_call,
+    execution_scope,
+)
+from mycelium.verify.invariants import check_at_most_one_committed_effect_state
+from mycelium.verify.registry import ScenarioContext, verify_scenario
+from mycelium.verify.types import VerificationEvidence, VerificationStatus
+
+
+def _decision(allowed: bool) -> dict[str, Any]:
+    return {"allowed": allowed, "verdicts": [], "denied_reasons": []}
+
+
+def _scope() -> TransitionScope:
+    return TransitionScope(
+        thread_id="verify-state-machine",
+        run_id="verify-state-machine",
+    )
+
+
+def _idempotent_binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="verify",
+        policy_version="verify",
+        side_effect_class=SideEffectClass.IDEMPOTENT_MUTATE,
+        spendability=Spendability.MULTI_USE,
+        retry_permission=RetryPermission.SAFE_RETRY,
+    )
+
+
+def _blind_binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="verify",
+        policy_version="verify",
+        side_effect_class=SideEffectClass.KEYED_MUTATE,
+        capability=ToolCapability.BLIND,
+        provider_idempotency_key_param="idempotency_key",
+        provider_idempotency_key_ttl=300.0,
+    )
+
+
+def _expire_lease(storage: InMemoryLedgerStorage, request_id: str) -> None:
+    entry = storage.get(request_id)
+    if entry is None:
+        return
+    storage.set(
+        replace(
+            entry,
+            lease_until=time.time() - 1.0,
+            last_heartbeat_at=time.time() - 3600.0,
+        )
+    )
+
+
+def _craft_expired_crash_row(
+    storage: InMemoryLedgerStorage,
+    *,
+    request_id: str,
+    binding: ToolTransitionBinding,
+    kwargs: dict[str, Any],
+    crash_step: int,
+) -> None:
+    """Persist a crashed intermediate row with an already-expired lease.
+
+    crash_step=1 → INTENDED (claimed, no decision)
+    crash_step=2 → ATTEMPTING (decision recorded, body never finished)
+    """
+    effect_id = derive_effect_id_for_call("charge", (), kwargs, binding)
+    decision = _decision(True) if crash_step >= 2 else None
+    phase = (
+        EffectState.ATTEMPTING.value if crash_step >= 2 else EffectState.INTENDED.value
+    )
+    storage.set(
+        LedgerEntry(
+            request_id=request_id,
+            tool="charge",
+            args=[],
+            kwargs=dict(kwargs),
+            status="in-flight",
+            terminal_outcome=TerminalOutcome.IN_FLIGHT.value,
+            owner="dead-worker",
+            lease_until=time.time() - 1.0,
+            last_heartbeat_at=time.time() - 3600.0,
+            effect_phase=phase,
+            decision=decision,
+            effect_protocol_required=True,
+            effect_id=effect_id,
+        )
+    )
+
+
+def _assert_at_most_one_committed(
+    storage: InMemoryLedgerStorage,
+    *,
+    effect_id: str | None,
+    failures: list[str],
+    label: str,
+) -> None:
+    if not effect_id:
+        failures.append(f"{label}: missing effect_id")
+        return
+    rows = [entry for entry in storage.list_all() if entry.effect_id == effect_id]
+    for violation in check_at_most_one_committed_effect_state(rows):
+        failures.append(f"{label}: {violation.message}")
+
+
+def _run_stale_fence_interleaving(stale_op: str) -> tuple[list[str], list[str]]:
+    failures: list[str] = []
+    decisions: list[str] = []
+    storage = InMemoryLedgerStorage()
+    ledger_a = ActionLedger(storage=storage, poll_interval=0.001, poll_timeout=1.0)
+    ledger_b = ActionLedger(storage=storage, poll_interval=0.001, poll_timeout=1.0)
+    binding = _idempotent_binding()
+    request_id = f"stale-{stale_op}"
+    kwargs = {"amount": 10, "tool_call_id": f"stale-{stale_op}-call"}
+    with execution_scope(_scope()):
+        entry_a = ledger_a.claim_side_effecting(request_id, "charge", (), kwargs, binding)
+    _expire_lease(storage, request_id)
+    with execution_scope(_scope()):
+        entry_b = ledger_b.claim_side_effecting(
+            request_id,
+            "charge",
+            (),
+            kwargs,
+            binding,
+        )
+    if entry_b.fence != entry_a.fence + 1:
+        failures.append(
+            f"{stale_op}: reclaim fence mismatch, "
+            f"expected {entry_a.fence + 1}, got {entry_b.fence}"
+        )
+        return failures, decisions
+    if stale_op != "record_decision":
+        with execution_scope(_scope()):
+            ledger_b.record_decision(
+                request_id,
+                _decision(True),
+                expected_owner=entry_b.owner,
+                expected_fence=entry_b.fence,
+            )
+    stale_rejected = False
+    try:
+        with execution_scope(_scope()):
+            if stale_op == "complete":
+                ledger_a.complete(
+                    request_id,
+                    {"charged": "stale"},
+                    _expected_owner=entry_a.owner,
+                    _expected_fence=entry_a.fence,
+                )
+            elif stale_op == "fail":
+                ledger_a.fail(
+                    request_id,
+                    RuntimeError("stale"),
+                    failed_after_effect=False,
+                    _expected_owner=entry_a.owner,
+                    _expected_fence=entry_a.fence,
+                )
+            else:
+                ledger_a.record_decision(
+                    request_id,
+                    _decision(True),
+                    expected_owner=entry_a.owner,
+                    expected_fence=entry_a.fence,
+                )
+    except LedgerOutcomeAlreadySetError:
+        stale_rejected = True
+    if not stale_rejected:
+        failures.append(f"{stale_op}: stale write unexpectedly succeeded")
+    with execution_scope(_scope()):
+        if stale_op == "record_decision":
+            ledger_b.record_decision(
+                request_id,
+                _decision(True),
+                expected_owner=entry_b.owner,
+                expected_fence=entry_b.fence,
+            )
+        ledger_b.complete(
+            request_id,
+            {"charged": True},
+            _expected_owner=entry_b.owner,
+            _expected_fence=entry_b.fence,
+        )
+    stored = storage.get(request_id)
+    _assert_at_most_one_committed(
+        storage,
+        effect_id=stored.effect_id if stored is not None else None,
+        failures=failures,
+        label=f"stale-{stale_op}",
+    )
+    decisions.append(f"stale-{stale_op}: stale-fence write rejected after fence takeover")
+    return failures, decisions
+
+
+def _run_crash_resume_matrix(target: str) -> tuple[list[str], list[str]]:
+    failures: list[str] = []
+    decisions: list[str] = []
+    expected = {
+        "completed": EffectState.COMMITTED,
+        "not_executed": EffectState.ABORTED,
+        "unknown": EffectState.UNKNOWN,
+    }[target]
+    for crash_step in range(0, 3):
+        storage = InMemoryLedgerStorage()
+        binding = _idempotent_binding()
+        request_id = f"crash-{target}-{crash_step}"
+        kwargs = {"amount": 20, "tool_call_id": f"crash-{target}-{crash_step}"}
+        # Deterministic crash points: craft expired intermediate rows so
+        # resume never depends on wall-clock lease expiry of a live claim.
+        if crash_step >= 1:
+            _craft_expired_crash_row(
+                storage,
+                request_id=request_id,
+                binding=binding,
+                kwargs=kwargs,
+                crash_step=crash_step,
+            )
+        ledger_b = ActionLedger(storage=storage, poll_interval=0.001, poll_timeout=1.0)
+        try:
+            with execution_scope(_scope()):
+                resumed = ledger_b.claim_side_effecting(
+                    request_id,
+                    "charge",
+                    (),
+                    kwargs,
+                    binding,
+                )
+                current = storage.get(resumed.request_id)
+                if current is None:
+                    failures.append(f"{request_id}: missing row after resume claim")
+                    continue
+                if current.decision is None:
+                    ledger_b.record_decision(
+                        resumed.request_id,
+                        _decision(True),
+                        expected_owner=resumed.owner,
+                        expected_fence=resumed.fence,
+                    )
+                if target == "completed":
+                    ledger_b.complete(
+                        resumed.request_id,
+                        {"charged": True},
+                        _expected_owner=resumed.owner,
+                        _expected_fence=resumed.fence,
+                    )
+                elif target == "not_executed":
+                    ledger_b.fail(
+                        resumed.request_id,
+                        RuntimeError("provider not executed"),
+                        failed_after_effect=False,
+                        _expected_owner=resumed.owner,
+                        _expected_fence=resumed.fence,
+                    )
+                else:
+                    ledger_b.mark_unknown(
+                        resumed.request_id,
+                        error="ambiguous",
+                        _expected_owner=resumed.owner,
+                        _expected_fence=resumed.fence,
+                    )
+        except LedgerHardBlockError as exc:
+            failures.append(f"{request_id}: unexpected HARD_BLOCK: {exc}")
+            continue
+        final = storage.get(request_id)
+        if final is None:
+            failures.append(f"{request_id}: final row missing")
+            continue
+        if final.resolved_effect_state() != expected:
+            got = final.resolved_effect_state().value
+            failures.append(
+                f"{request_id}: expected {expected.value}, got {got}"
+            )
+        _assert_at_most_one_committed(
+            storage,
+            effect_id=final.effect_id,
+            failures=failures,
+            label=request_id,
+        )
+        decisions.append(
+            f"{request_id}: crash@step{crash_step} resumed to "
+            f"{final.resolved_effect_state().value}"
+        )
+    return failures, decisions
+
+
+def _run_blind_unknown_no_retry() -> tuple[list[str], list[str], int]:
+    failures: list[str] = []
+    decisions: list[str] = []
+    executions = 0
+    storage = InMemoryLedgerStorage()
+    ledger_a = ActionLedger(storage=storage, poll_interval=0.001, poll_timeout=1.0)
+    ledger_b = ActionLedger(storage=storage, poll_interval=0.001, poll_timeout=1.0)
+    binding = _blind_binding()
+    request_id = "blind-unknown"
+    kwargs = {
+        "amount": 5,
+        "idempotency_key": "blind-key",
+        "tool_call_id": "blind-call",
+    }
+    with execution_scope(_scope()):
+        claim = ledger_a.claim_side_effecting(
+            request_id, "send_payment", (), kwargs, binding
+        )
+        ledger_a.record_decision(
+            request_id,
+            _decision(True),
+            expected_owner=claim.owner,
+            expected_fence=claim.fence,
+        )
+        executions += 1
+        ledger_a.mark_unknown(
+            request_id,
+            error="timeout after maybe crossed",
+            _expected_owner=claim.owner,
+            _expected_fence=claim.fence,
+        )
+    blocked = False
+    try:
+        with execution_scope(_scope()):
+            ledger_b.claim_side_effecting(
+                request_id, "send_payment", (), kwargs, binding
+            )
+    except LedgerHardBlockError:
+        blocked = True
+    if not blocked:
+        failures.append("blind-unknown: redispatch unexpectedly bypassed HARD_BLOCK")
+    if executions != 1:
+        failures.append(f"blind-unknown: expected 1 execution, got {executions}")
+    final = storage.get(request_id)
+    if final is None:
+        failures.append("blind-unknown: final row missing")
+    else:
+        _assert_at_most_one_committed(
+            storage,
+            effect_id=final.effect_id,
+            failures=failures,
+            label="blind-unknown",
+        )
+    decisions.append(
+        "blind-unknown: UNKNOWN stayed parked and body counter remained 1"
+    )
+    return failures, decisions, executions
+
+
+def _run_concurrent_intended_claim_race() -> tuple[list[str], list[str]]:
+    failures: list[str] = []
+    decisions: list[str] = []
+    storage = InMemoryLedgerStorage()
+    ledger_a = ActionLedger(storage=storage, poll_interval=0.001, poll_timeout=1.0)
+    ledger_b = ActionLedger(storage=storage, poll_interval=0.001, poll_timeout=1.0)
+    binding = _idempotent_binding()
+    kwargs = {"amount": 42, "tool_call_id": "race-call"}
+    request_a = "race-a"
+    request_b = "race-b"
+    results: dict[str, Any] = {}
+    errors: dict[str, BaseException] = {}
+    first_returned = threading.Event()
+    lock = threading.Lock()
+
+    def _claim(name: str, ledger: ActionLedger, request_id: str) -> None:
+        try:
+            with execution_scope(_scope()):
+                entry = ledger.claim_side_effecting(
+                    request_id, "charge", (), kwargs, binding
+                )
+            with lock:
+                results[name] = entry
+                first_returned.set()
+        except BaseException as exc:  # pragma: no cover - defensive
+            with lock:
+                errors[name] = exc
+                first_returned.set()
+
+    t_a = threading.Thread(target=_claim, args=("A", ledger_a, request_a))
+    t_b = threading.Thread(target=_claim, args=("B", ledger_b, request_b))
+    t_a.start()
+    t_b.start()
+    if not first_returned.wait(timeout=1.0):
+        failures.append("race: no worker returned from initial claim")
+    with lock:
+        winner_name = next(iter(results.keys()), None)
+    if winner_name is None:
+        failures.append(f"race: no winner, errors={errors!r}")
+        t_a.join(timeout=1.0)
+        t_b.join(timeout=1.0)
+        return failures, decisions
+    winner_entry = results[winner_name]
+    winner_ledger = ledger_a if winner_name == "A" else ledger_b
+    with execution_scope(_scope()):
+        winner_ledger.record_decision(
+            winner_entry.request_id,
+            _decision(True),
+            expected_owner=winner_entry.owner,
+            expected_fence=winner_entry.fence,
+        )
+        winner_ledger.complete(
+            winner_entry.request_id,
+            {"charged": "race"},
+            _expected_owner=winner_entry.owner,
+            _expected_fence=winner_entry.fence,
+        )
+    t_a.join(timeout=1.0)
+    t_b.join(timeout=1.0)
+    if errors:
+        failures.append(f"race: claim error(s) observed: {errors!r}")
+    if set(results.keys()) != {"A", "B"}:
+        failures.append(
+            f"race: expected both workers to return, got {sorted(results.keys())}"
+        )
+    if len(results) == 2:
+        first = results["A"]
+        second = results["B"]
+        if first.request_id != second.request_id:
+            failures.append(
+                "race: workers did not converge on a single canonical request row "
+                f"({first.request_id!r} vs {second.request_id!r})"
+            )
+        if first.effect_id != second.effect_id:
+            failures.append(
+                "race: workers disagreed on effect_id for shared INTENDED claim"
+            )
+    rows = storage.list_all()
+    if len(rows) != 1:
+        failures.append(f"race: expected exactly one ledger row, found {len(rows)}")
+    effect_id = rows[0].effect_id if rows else None
+    _assert_at_most_one_committed(
+        storage,
+        effect_id=effect_id,
+        failures=failures,
+        label="race",
+    )
+    decisions.append(
+        "race: concurrent INTENDED claims converged to one row and one COMMITTED"
+    )
+    return failures, decisions
+
+
+@verify_scenario("state-machine-exhaustive")
+def run_state_machine_exhaustive(ctx: ScenarioContext) -> VerificationEvidence:
+    started = time.time()
+    failures: list[str] = []
+    decisions: list[str] = []
+    total_executions = 0
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*InMemoryLedgerStorage.*",
+            category=UserWarning,
+        )
+
+        for stale_op in ("complete", "fail", "record_decision"):
+            stale_failures, stale_decisions = _run_stale_fence_interleaving(stale_op)
+            failures.extend(stale_failures)
+            decisions.extend(stale_decisions)
+
+        for target in ("completed", "not_executed", "unknown"):
+            case_failures, case_decisions = _run_crash_resume_matrix(target)
+            failures.extend(case_failures)
+            decisions.extend(case_decisions)
+
+        blind_failures, blind_decisions, executions = _run_blind_unknown_no_retry()
+        failures.extend(blind_failures)
+        decisions.extend(blind_decisions)
+        total_executions += executions
+
+        race_failures, race_decisions = _run_concurrent_intended_claim_race()
+        failures.extend(race_failures)
+        decisions.extend(race_decisions)
+
+    isolation = getattr(ctx, "isolation", None)
+    backend = getattr(isolation, "backend", "memory")
+    namespace = getattr(
+        getattr(isolation, "namespace", None),
+        "prefix",
+        "state-machine-exhaustive",
+    )
+    observed = "; ".join(failures or decisions)
+    ok = not failures
+    return VerificationEvidence(
+        scenario="state-machine-exhaustive",
+        backend=str(backend),
+        namespace=str(namespace),
+        attempts=3 + (3 * 3) + 1 + 1,
+        body_executions=total_executions,
+        ledger_decisions=decisions,
+        terminal_outcome="COMMITTED" if ok else "FAILED",
+        duration=time.time() - started,
+        expected_behavior=(
+            "INTENDED->ATTEMPTING->COMMITTED|ABORTED|UNKNOWN transitions remain "
+            "fenced; at-most-one COMMITTED row holds under crash/resume and race "
+            "interleavings"
+        ),
+        observed_behavior=observed,
+        artifacts=[],
+        limitations=[],
+        status=VerificationStatus.PASS if ok else VerificationStatus.FAIL,
+        summary=(
+            "exhaustive state-machine interleavings held"
+            if ok
+            else "; ".join(failures)[:200]
+        ),
+        remediation="" if ok else "Inspect failed interleaving(s) in observed_behavior.",
+    )
+
+
+__all__ = ["run_state_machine_exhaustive"]

--- a/sdk/tests/test_effect_id_index.py
+++ b/sdk/tests/test_effect_id_index.py
@@ -1,0 +1,119 @@
+"""Effect-id secondary index behavior across claim paths."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from mycelium import (
+    ActionLedger,
+    FileLedgerStorage,
+    InMemoryLedgerStorage,
+    LedgerHardBlockError,
+    SideEffectBoundary,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+)
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="effect-index-tests",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def test_identical_effect_different_explicit_request_ids_reuses_single_row() -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(storage=storage)
+    binding = _binding()
+    kwargs = {"amount": 10.0, "recipient": "acct_1", "tool_call_id": "call_same_effect_1"}
+
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+        first = ledger.claim_side_effecting("audit-1", "send_payment", (), kwargs, binding)
+        ledger.record_decision(
+            first.request_id,
+            {"allowed": True, "verdicts": [], "denied_reasons": []},
+            expected_owner=first.owner,
+            expected_fence=first.fence,
+        )
+        ledger.complete(first.request_id, {"charged": True}, expected_fence=first.fence)
+        second = ledger.claim_side_effecting("audit-2", "send_payment", (), kwargs, binding)
+
+    assert second.request_id == first.request_id
+    assert second.result == {"charged": True}
+    assert len(storage.list_all()) == 1
+
+
+def test_redispatch_after_crash_collides_on_effect_id_and_does_not_create_second_row() -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(storage=storage, lease_ttl=0.05, poll_timeout=0.2, poll_interval=0.01)
+    binding = _binding()
+    kwargs = {"amount": 10.0, "recipient": "acct_2", "tool_call_id": "call_crash_effect_1"}
+
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+        first = ledger.claim_side_effecting("audit-crash-1", "send_payment", (), kwargs, binding)
+        ledger.record_decision(
+            first.request_id,
+            {"allowed": True, "verdicts": [], "denied_reasons": []},
+            expected_owner=first.owner,
+            expected_fence=first.fence,
+        )
+        ledger.advance_boundary(
+            first.request_id,
+            SideEffectBoundary.MAYBE_CROSSED,
+            expected_owner=first.owner,
+            expected_fence=first.fence,
+        )
+        current = ledger.get(first.request_id)
+        assert current is not None
+        expired = replace(current, lease_until=time.time() - 1)
+        storage.set(expired)
+        with pytest.raises(LedgerHardBlockError):
+            ledger.claim_side_effecting("audit-crash-2", "send_payment", (), kwargs, binding)
+
+    rows = storage.list_all()
+    assert len(rows) == 1
+    assert rows[0].request_id == "audit-crash-1"
+
+
+def test_legacy_schema1_row_get_by_effect_id_lazy_indexes(tmp_path: Path) -> None:
+    storage = FileLedgerStorage(tmp_path / "legacy-ledger.json")
+
+    def _seed_legacy(data: dict[str, dict[str, object]]) -> None:
+        data["legacy-req-1"] = {
+            "request_id": "legacy-req-1",
+            "tool": "send_payment",
+            "args": [],
+            "kwargs": {"amount": 10.0, "recipient": "acct_legacy", "tool_call_id": "legacy_call_1"},
+            "status": "completed",
+            "terminal_outcome": TerminalOutcome.COMPLETED.value,
+            "result": {"charged": True},
+        }
+
+    storage._file.read_modify_write(_seed_legacy)
+    loaded = storage.get_by_effect_id("legacy-req-1")
+    assert loaded is not None
+    assert loaded.request_id == "legacy-req-1"
+    assert loaded.effect_id == "legacy-req-1"
+
+
+def test_unclassified_claim_path_unchanged() -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(storage=storage)
+
+    first = ledger.claim("legacy-1", "legacy_tool", (), {"amount": 1})
+    second = ledger.claim("legacy-2", "legacy_tool", (), {"amount": 1})
+
+    assert first.request_id == "legacy-1"
+    assert second.request_id == "legacy-2"
+    assert first.effect_id == "legacy-1"
+    assert second.effect_id == "legacy-2"
+    assert len(storage.list_all()) == 2

--- a/sdk/tests/test_effect_identity.py
+++ b/sdk/tests/test_effect_identity.py
@@ -36,7 +36,10 @@ from mycelium.transition import (
     derive_effect_id,
     derive_effect_id_for_call,
 )
-from mycelium.verify.invariants import check_at_most_one_committed_effect_state
+from mycelium.verify.invariants import (
+    check_at_most_one_committed_effect_state,
+    check_no_duplicate_effect_ids,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -297,7 +300,46 @@ def test_concurrent_workers_same_call_collide_on_one_row() -> None:
     entries = storage.list_all()
     assert len(entries) == 1
     assert check_at_most_one_committed_effect_state(entries) == []
+    assert check_no_duplicate_effect_ids(entries) == []
     assert entries[0].resolved_effect_state().value == "COMMITTED"
+
+
+def test_explicit_request_id_redispatch_collides_on_effect_id_row() -> None:
+    storage = InMemoryLedgerStorage()
+    binding = _binding()
+    ledger_inst = ActionLedger(storage=storage)
+    kwargs = {
+        "recipient": "billing@customer.com",
+        "amount": 10.0,
+        "tool_call_id": "call_effect_collision_1",
+    }
+
+    with execution_scope(TransitionScope(thread_id="thread-1", run_id="run-1")):
+        first = ledger_inst.claim_side_effecting(
+            "audit-req-1",
+            "send_email",
+            (),
+            kwargs,
+            binding,
+        )
+        ledger_inst.record_decision(
+            first.request_id,
+            {"allowed": True, "verdicts": [], "denied_reasons": []},
+            expected_owner=first.owner,
+            expected_fence=first.fence,
+        )
+        ledger_inst.complete(first.request_id, {"ok": True}, expected_fence=first.fence)
+        replay = ledger_inst.claim_side_effecting(
+            "audit-req-2",
+            "send_email",
+            (),
+            kwargs,
+            binding,
+        )
+
+    assert replay.request_id == "audit-req-1"
+    assert replay.result == {"ok": True}
+    assert len(storage.list_all()) == 1
 
 
 def test_explicit_destination_in_preimage() -> None:

--- a/sdk/tests/test_effect_state_machine.py
+++ b/sdk/tests/test_effect_state_machine.py
@@ -62,7 +62,9 @@ def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     binding = _binding()
 
     # INTENDED -> ATTEMPTING -> COMMITTED
-    allowed = ledger.claim_side_effecting("req-allowed", "tool", (), {}, binding)
+    allowed = ledger.claim_side_effecting(
+        "req-allowed", "tool", (), {"case": "allowed"}, binding
+    )
     ledger.record_decision(
         "req-allowed",
         _decision(True),
@@ -72,7 +74,9 @@ def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     assert committed.resolved_effect_state() == EffectState.COMMITTED
 
     # INTENDED -> ABORTED
-    denied = ledger.claim_side_effecting("req-denied", "tool", (), {}, binding)
+    denied = ledger.claim_side_effecting(
+        "req-denied", "tool", (), {"case": "denied"}, binding
+    )
     denied_row = ledger.record_decision(
         "req-denied",
         _decision(False),
@@ -81,7 +85,9 @@ def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     assert denied_row.resolved_effect_state() == EffectState.ABORTED
 
     # ATTEMPTING -> UNKNOWN (BLIND-like after-effect failure)
-    unknown = ledger.claim_side_effecting("req-unknown", "tool", (), {}, binding)
+    unknown = ledger.claim_side_effecting(
+        "req-unknown", "tool", (), {"case": "unknown"}, binding
+    )
     ledger.record_decision(
         "req-unknown",
         _decision(True),
@@ -95,7 +101,9 @@ def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     assert unknown_row.resolved_effect_state() == EffectState.UNKNOWN
 
     # ATTEMPTING -> ABORTED (failure before effect after allow)
-    failed = ledger.claim_side_effecting("req-fail-before", "tool", (), {}, binding)
+    failed = ledger.claim_side_effecting(
+        "req-fail-before", "tool", (), {"case": "fail-before"}, binding
+    )
     ledger.record_decision(
         "req-fail-before",
         _decision(True),
@@ -110,7 +118,9 @@ def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     assert failed_row.resolved_effect_state() == EffectState.ABORTED
 
     # ILLEGAL: complete before decision (still INTENDED)
-    no_decision = ledger.claim_side_effecting("req-no-decision", "tool", (), {}, binding)
+    no_decision = ledger.claim_side_effecting(
+        "req-no-decision", "tool", (), {"case": "no-decision"}, binding
+    )
     with pytest.raises(LedgerOutcomeAlreadySetError):
         ledger.complete(
             "req-no-decision",

--- a/sdk/tests/test_proof_two_worker_redis.py
+++ b/sdk/tests/test_proof_two_worker_redis.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+
 from backend_gates import require_redis_or_skip
 
 from mycelium.proofs.langgraph_7417_redis import prove_two_worker_redis_redispatch
@@ -10,6 +12,18 @@ from mycelium.proofs.langgraph_7417_redis import prove_two_worker_redis_redispat
 def test_two_worker_redis_cloud_style_redispatch() -> None:
     url = require_redis_or_skip()
     result = prove_two_worker_redis_redispatch(url=url)
+    assert result["workers"] == 2
+    assert result["storage"] == "redis"
+    assert result["executions"] == 1
+    assert result["result"] == {"task": "analyze_market", "result": "done"}
+
+
+def test_two_worker_redis_mismatched_explicit_request_ids_still_single_row() -> None:
+    url = require_redis_or_skip()
+    result = prove_two_worker_redis_redispatch(
+        url=url,
+        request_id_b=f"audit-rid-b-{uuid.uuid4().hex}",
+    )
     assert result["workers"] == 2
     assert result["storage"] == "redis"
     assert result["executions"] == 1

--- a/sdk/tests/test_provider_idempotency_key.py
+++ b/sdk/tests/test_provider_idempotency_key.py
@@ -237,6 +237,29 @@ tools:
     assert binding.provider_idempotency_key_param == "idempotency_key"
 
 
+def test_config_parses_and_binds_effect_key_propagation_flag() -> None:
+    yaml_text = """
+transition:
+  agent_id: demo
+  policy_version: "1"
+action_ledger:
+  storage: memory
+  tools: [send_payment]
+tools:
+  send_payment:
+    side_effect_class: keyed_mutate
+    provider_idempotency_key_param: idempotency_key
+    propagate_effect_id_as_provider_key: true
+"""
+    config = load_config_from_string(yaml_text)
+    tool_config = config.tools["send_payment"]
+    assert tool_config.propagate_effect_id_as_provider_key is True
+
+    binding = config.tool_transition_binding(tool_config)
+    assert binding is not None
+    assert binding.propagate_effect_id_as_provider_key is True
+
+
 def test_config_rejects_non_string_provider_key_param() -> None:
     from mycelium import ConfigError
 
@@ -250,6 +273,23 @@ tools:
     provider_idempotency_key_param: 123
 """
     with pytest.raises(ConfigError, match="provider_idempotency_key_param"):
+        load_config_from_string(yaml_text)
+
+
+def test_config_rejects_non_bool_effect_key_propagation_flag() -> None:
+    from mycelium import ConfigError
+
+    yaml_text = """
+transition:
+  agent_id: demo
+  policy_version: "1"
+tools:
+  send_payment:
+    side_effect_class: keyed_mutate
+    provider_idempotency_key_param: idempotency_key
+    propagate_effect_id_as_provider_key: "yes"
+"""
+    with pytest.raises(ConfigError, match="propagate_effect_id_as_provider_key"):
         load_config_from_string(yaml_text)
 
 

--- a/sdk/tests/test_provider_key_propagation.py
+++ b/sdk/tests/test_provider_key_propagation.py
@@ -1,0 +1,188 @@
+"""Effect-id to provider-key propagation for keyed side-effect tools."""
+
+from __future__ import annotations
+
+import pytest
+
+from mycelium import (
+    InMemoryLedgerStorage,
+    SideEffectClass,
+    ToolTransitionBinding,
+    TransitionScope,
+    derive_effect_id_for_call,
+    execution_scope,
+    get_ledger,
+    ledger_sync,
+)
+
+
+def _scope() -> TransitionScope:
+    return TransitionScope(thread_id="t-prop", run_id="r-prop")
+
+
+def _binding(*, propagate: bool = True) -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="demo",
+        policy_version="1",
+        side_effect_class=SideEffectClass.KEYED_MUTATE,
+        provider_idempotency_key_param="idempotency_key",
+        propagate_effect_id_as_provider_key=propagate,
+    )
+
+
+def test_keyed_mutate_injects_effect_key_and_stamps_ledger() -> None:
+    seen_keys: list[str | None] = []
+    binding = _binding(propagate=True)
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str | None = None) -> dict[str, str | None]:
+        seen_keys.append(idempotency_key)
+        return {"status": "sent", "key": idempotency_key}
+
+    with execution_scope(_scope()):
+        send_payment(amount=10.0, tool_call_id="call-prop-1")
+
+    ledger_inst = get_ledger(send_payment)
+    assert ledger_inst is not None
+    with execution_scope(_scope()):
+        request_id = ledger_inst.derive_request_id(
+            "send_payment",
+            (),
+            {"amount": 10.0, "tool_call_id": "call-prop-1"},
+            transition_binding=binding,
+        )
+    entry = ledger_inst.get(request_id)
+    assert entry is not None
+    assert entry.effect_id is not None
+    expected = f"mycelium:{entry.effect_id}"
+    assert entry.provider_idempotency_key == expected
+    assert seen_keys == [expected]
+
+
+def test_retry_without_kwarg_reuses_same_stored_provider_key() -> None:
+    seen_keys: list[str | None] = []
+    attempts = {"n": 0}
+    binding = _binding(propagate=True)
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str | None = None) -> dict[str, str]:
+        seen_keys.append(idempotency_key)
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise RuntimeError("timeout")
+        return {"status": "sent"}
+
+    with execution_scope(_scope()):
+        with pytest.raises(RuntimeError):
+            send_payment(amount=10.0, tool_call_id="call-prop-2")
+        send_payment(amount=10.0, tool_call_id="call-prop-2")
+
+    assert len(seen_keys) == 2
+    assert seen_keys[0] is not None
+    assert seen_keys[0] == seen_keys[1]
+
+
+def test_explicit_provider_kwarg_overrides_propagation() -> None:
+    seen_keys: list[str | None] = []
+    binding = _binding(propagate=True)
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str | None = None) -> dict[str, str | None]:
+        seen_keys.append(idempotency_key)
+        return {"status": "sent", "key": idempotency_key}
+
+    with execution_scope(_scope()):
+        send_payment(amount=10.0, idempotency_key="host-key", tool_call_id="call-prop-3")
+
+    ledger_inst = get_ledger(send_payment)
+    assert ledger_inst is not None
+    with execution_scope(_scope()):
+        request_id = ledger_inst.derive_request_id(
+            "send_payment",
+            (),
+            {
+                "amount": 10.0,
+                "idempotency_key": "host-key",
+                "tool_call_id": "call-prop-3",
+            },
+            transition_binding=binding,
+        )
+    entry = ledger_inst.get(request_id)
+    assert entry is not None
+    assert entry.provider_idempotency_key == "host-key"
+    assert seen_keys == ["host-key"]
+
+
+def test_no_injection_when_flag_disabled() -> None:
+    seen_keys: list[str | None] = []
+    binding = _binding(propagate=False)
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str | None = None) -> dict[str, str | None]:
+        seen_keys.append(idempotency_key)
+        return {"status": "sent", "key": idempotency_key}
+
+    with execution_scope(_scope()):
+        send_payment(amount=10.0, tool_call_id="call-prop-4")
+
+    ledger_inst = get_ledger(send_payment)
+    assert ledger_inst is not None
+    with execution_scope(_scope()):
+        request_id = ledger_inst.derive_request_id(
+            "send_payment",
+            (),
+            {"amount": 10.0, "tool_call_id": "call-prop-4"},
+            transition_binding=binding,
+        )
+    entry = ledger_inst.get(request_id)
+    assert entry is not None
+    assert entry.provider_idempotency_key is None
+    assert seen_keys == [None]
+
+
+def test_effect_identity_stable_between_injected_and_explicit_provider_key() -> None:
+    binding = _binding(propagate=True)
+    with execution_scope(_scope()):
+        injected_identity = derive_effect_id_for_call(
+            "send_payment",
+            (),
+            {"amount": 10.0, "tool_call_id": "call-prop-5"},
+            binding,
+        )
+        explicit_identity = derive_effect_id_for_call(
+            "send_payment",
+            (),
+            {
+                "amount": 10.0,
+                "idempotency_key": "host-key",
+                "tool_call_id": "call-prop-5",
+            },
+            binding,
+        )
+    assert injected_identity == explicit_identity
+
+
+def test_retry_identity_stable_between_injected_and_explicit_same_key() -> None:
+    seen_keys: list[str | None] = []
+    attempts = {"n": 0}
+    binding = _binding(propagate=True)
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str | None = None) -> dict[str, str]:
+        seen_keys.append(idempotency_key)
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise RuntimeError("timeout")
+        return {"status": "sent"}
+
+    with execution_scope(_scope()):
+        with pytest.raises(RuntimeError):
+            send_payment(amount=10.0, tool_call_id="call-prop-6")
+        assert seen_keys[0] is not None
+        send_payment(
+            amount=10.0,
+            idempotency_key=seen_keys[0],
+            tool_call_id="call-prop-6",
+        )
+
+    assert attempts["n"] == 2

--- a/sdk/tests/test_state_machine_exhaustive.py
+++ b/sdk/tests/test_state_machine_exhaustive.py
@@ -1,0 +1,35 @@
+"""Fast direct test for the in-process exhaustive state-machine scenario."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mycelium.verify.registry import ScenarioContext, known_scenarios
+from mycelium.verify.scenarios.state_machine_exhaustive import (
+    run_state_machine_exhaustive,
+)
+from mycelium.verify.types import VerificationStatus
+
+
+def _context() -> ScenarioContext:
+    isolation = SimpleNamespace(
+        backend="memory",
+        namespace=SimpleNamespace(prefix="test-state-machine-exhaustive"),
+    )
+    return ScenarioContext(
+        isolation=isolation,
+        timeout_seconds=2.0,
+        rounds=1,
+        workers=2,
+        keep_artifacts=False,
+    )
+
+
+def test_state_machine_exhaustive_direct_passes() -> None:
+    evidence = run_state_machine_exhaustive(_context())
+    assert evidence.status == VerificationStatus.PASS, evidence.observed_behavior
+    assert evidence.scenario == "state-machine-exhaustive"
+
+
+def test_state_machine_exhaustive_registered() -> None:
+    assert "state-machine-exhaustive" in known_scenarios()

--- a/sdk/tests/test_tool_capability.py
+++ b/sdk/tests/test_tool_capability.py
@@ -192,6 +192,19 @@ def test_binding_explicit_blind_wins_over_provider_key() -> None:
     assert binding.explicit_capability == ToolCapability.BLIND
 
 
+def test_binding_explicit_blind_stays_blind_with_effect_key_propagation() -> None:
+    binding = ToolTransitionBinding.for_tool(
+        agent_id="demo",
+        policy_version="1",
+        side_effect_class=SideEffectClass.KEYED_MUTATE,
+        provider_idempotency_key_param="idempotency_key",
+        propagate_effect_id_as_provider_key=True,
+        capability=ToolCapability.BLIND,
+    )
+    assert binding.capability == ToolCapability.BLIND
+    assert binding.effective_capability(has_reconciler=True) == ToolCapability.BLIND
+
+
 def test_binding_explicit_queryable_no_mechanism_is_deferred_to_reconciler() -> None:
     """Explicit QUERYABLE on plain non-idempotent w/o provider key: floor stays
     BLIND, but effective_capability(has_reconciler=True) upgrades it."""

--- a/sdk/tests/test_verify.py
+++ b/sdk/tests/test_verify.py
@@ -460,6 +460,7 @@ def test_cli_smoke_each_scenario(tmp_path: Path) -> None:
         "destructive-confirm",
         "authority-window",
         "use-time-currency",
+        "state-machine-exhaustive",
     ):
         code = main(
             [
@@ -674,6 +675,7 @@ def test_all_order_sqlite(tmp_path: Path, scenario: str) -> None:
         "destructive-confirm",
         "authority-window",
         "use-time-currency",
+        "state-machine-exhaustive",
         "simulation",
     ]
     assert all(item.status == VerificationStatus.PASS for item in report.scenarios)


### PR DESCRIPTION
## Summary
Stacked on #99 — completes the remaining §1 items: effect_id as the authoritative collision key, opt-in provider idempotency propagation, and the Change 5 verification moat.

### effect_id secondary index (Phase A)
- `LedgerStorage.get_by_effect_id` + CAS-enforced at-most-one-row-per-effect_id across InMemory (index dict), File (locked scan), Redis (sibling-namespace effect keys, WATCHed in CAS paths, stale mappings treated as absent), Postgres/Sqlite (unique COALESCE(payload->>'effect_id', request_id) indexes; lazy legacy backfill)
- Redispatch with a *different* explicit request_id re-enters the normal claim loop under the stored canonical request_id, so all gates (RETURN/POLL/HARD_BLOCK/reconciler) apply unchanged; explicit request_id is now an audit id on the row

### Provider idempotency propagation (Phase B)
- Opt-in `ToolTransitionBinding.propagate_effect_id_as_provider_key` (default False): injects `mycelium:{effect_id}` after the ATTEMPTING decision CAS and before the body, stamps it on the row under the same fence; retries reuse the stored key verbatim; explicit host kwargs win; capability typing untouched

### Change 5 (Phase C) + docs sync (Phase D)
- New deterministic `state-machine-exhaustive` verify scenario: crash/resume at every legal transition from crafted expired intermediate rows, stale-fence takeover rejections, BLIND UNKNOWN parking, concurrent INTENDED claim races; asserts at-most-one-COMMITTED after every shape; never skips
- TLA+ spec at `sdk/docs/spec/effect_state.tla` (+ README mapping actions → ledger methods/CAS preconditions); TLC optional, not CI-wired
- Docs present unified EffectState as primary model; TODO(Change 5) removed from CHANGELOG

## Test plan
- New/extended: test_effect_id_index.py, two-worker Redis mismatched-explicit-request_ids proof, provider-key propagation suite, state-machine-exhaustive direct test
- ruff clean; full suite 1320 passed (8 pre-existing environmental failures only); `mycelium verify --scenario simulation` and `--scenario state-machine-exhaustive` PASS

No version bump.