### PR TITLE
chore: release v1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+## 1.34.0 (2026-08-22)
+
+MINOR: one coherent effect-commit and side-effect-safety batch. PyPI 1.32.0
+was the last published package: this release therefore includes the complete
+v1.33.0 guardrail batch (secret-in-args, destination policy, destructive
+confirm, authority-window expiry, and use-time currency) plus all post-v1.33.0
+effect-commit work described below.
+
+### Added
+
 - Unified durable WAL intent (`EffectState`) completes the effect-commit
   protocol. New `mycelium.transition.EffectState` (INTENDED / ATTEMPTING /
   COMMITTED / ABORTED / UNKNOWN) plus `resolve_effect_state(entry)` collapses
@@ -24,15 +34,6 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
   EffectState-string semantics), and `profile: production` now defaults
   `action_ledger.unclassified_policy` to `strict` when omitted
   (explicit `warn` remains honored).
-
-- TODO(Change 5): exhaustive interleaving simulation and a formal
-  TLA+/PlusCal spec of the intent state machine.
-
-- Budget accounting now warns when `record_usage(steps=...)` is combined with
-  the step meter that `check()` and `@budget_guard` enable by default, preventing
-  silent double metering. `get_state()` now matches `remaining_budget()` by
-  resolving the active execution scope when no key is passed, and the runway
-  contract explicitly distinguishes a missing scope from a hard-blocked run.
 
 - Deterministic simulation proof (effect-commit Change 4). New
   `mycelium.verify.invariants` module (`InvariantViolation`,
@@ -99,6 +100,14 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
   a worker whose lease was taken over cannot mutate the winning entry even if
   it resumes with its old owner metadata. Legacy rows without a fence load as
   fence zero and receive a current token when claimed.
+
+### Changed
+
+- Budget accounting now warns when `record_usage(steps=...)` is combined with
+  the step meter that `check()` and `@budget_guard` enable by default, preventing
+  silent double metering. `get_state()` now matches `remaining_budget()` by
+  resolving the active execution scope when no key is passed, and the runway
+  contract explicitly distinguishes a missing scope from a hard-blocked run.
 
 ## 1.33.0 (2026-08-15)
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,25 @@ Mycelium wraps tool calls after the LLM returns `tool_calls` and returns a verdi
 
 - Durable **execution ledger** around mutating tools: claim before the side effect, record terminal state, **do not redispatch unless the previous attempt is proven safe**.
   - **Flagship (AF-002):** any tool, any provider — record a handle, ask the provider what happened, enforce **at-most-once**. Shipped adapters (e.g. Gmail sent-log) are demos of that contract, not the product story.
+  - **Effect identity and state for classified transitions:** deterministic,
+    destination-aware `effect_id`; unified durable `EffectState`
+    (`INTENDED → ATTEMPTING → COMMITTED | ABORTED | UNKNOWN`) with legacy-row
+    resolution.
+  - **Fenced effect commit:** every claim increments a durable fence; decision,
+    boundary, heartbeat, provider-reference, completion, failure,
+    reconciliation, and operator-resolution writes reject stale fences.
+    Registered pure decision predicates are evaluated once and recorded
+    atomically with `INTENDED → ATTEMPTING`.
+  - **Recovery capability:** `ToolCapability` distinguishes `idempotent`,
+    `queryable`, and `blind`. Ambiguous blind effects park; queryable effects
+    require a class-appropriate probe (`keyed_mutate` provider key or a
+    `Reconciler`; non-idempotent mutation requires a reconciler). Dishonest
+    declarations fail closed.
   - **Reads:** poll in-flight, reclaim expired leases, soft-block ambiguous `UNKNOWN`
   - **Mutations:** hard-block ambiguity; **provider reconcile** when a lookup can prove ran-or-not; **operator release** when a human must verify (`mycelium transitions release`)
+  - `mycelium verify --scenario simulation` sweeps crash boundaries and proves
+    the at-most-one-COMMITTED invariant plus stale-fence rejection on durable
+    backends.
   - Crash windows, worker death, lease auto-renew, CAS/atomicity, and fail-closed storage — see [sdk/README.md](sdk/README.md#resolution-gates)
   - LangGraph Cloud redispatches long tools around **~180s**; the ledger guards that window ([langgraph#7417](https://github.com/langchain-ai/langgraph/issues/7417))
 
@@ -71,6 +88,11 @@ Mycelium wraps tool calls after the LLM returns `tool_calls` and returns a verdi
 - **AF-002 Args drift** — default `on_args_drift: soft` (same call id, different args refused; `hard` / `off` opt-in)
 - **State authority** — refuse decisions from superseded checkpoints before claim
 - **DTTR telemetry** — opt-in `OutcomeEmitter` so the no-double-execute guarantee is observable
+
+Budget step accounting is automatic in `check()` and `@budget_guard`.
+Use `record_usage()` for observed token/USD usage without `steps`; combining
+`record_usage(steps=...)` with the default step meter warns because it counts
+the step twice.
 
 Implementation detail (envelope field stack, gate matrix, payment identity): [sdk/README.md](sdk/README.md#transition-envelope-fields). Failure & threat model: [sdk/docs/FAILURE_AND_THREAT_MODEL.md](sdk/docs/FAILURE_AND_THREAT_MODEL.md).
 
@@ -129,6 +151,12 @@ mycelium run --config mycelium.yaml -- python -m my_app
 application starts. It preserves the child process's arguments, working
 directory, signals, and exit code. The command accepts the current Python
 interpreter only.
+
+The direct/decorator library default for an unclassified tool is still
+`unclassified_policy: warn`. Under `profile: production`, an omitted
+`action_ledger.unclassified_policy` now defaults to `strict`, so failed
+unclassified retries hard-block; an explicit `warn` remains a compatibility
+choice. Consequential production tools should declare `side_effect_class`.
 
 Explicit instrumentation remains supported when you prefer code-level control:
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -6,13 +6,17 @@
 **The reliability layer for AI agents** — installable as `mycelium-runtime`
 (current version on [PyPI](https://pypi.org/project/mycelium-runtime/)).
 
-The public story is the [failure-mode catalog](docs/FAILURE_MODE_CATALOG.md) (**AF-001…AF-010**): each ID is a real runtime failure class; each shipped surface is a deterministic guard. The taxonomy is the product promise; envelope fields and gates are how AF-002 is implemented underneath.
+The public story is the [failure-mode catalog](docs/FAILURE_MODE_CATALOG.md) (**AF-001…AF-012**): each ID is a real runtime failure class; each shipped surface is a deterministic guard. The taxonomy is the product promise; envelope fields and gates are how AF-002 is implemented underneath.
 
 **Releases:** batch; calm over velocity — [release policy & pre-release checklist](docs/RELEASE.md).
 
 **AF-002 flagship:** any tool, any provider — prove run-or-not and enforce at-most-once (ledger · lease · `Reconciler` · operator release). Provider adapters (Gmail sent-log, Stripe-shaped examples) are demos of that contract, not the headline.
 
-Also shipping: AF-003 loop guard · AF-004 `@bounded` · AF-006 context guards · AF-007 completion · AF-008 scope guard · SQLite + Redis/Postgres · DTTR · atomicity / CAS / owner fencing · worker-death · lease auto-renew.
+Also shipping: destination-aware effect identity + unified `EffectState`; fenced CAS
+and atomic decision predicates/records; and `ToolCapability`-aware recovery. The wider
+surface includes AF-003/004/006/007/008; the AF-010–AF-012 side-effect guardrail batch
+(secret and destination checks, destructive grants, authority expiry, and use-time
+currency); SQLite + Redis/Postgres; DTTR; worker-death detection; and lease auto-renew.
 
 ## One painful bug → a few lines of config
 
@@ -429,8 +433,9 @@ def send_payment(amount: float, recipient: str, *, tool_call_id: str) -> dict:
         try:
             result = gateway.charge(amount, recipient)
         except Exception as exc:
+            # The provider may have accepted before raising: park ambiguity.
             ledger.fail(
-                request_id, exc, failed_after_effect=False,
+                request_id, exc, failed_after_effect=True,
                 expected_fence=entry.fence,
             )
             raise
@@ -444,7 +449,7 @@ def send_payment(amount: float, recipient: str, *, tool_call_id: str) -> dict:
 | `COMPLETED` → return `entry.result` | Partner-facing **SKIP** — already done. |
 | `record_decision(...)` | Atomically records the final allow/deny result and advances `INTENDED → ATTEMPTING`. |
 | Else run body + `complete(..., expected_fence=entry.fence)` | Partner-facing **PROCEED** then settle. |
-| `fail(..., expected_fence=entry.fence)` | Settle a failure; use `failed_after_effect=True` if the provider may have accepted. |
+| `fail(..., expected_fence=entry.fence)` | Settle a failure; use `failed_after_effect=True` when the effect may have happened. Use `False` only when failure is proven pre-effect. |
 
 The decorators evaluate registered decision predicates at this single boundary
 and record their verdicts automatically. A manual integration must record its
@@ -516,8 +521,9 @@ def handle_event(tool: str, event_id: str, do_work) -> int:
     try:
         result = do_work()                  # the side effect, once
     except Exception as exc:
+        # Handler effects may precede the exception: park ambiguity.
         ledger.fail(
-            request_id, exc, failed_after_effect=False,
+            request_id, exc, failed_after_effect=True,
             expected_fence=entry.fence,
         )
         return 500
@@ -548,7 +554,73 @@ See [examples/failure_cases/](examples/failure_cases/)
 - Resolve redispatches through **gates** (see [Resolution gates](#resolution-gates)) instead of re-running blindly
 - Persist failed attempts with **terminal outcomes** (`FAILED_BEFORE_EFFECT`, `FAILED_AFTER_EFFECT`, `UNKNOWN`, `EXPIRED`, etc.) for audit and reconciliation
 
-**Failure-mode catalog.** Stable AF-001…AF-010 definitions (shipped vs roadmap)
+### Effect-commit protocol
+
+Ledger rows for tools with a `ToolTransitionBinding` enable the effect-commit
+protocol: they store a deterministic, destination-aware `effect_id`,
+`schema_version`, claim `fence`, atomic `decision`, and unified effect state.
+Unclassified `claim()` rows keep the protocol disabled; because no binding
+exists, their compatibility `effect_id` falls back to `request_id` rather than
+the destination-aware derivation. The public API is exported from `mycelium`:
+
+```python
+from mycelium import (
+    Decision,
+    DecisionIntent,
+    DecisionSnapshot,
+    EffectState,
+    PredicateVerdict,
+    ToolCapability,
+    derive_effect_id_for_call,
+    register_decision_predicate,
+    resolve_effect_state,
+)
+```
+
+`EffectState` is the durable write-ahead intent:
+
+| State | Meaning |
+|---|---|
+| `INTENDED` | Row exists; no allow decision has been recorded |
+| `ATTEMPTING` | The atomic decision allowed; the provider boundary may be crossed |
+| `COMMITTED` | The ledger records the effect as completed |
+| `ABORTED` | Denied or failed before the effect |
+| `UNKNOWN` | The effect may have happened; redispatch stays fail-closed until resolved |
+
+Use `resolve_effect_state(entry)` or `entry.resolved_effect_state()`. It folds
+legacy `terminal_outcome`, boundary, decision, and `effect_phase` rows into the
+unified view without a storage migration. `terminal_outcome` remains available
+for compatibility and detailed failure labels.
+
+`derive_effect_id_for_call()` uses the same canonical SHA-256 preimage as the
+derived transition key: execution scope, dispatch identity, tool,
+canonicalized meaningful arguments, canonical destination, side-effect class,
+agent, and policy. Canonically equivalent destinations produce the same id;
+different destinations do not. With derived identity, `request_id` and
+`effect_id` coincide. With an explicit business `request_id`, the row stores
+the independently derived `effect_id` for audit, but storage still keys and
+deduplicates by `request_id`; callers must reuse the same explicit
+`request_id` for the same logical effect.
+
+Every successful claim increments `LedgerEntry.fence`. Every later mutation
+for that claim—decision, boundary, heartbeat/lease, provider reference,
+receipt, completion, failure, reconciliation, and operator resolution—uses a
+storage CAS that requires the same fence. A worker resumed after takeover
+cannot mutate the winner's row even if stale owner or lease metadata still
+looks plausible.
+
+Policy checks compose as pure `(DecisionIntent, DecisionSnapshot)` predicates.
+`register_decision_predicate(name, predicate)` adds a host predicate at the
+single enforcement point. The combined `Decision` and every predicate verdict
+are sanitized and persisted atomically with the fenced
+`INTENDED → ATTEMPTING` transition. A denial records `ABORTED`; the
+`@ledger` / `@ledger_sync` and YAML/config wrapper paths do not invoke the body
+unless the allowed decision write succeeded. A stale-fence worker cannot
+record a decision. A manual integration must call `record_decision(...)` with
+the claim fence and wait for success before invoking the body or provider;
+Mycelium cannot stop a manual host from calling a provider outside its APIs.
+
+**Failure-mode catalog.** Stable AF-001…AF-012 definitions (shipped vs roadmap)
 live in [`docs/FAILURE_MODE_CATALOG.md`](docs/FAILURE_MODE_CATALOG.md).
 
 **Failure & threat model.** What this core can and cannot protect you from is
@@ -736,7 +808,9 @@ see [examples/langgraph_redis_crash/](examples/langgraph_redis_crash/).
 
 ### Transition envelope fields
 
-Seven fields decide whether an unresolved prior execution is merely **wasteful** (safe to retry/poll) or **unsafe** (must not re-run). Priority order:
+Seven recovery axes decide whether an unresolved prior execution is merely
+**wasteful** (safe to retry/poll) or **unsafe** (must not re-run). Priority
+order:
 
 | # | Field | Role |
 |---|-------|------|
@@ -750,7 +824,11 @@ Seven fields decide whether an unresolved prior execution is merely **wasteful**
 
 **Invariant:** for a given tool class, the fields that class **requires** must already be **supported and recorded** on the transition before a redispatch is treated as a safe retry. Reads need a lighter set (class + terminal + lease). Payment / write / email / subagent need spendability, boundary, terminal outcome, and usually an external receipt/ref — without them, a second dispatch is an **unsupported second transition**, not a retry.
 
-Also on the durable record: `transition_key`, `idempotency_key`, `owner`, `lease_until`, `receipt_ref`.
+For a classified, bound transition, the effect-commit record additionally
+carries `effect_id`, `EffectState` (resolved from the compatibility
+`effect_phase` storage field), `schema_version`, atomic `decision`, `fence`,
+`transition_key`, `idempotency_key`, `owner`, `lease_until`, and
+`receipt_ref`.
 
 ### Side-effect classes
 
@@ -1397,9 +1475,10 @@ Authorization is checked again immediately before use. Expiry at or before
 the use instant (`now >= expires_at`) blocks execution; completed-result
 reads remain available. Mycelium cannot guarantee authority remains valid
 throughout an external network call. Clock synchronization is an
-operational assumption unless storage/server time is authoritative. This
-item alone does not complete use-time currency — do not release until that
-lands.
+operational assumption unless storage/server time is authoritative.
+Authority expiry and use-time currency are separate checks and ship together:
+the former validates time-bounded authority, while the latter revalidates the
+facts behind the decision.
 
 ```python
 from mycelium import (
@@ -1564,8 +1643,9 @@ with execution_scope(TransitionScope(run_id="r1", thread_id="t")):
     fetch_customer(customer_id="c1")  # ok; tools outside the freeze soft-block
 ```
 
-Wrapper order: `@secret_args` → `@entity_guard` → `@destructive_confirm` → `@scope_guard` → `@loop_guard` → `@ledger` →
-`@bounded` → `@protect`. CLI: `mycelium scope status|bind`. Demo:
+Wrapper order: `@secret_args` → `@entity_guard` → `@destructive_confirm` →
+`@state_authority` → `@scope_guard` → `@budget_guard` → `@loop_guard` →
+`@ledger` → `@bounded` → `@protect`. CLI: `mycelium scope status|bind`. Demo:
 `python examples/scope_guard_allowlist.py` (from `sdk/`).
 
 ### Completion contract (AF-007): refuse terminal while required subtasks pending
@@ -1739,8 +1819,8 @@ Tools without a `transition_binding` (unclassified) have unknown side-effect sem
 
 | Policy | Default | Behavior |
 |--------|---------|----------|
-| `warn` | yes | One-time `UserWarning` per tool when a failed entry is reclaimed; legacy behavior (re-execute) |
-| `strict` | no | Routes through `claim_side_effecting` with a conservative binding (`non_idempotent_mutate`); failed retries **hard-block** instead of re-executing |
+| `warn` | library / development | One-time `UserWarning` per tool when a failed entry is reclaimed; legacy behavior (re-execute) |
+| `strict` | omitted YAML value under `profile: production` | Routes through `claim_side_effecting` with a conservative binding (`non_idempotent_mutate`); failed retries **hard-block** instead of re-executing |
 
 ```python
 # Decorator
@@ -1823,9 +1903,9 @@ r2 = process_invoice(invoice_id="inv-42", task_id="invoice-42-attempt-2")  # fre
 Separate YAML sections per guard type. Global ledger settings inherit into tools/tasks
 so you do not repeat storage paths on every function.
 
-**Deployments:** set `profile: production`. That does not change library defaults
-for omitted configs (still `warn` / `derived`). It applies fail-closed
-policies:
+**Deployments:** set `profile: production`. Direct constructors and development
+keep their compatibility defaults; the production profile applies these
+fail-closed YAML defaults and requirements:
 
 - `action_ledger.memory_storage_policy: error` — side-effecting tools cannot
   use memory storage
@@ -1834,6 +1914,10 @@ policies:
   `irreversible` tools need a host-owned `request_id` (or
   `request_id_from`) before claim or execution. Reads may keep derived
   identity. `tool_call_id` / `run_id` / `thread_id` are not business IDs.
+- omitted `action_ledger.unclassified_policy` defaults to `strict`, so a
+  failed retry without a transition binding hard-blocks instead of silently
+  reclaiming. An explicit `warn` remains accepted for compatibility; declare
+  `side_effect_class` for consequential tools.
 - `loop_guard` / `scope_guard` `missing_run_id_policy: error` when those
   guards are enabled — missing `run_id` raises `MissingRunIdentityError`
 - `outcome_emit:` is required with durable storage (not memory). Prefer
@@ -1852,12 +1936,15 @@ policies:
   must be declared. Omitted `destructive_confirm:` stays backward
   compatible.
 
-Explicit weaker settings (`warn`, `derived`, memory outcomes) under
-production are rejected (`ConfigError`), not silently weakened. Omit
-`profile` or set `profile: development` for tests.
+Explicit weaker settings for memory storage, request identity, run identity,
+outcome storage, and enabled production guards are rejected (`ConfigError`),
+not silently weakened. `action_ledger.unclassified_policy: warn` is the stated
+compatibility exception. Omit `profile` or set `profile: development` for
+tests.
 
-`unclassified_policy: warn` remains an accepted product choice. Important
-tools should still declare `side_effect_class`.
+The direct/decorator and development default remains
+`unclassified_policy: warn`. Production changes only the omitted YAML value to
+`strict`; explicit `warn` remains an accepted compatibility choice.
 
 ```yaml
 profile: production
@@ -1877,7 +1964,7 @@ transition:
 action_ledger:
   storage: postgres
   dsn_env: MYCELIUM_POSTGRES_DSN
-  unclassified_policy: warn
+  unclassified_policy: strict
   memory_storage_policy: error
   request_identity_policy: require_explicit
 
@@ -2082,7 +2169,10 @@ Legacy per-tool style still works. Start with `mycelium init`; use `mycelium ini
 
 **Problem:** Two workers claim the same transition. Worker A completes. Worker B's stale `IN_FLIGHT` entry resolves later and silently overwrites A's `COMPLETED` result with a `FAILED_*` outcome. The operation's terminal state is lost.
 
-**Solution:** Every terminal-outcome write goes through a CAS (`try_transition`) that checks the entry's current `terminal_outcome` and `owner` against expected values. Already-resolved entries refuse overwrites.
+**Solution:** Every claim receives a monotonically increasing fence. Every
+subsequent mutation goes through `try_transition`, which checks the stored
+terminal outcome plus the expected fence (and owner/effect state where
+applicable). Already-resolved or superseded entries refuse overwrites.
 
 ### Transition matrix (rejected transitions)
 
@@ -2097,9 +2187,14 @@ Legacy per-tool style still works. Start with `mycelium init`; use `mycelium ini
 
 Resolution paths (`release()` / reconcile) can complete from `BLOCKED`, `UNKNOWN`, or `FAILED_AFTER_EFFECT` — they pass a broader `_expected_from` set.
 
-### Owner fencing
+### Fenced mutations
 
-The `@ledger` / `@ledger_sync` wrapper captures the current worker's identity (`_ledger_owner()`) and passes it to `complete()` and `_record_failure`. If a different worker tries to resolve the same entry, the CAS rejects it with `LedgerOutcomeAlreadySetError`. In `_record_failure`, the CAS error is caught and the original tool exception is re-raised — never masked.
+The `@ledger` / `@ledger_sync` wrapper captures the current worker identity and
+claim fence. A takeover increments the stored fence; stale decision, boundary,
+heartbeat, provider-reference, receipt, completion, failure, reconciliation,
+and operator-resolution writes are rejected with
+`LedgerOutcomeAlreadySetError`. Owner checks remain additional protection. In
+`_record_failure`, a CAS rejection never masks the original tool exception.
 
 ### Backend implementation
 
@@ -2107,8 +2202,9 @@ The `@ledger` / `@ledger_sync` wrapper captures the current worker's identity (`
 |---------|--------------|
 | Memory | `InMemoryLedgerStorage` delegates to `set()` when CAS matches |
 | File | Within `LockedJsonDictFile.read_modify_write` |
+| SQLite | Conditional `UPDATE` over JSON outcome / owner / fence / effect state |
 | Redis | `pipe.watch()` on the key; `WatchError` retry loop on conflict |
-| Postgres | `UPDATE ... WHERE payload->>'terminal_outcome' = ANY(...) RETURNING` |
+| Postgres | Conditional `UPDATE ... RETURNING` over outcome / owner / fence / effect state |
 
 ### NOT_EXECUTED reset CAS (v1.18+)
 

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -12,8 +12,8 @@ README is the source of truth for how the pieces are used; this file is the
 honest accounting of what can go wrong and which guarantee is pinned to which
 test.
 
-> Version note: this document tracks the current release (**v1.33.0**).
-> Ledger-core guarantees below hold; since **v1.28.0**, `on_args_drift: soft`
+> This document tracks the shipped ledger core in this repository. Since
+> **v1.28.0**, `on_args_drift: soft`
 > is the default (identity-conflict refuse). Optional `loop_guard:` (AF-003),
 > `completion:` (AF-007), `scope_guard:` (AF-008), and `state_authority:` are
 > documented in the SDK README and are outside this core guarantee set.
@@ -87,7 +87,7 @@ The actors this core defends against (and the ones it assumes are honest):
 | 2 | **Two concurrent workers** | Worker A and Worker B both claim the same transition; both run the tool body. |
 | 3 | **Crash mid-effect** | The process is killed after the provider accepted the charge but before `complete()` — the transition is ambiguous. |
 | 4 | **Storage outage** | Redis / Postgres / the file backend is down at claim, complete, or failure-recording time. |
-| 5 | **Stalled worker wake** | A worker is paused (GC, partition, stopped auto-renew), its lease expires, then it wakes late with a stale snapshot and tries to resolve the entry. |
+| 5 | **Stalled worker wake** | A worker is paused (GC, partition, stopped auto-renew), its lease expires, then it wakes late with a stale fence and tries to mutate the winning entry. |
 | 6 | **Operator with backend access** | Anyone who can write to the ledger backend can release, stamp a resolution, or assert worker death. |
 | 7 | **Provider indexing lag** | A provider (e.g. Gmail sent-log) hasn't made a sent message visible yet — a naive reconciler would say "never sent". |
 | 8 | **Caller tweaking args / keys** | A caller changes a "fluff" argument to re-mint a different transition key and dodge an in-flight lease, starting a second side effect. |
@@ -110,18 +110,24 @@ section; the tests are concrete `file::test_name` entries.
    *Where:* [Resolution gates](../README.md#resolution-gates),
    [Backend implementation](../README.md#backend-implementation).
 
-2. **CAS on every terminal-outcome write.** `complete()` / `fail()` /
-   `mark_blocked()` / `mark_unknown()` are compare-and-swap writes that only
-   succeed from `IN_FLIGHT`. A resolved transition
-   (`COMPLETED` / `BLOCKED` / `UNKNOWN` / `FAILED_*`) refuses all four.
+2. **Fenced CAS on every claim mutation.** Every successful claim increments
+   a durable fence. Decision, boundary, heartbeat/lease, provider-reference,
+   receipt, completion, failure, reconciliation, worker-death, and
+   operator-resolution writes require the claim's current fence. A resolved
+   or superseded transition refuses stale writes.
    *Where:* [Atomicity contract](../README.md#atomicity-contract-v118),
    [Transition matrix](../README.md#transition-matrix-rejected-transitions).
 
-3. **Owner fencing.** The wrapper captures the worker's identity and passes it
-   as `_expected_owner`; a different worker's write to the same entry is
-   refused. A stale worker cannot silently overwrite a real `COMPLETED` (or a
-   real failure).
-   *Where:* [Owner fencing](../README.md#owner-fencing).
+3. **Single atomic decision point.** Registered pure predicates evaluate one
+   `(DecisionIntent, DecisionSnapshot)` and the combined, sanitized `Decision`
+   is persisted in the same fenced CAS that advances
+   `EffectState.INTENDED → ATTEMPTING` (or `ABORTED` on denial). The
+   `@ledger` / `@ledger_sync` and YAML/config wrapper paths invoke the body only
+   after that allowed decision is durably recorded. Ledger APIs for provider
+   references, boundary advancement, and completion require both an allowed
+   decision and the current fence. A stale worker cannot record a decision.
+   *Where:* [Effect-commit protocol](../README.md#effect-commit-protocol),
+   [Fenced mutations](../README.md#fenced-mutations).
 
 4. **Single-winner reclaim.** After a lease expires, at most one worker
    reclaims the transition; the loser polls or hard-blocks — never both run.
@@ -151,7 +157,12 @@ section; the tests are concrete `file::test_name` entries.
    transition (`maybe_crossed`, `crossed`, `FAILED_AFTER_EFFECT`, `EXPIRED`
    past the boundary, or `UNKNOWN` with no reconciler) hard-blocks instead of
    re-executing. The tool body never runs again until a reconciler proves
-   `NOT_EXECUTED` or an operator releases it.
+   `NOT_EXECUTED` or an operator releases it. `ToolCapability` makes the
+   recovery contract explicit: `BLIND` ambiguity never auto-redispatches;
+   `QUERYABLE` requires a class-appropriate mechanism (a provider key for
+   `keyed_mutate`, or a reconciler; non-idempotent mutation requires the
+   reconciler) and otherwise fails closed; `IDEMPOTENT` retains safe retry
+   behavior.
    *Where:* [Resolution gates](../README.md#resolution-gates),
    [Marking the side-effect boundary](../README.md#marking-the-side-effect-boundary-side_effect).
 
@@ -193,12 +204,15 @@ section; the tests are concrete `file::test_name` entries.
     so key-swapping retries are caught, not silently re-keyed.
     *Where:* [Enforcing the same provider idempotency key](../README.md#enforcing-the-same-provider-idempotency-key-provider_idempotency_key_param).
 
-15. **Key derivation is deterministic and sound.** Identical redispatches map
-    to one key. With derived identity, changing a *real* argument produces a
-    new key; `tool_call_id` binds the dispatch identity but is excluded from
-    the args fingerprint. An explicit host-owned `request_id` is itself the
-    key, and reuse with a different tool, scope, or meaningful argument is
-    fail-closed.
+15. **Effect identity and unified state are deterministic and legacy-safe.**
+    Identical derived redispatches map to one destination-aware SHA-256
+    `effect_id` / transition key; changing a meaningful argument or canonical
+    destination changes it. `EffectState` maps current and legacy rows onto
+    `INTENDED`, `ATTEMPTING`, `COMMITTED`, `ABORTED`, or `UNKNOWN`; the
+    COMMITTED view must agree with legacy `COMPLETED`. An explicit host-owned
+    `request_id` remains the storage key: the independently derived
+    `effect_id` is audit evidence, not a cross-row secondary dedupe index, so
+    the host must reuse the same request id for one logical effect.
     *Where:* [Transition identity and host-owned `request_id`](../README.md#transition-identity-and-host-owned-request_id).
 
 16. **Task-level idempotency.** The task ledger returns a stored result for a
@@ -318,10 +332,12 @@ than the code makes.
   Durable storage preserves `maybe_crossed` across restart but cannot alone
   prove whether the provider completed; unresolved ambiguity stays
   fail-closed.
-- **Unclassified tools under the default `warn` policy.** A tool without a
+- **Unclassified tools under the library/development `warn` policy.** A tool without a
   transition binding that fails is re-executed on reclaim (legacy behavior,
   with a one-time warning). `unclassified_policy: strict` routes them through
   a conservative `non_idempotent_mutate` binding that hard-blocks instead.
+  `profile: production` defaults an omitted policy to `strict`; explicit
+  `warn` remains a compatibility choice.
 - **Temporal-style workflows.** Mycelium guards individual tool calls (and
   task ledger entries); it does not re-run a multi-step workflow graph with
   orchestrator recovery semantics.
@@ -349,13 +365,13 @@ are cited once. "Where documented" links the README section.
 | Guarantee | Where documented | Test(s) |
 |---|---|---|
 | Atomic first claim, single winner | README § [Resolution gates](../README.md#resolution-gates) / [Backend implementation](../README.md#backend-implementation) | `test_storage_backends.py::test_file_storage_serializes_concurrent_claims` · `test_storage_backends.py::test_redis_storage_atomic_claim` · `test_storage_backends.py::test_postgres_storage_atomic_claim`<sup>1</sup> · `test_proof_two_worker_redis.py::test_two_worker_redis_cloud_style_redispatch`<sup>2</sup> · `test_multiprocess_concurrency.py::test_two_processes_redis_contested_claim` |
-| CAS on terminal-outcome writes | README § [Transition matrix](../README.md#transition-matrix-rejected-transitions) | `test_atomicity_contract.py::test_transition_matrix` · `test_atomicity_contract.py::test_concurrent_complete_race` · `test_atomicity_contract.py::test_concurrent_complete_and_fail_race` |
-| Owner fencing (no silent overwrite of COMPLETED) | README § [Owner fencing](../README.md#owner-fencing) | `test_atomicity_contract.py::test_owner_mismatch_on_complete` · `test_atomicity_contract.py::test_owner_match_succeeds` · `test_atomicity_contract.py::test_wrapper_owner_fencing_prevents_stale_overwrite` · `test_atomicity_contract.py::test_stalled_worker_cannot_overwrite_completed` · `test_atomicity_contract.py::test_stalled_worker_cannot_overwrite_failed` |
+| Fenced CAS on claim mutations | README § [Fenced mutations](../README.md#fenced-mutations) / [Transition matrix](../README.md#transition-matrix-rejected-transitions) | `test_atomicity_contract.py::test_transition_matrix` · `test_atomicity_contract.py::test_claim_bumps_fence_monotonically` · `test_atomicity_contract.py::test_stale_fence_rejected_even_when_lease_valid` · `test_atomicity_contract.py::test_legacy_claim_mutations_require_and_reject_stale_fences` |
+| Atomic decision + stale-fence refusal | README § [Effect-commit protocol](../README.md#effect-commit-protocol) | `test_decision.py::test_plugin_predicate_evaluated_and_recorded_end_to_end` · `test_decision.py::test_plugin_denial_hard_blocks_with_decision_recorded` · `test_decision.py::test_stale_fence_worker_cannot_record_decision` · `test_decision.py::test_manual_pre_provider_mutations_require_attempting_phase` |
 | Single-winner reclaim after lease expiry | README § Lease validity / auto-renew → [Resolution gates](../README.md#resolution-gates) | `test_atomicity_contract.py::test_concurrent_reclaim_race_inmemory` · `test_atomicity_contract.py::test_concurrent_reclaim_race_redis` · `test_terminal_outcome.py::test_reclaim_after_expired_lease` · `test_side_effect_resolution.py::test_spendability_override_allows_expired_reclaim` · `test_multiprocess_concurrency.py::test_two_processes_reclaim_expired_payment_single_reexec` |
 | Stale-snapshot guard (`mark_blocked` never on a held lease) | README § [NOT_EXECUTED reset CAS](../README.md#not_executed-reset-cas-v118) | `test_atomicity_contract.py::test_raise_hard_block_stale_snapshot_returns_inflight_held_lease` · `test_conformance_tsc007.py::test_case_1_in_flight_valid_lease_polls_without_reexecuting` · `test_lease_validity.py::test_auto_renew_keeps_peer_on_poll_past_original_ttl` |
 | Dual `NOT_EXECUTED` → at most one re-execution | README § [NOT_EXECUTED reset CAS](../README.md#not_executed-reset-cas-v118) | `test_atomicity_contract.py::test_concurrent_reconcile_not_executed_race` · `test_atomicity_contract.py::test_concurrent_reconcile_not_executed_race_expired_seed` · `test_mengchheang_public_repro.py::test_concurrent_reconcile_not_executed` · `test_payment_provider_mock.py::test_redispatch_storm_never_double_charges` |
 | Fail-closed on storage outage | README § [What happens when storage is down](../README.md#what-happens-when-storage-is-down) | `test_fail_closed_storage.py::test_claim_raises_storage_unavailable` · `test_fail_closed_storage.py::test_tool_never_runs_on_storage_down_claim` · `test_fail_closed_storage.py::test_complete_propagates_storage_error` · `test_fail_closed_storage.py::test_storage_failure_does_not_mask_tool_exception` · `test_fail_closed_storage.py::test_tool_exception_propagates_not_storage_exception` · `test_outage_redis_postgres.py::test_claim_during_outage_raises_storage_unavailable` · `test_outage_redis_postgres.py::test_complete_during_outage_keeps_inflight` · `test_outage_redis_postgres.py::test_failure_recording_outage_surfaces_original_exception` · `test_outage_redis_postgres.py::test_real_redis_entry_path_wraps_connection_error` |
-| Hard-block on ambiguous mutation | README § [Resolution gates](../README.md#resolution-gates) | `test_side_effect_resolution.py::test_payment_hard_blocks_expired_lease` · `test_side_effect_resolution.py::test_crash_after_claim_before_complete_hard_blocks_redispatch` · `test_side_effect_resolution.py::test_payment_hard_blocks_failed_after_effect_retry` · `test_reconcile.py::test_hard_block_without_reconciler_still_blocks` · `test_process_kill_crash_window.py::test_kill_before_ref_recorded_hard_blocks_no_provider_lookup` · `test_payment_provider_mock.py::test_no_reconciler_hard_blocks_without_provider_evidence` |
+| Hard-block on ambiguous mutation / capability recovery | README § [Resolution gates](../README.md#resolution-gates) / [Tool capabilities](../README.md#tool-capabilities) | `test_side_effect_resolution.py::test_payment_hard_blocks_expired_lease` · `test_reconcile.py::test_hard_block_without_reconciler_still_blocks` · `test_tool_capability.py::test_blind_unknown_parks_and_never_retries` · `test_tool_capability.py::test_queryable_reconciler_probe_commits` · `test_tool_capability.py::test_queryable_without_reconciler_fails_closed_parks` |
 | Resolution gate matrix (POLL / RETURN / ALLOW / HARD_BLOCK / reconcile) | README § [Resolution gates](../README.md#resolution-gates) | `test_conformance_tsc007.py` (5 cases) · `test_side_effect_resolution.py::test_resolve_side_effect_gate_matrix` · `test_read_only_resolution.py::test_resolve_read_only_gate_matrix` |
 | Reconciliation fail-closed | README § [Reconciling automatically](../README.md#reconciling-automatically-reconciler) | `test_reconcile.py::test_reconcile_failure_is_fail_closed` · `test_reconcile.py::test_reconcile_skipped_without_external_ref` · `test_reconcile.py::test_reconcile_unknown_hard_blocks` · `test_outage_redis_postgres.py::test_mid_reconcile_storage_outage_fail_closed` |
 | Boundary classification + monotonic, durable `maybe_crossed` | README § [Marking the side-effect boundary](../README.md#marking-the-side-effect-boundary-side_effect) | `test_side_effect_boundary.py::test_advance_boundary_is_monotonic` · `test_side_effect_boundary.py::test_side_effect_marks_maybe_crossed_midflight` · `test_side_effect_boundary.py::test_exception_inside_side_effect_marks_unknown_and_hard_blocks` · `test_side_effect_boundary.py::test_exception_before_marker_is_failed_before_effect` · `test_side_effect_boundary.py::test_mark_crossed_then_exception_is_failed_after_effect` · `test_side_effect_boundary.py::test_async_side_effect_marks_unknown_on_error` · `test_storage_backends.py::test_sqlite_maybe_crossed_survives_restart_and_does_not_reexecute` |
@@ -365,7 +381,7 @@ are cited once. "Where documented" links the README section.
 | Release emits signed audit receipts when configured | README § [Operator runbook](../README.md#operator-runbook-your-agent-hard-blocked) | `test_operator_release.py::test_release_emits_audit_receipt_when_emitter_configured` · `test_audit_receipt.py::test_emitter_signs_and_verifies_tool_receipt` · `test_audit_receipt.py::test_tampered_receipt_fails_verification` |
 | Worker-death gate (opt-in) | README § [Assert worker death](../README.md#operator-runbook-your-agent-hard-blocked) | `test_worker_death_signal.py::test_release_expired_refused_without_death_evidence` · `test_worker_death_signal.py::test_release_expired_allowed_with_asserted_death` · `test_worker_death_signal.py::test_mark_worker_dead_refuses_recent_heartbeat_without_override` · `test_worker_death_signal.py::test_read_only_reclaim_blocked_without_death_evidence` · `test_worker_death_signal.py::test_side_effecting_allow_blocked_without_death_evidence` |
 | Provider idempotency-key enforcement (opt-in) | README § [Enforcing the same provider idempotency key](../README.md#enforcing-the-same-provider-idempotency-key-provider_idempotency_key_param) | `test_provider_idempotency_key.py::test_gate_hard_blocks_different_provider_key` · `test_provider_idempotency_key.py::test_gate_hard_blocks_missing_incoming_key` · `test_provider_idempotency_key.py::test_gate_hard_blocks_missing_stored_key` · `test_provider_idempotency_key.py::test_declared_key_is_excluded_from_transition_key` · `test_provider_key_validity.py::test_same_key_expired_ttl_hard_blocks` · `test_provider_key_validity.py::test_unknown_same_key_valid_ttl_allows` · `test_provider_key_validity.py::test_unknown_same_key_expired_ttl_hard_blocks` · `test_provider_key_validity.py::test_unknown_same_key_prefers_reconciler_over_reexec` |
-| Key derivation soundness | README § [Transition identity and host-owned `request_id`](../README.md#transition-identity-and-host-owned-request_id) | `test_transition.py::test_same_inputs_produce_same_transition_key` · `test_transition.py::test_different_tool_call_id_produces_different_key` · `test_transition.py::test_ledger_deduplicates_by_transition_key` · `test_property_transitions.py::test_transition_key_invariants` (property test) · `test_explicit_request_id.py` |
+| Deterministic effect identity + unified EffectState | README § [Effect-commit protocol](../README.md#effect-commit-protocol) / [Transition identity](../README.md#transition-identity-and-host-owned-request_id) | `test_effect_identity.py` · `test_effect_state_machine.py::test_effect_state_transition_matrix_and_illegal_cas_rejections` · `test_effect_state_machine.py::test_legacy_deserialization_resolves_unified_effect_state` · `test_property_transitions.py::test_transition_key_invariants` |
 | Task-level idempotency | README § [Quickstart: task-level idempotency](../README.md#quickstart-task-level-idempotency) | `test_cli_run.py::test_run_instruments_sync_tool_and_task_across_processes` |
 | Secret-in-args (when enabled) | README § [Secret-in-args (AF-010)](../README.md#secret-in-args-af-010) | `test_secret_protection.py` · `test_verify.py::test_cli_smoke_each_scenario` (`secret-in-args`) |
 | Destination policy (when enabled) | README § [Entity / destination guard](../README.md#entity--destination-guard-unnumbered) | `test_entity_guard.py` · `test_verify.py::test_cli_smoke_each_scenario` (`entity-guard`) |
@@ -373,6 +389,7 @@ are cited once. "Where documented" links the README section.
 | Authority-window expiry (when enabled) | README § [Authority-window expiry](../README.md#authority-window-expiry) | `test_authority_window.py` · `test_verify.py::test_cli_smoke_each_scenario` (`authority-window`) |
 | Use-time currency (when enabled) | README § [Use-time currency (AF-012)](../README.md#use-time-currency-af-012) | `test_use_time_currency.py` · `test_verify.py::test_cli_smoke_each_scenario` (`use-time-currency`) |
 | Single-key state machine invariants (executions ≤ 1 + not-executed verdicts; COMPLETED terminal; CAS out of IN_FLIGHT) | this doc, § C / [NOT_EXECUTED reset CAS](../README.md#not_executed-reset-cas-v118) | `test_property_transitions.py::test_transition_key_invariants` (Hypothesis, file + Redis) · `test_payment_provider_mock.py::test_redispatch_storm_never_double_charges` |
+| Deterministic simulation invariant (legacy COMPLETED and unified EffectState.COMMITTED) | README § [`mycelium verify`](../README.md#mycelium-verify-exercise-the-guarantees) | `test_simulation.py::test_simulation_scenario_passes_on_shared_backend` · `test_verify.py::test_all_order_sqlite` |
 
 <sup>1</sup> `test_postgres_storage_atomic_claim` runs when `psycopg` is
 installed and `MYCELIUM_TEST_POSTGRES_DSN` is set; it skips otherwise.
@@ -414,6 +431,15 @@ Still can go wrong — even with everything above configured correctly:
   (server-authoritative, HMAC-derived keys) is the mitigation — the runtime
   enforces *same key on retry*, your application must mint stable, server-side
   keys.
+- **`effect_id` is not a second storage index.** With an explicit business
+  `request_id`, Mycelium records the independently derived `effect_id` for
+  audit and invariant checks but does not merge two differently keyed rows.
+  The host must reuse one stable request id for one logical effect.
+- **Manual hosts can bypass the decision boundary.** The ledger cannot stop
+  application code from calling a provider directly. A manual integration
+  must call `record_decision(...)` with the claim fence and wait for that write
+  to succeed before invoking the tool body or provider. Use the wrappers when
+  possible.
 - **Wall-clock leases.** Leases rely on `time.time()`. Clock skew can renew or
   expire leases early; extreme skew is a deployment concern, not something the
   runtime compensates for.
@@ -445,7 +471,10 @@ Still can go wrong — even with everything above configured correctly:
   fault-injection tests. Use `mycelium verify --config mycelium.yaml
   --scenario all --strict` to empirically exercise synthetic failure
   scenarios (redispatch, contention, crash windows, storage outage,
-  ambiguous effects, reconcile) against an isolated namespace. Verify never
+  ambiguous effects, reconcile, and deterministic simulation) against an
+  isolated namespace. The simulation scenario is skipped for memory storage;
+  on durable multiprocess-capable backends it checks both legacy COMPLETED and
+  unified EffectState.COMMITTED invariants plus stale-fence takeover. Verify never
   runs application tools, never calls an LLM, and never contacts a real
   business provider. Some infrastructure properties (Redis persistence,
   host call-site identity) remain operator assertions or not verifiable

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.33.0"
+version = "1.34.0"
 description = "The reliability layer for AI agents — prove run-or-not and enforce at-most-once at the tool boundary"
 authors = [
   { name = "Nandana Dileep" },

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.33.0"
+version = "1.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Release mycelium-runtime 1.34.0 as one coherent batch. PyPI 1.32.0 is the last published package; GitHub v1.33.0 was tagged but never uploaded, so this cut includes that guardrail batch and all subsequent effect-commit work.

Release checklist

- [x] Batched release; no PyPI version published today
- [x] Coherent changelog summary
- [x] Full tests pass: 1312 passed, 5 skipped on Python 3.12
- [x] Ruff clean
- [x] New guarantees mapped to tests
- [x] Public symbols verified at package root
- [x] Root README, PyPI README, and threat model synchronized
- [x] Package version and uv lock are 1.34.0
- [x] No current-version strings added to README badges or prose
- [x] Wheel and sdist build successfully; Twine checks pass

N/A: not a hotfix; no separate handbook repository changes are included in this SDK release.