### PR TITLE
feat: authoritative effect_id dedupe and effect-commit closure (v1.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+## 1.35.0 (2026-08-22)
+
+MINOR: closes remaining Core Protocol Architecture gaps from the effect-commit
+roadmap — authoritative `effect_id` dedupe, provider-key auto-propagation, the
+`state-machine-exhaustive` verify scenario, and a TLA+ intent-state sketch.
+
+### Added
+
+- Effect-commit closure batch for Core Protocol Architecture gaps:
+  consequential `claim_side_effecting` now treats derived `effect_id` as the
+  authoritative dedupe key (cross-request aliasing, no second-row duplicates),
+  storage backends expose `resolve_request_id()` / `get_by_effect_id()` with
+  backend-specific effect indexes (file sidecar, Redis secondary key,
+  Sqlite/Postgres unique index), and verify invariants add
+  `check_unique_effect_id_index`. Added deterministic
+  `state-machine-exhaustive` verify scenario plus `sdk/docs/spec/effect_state.tla`
+  and `sdk/docs/spec/README.md` formal-model notes.
+
+### Changed
+
+- For `keyed_mutate` tools that declare `provider_idempotency_key_param`,
+  Mycelium now defaults to propagating `effect_id` as the provider key when the
+  kwarg is omitted, persists the injected key on first attempt, and reuses it
+  for retries (explicit user-provided keys still win and are enforced). Setting
+  `propagate_effect_id_as_provider_key: true` without a declared
+  `provider_idempotency_key_param` is now rejected at binding/config load time.
+
 ## 1.34.0 (2026-08-22)
 
 MINOR: one coherent effect-commit and side-effect-safety batch. PyPI 1.32.0

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -597,10 +597,11 @@ derived transition key: execution scope, dispatch identity, tool,
 canonicalized meaningful arguments, canonical destination, side-effect class,
 agent, and policy. Canonically equivalent destinations produce the same id;
 different destinations do not. With derived identity, `request_id` and
-`effect_id` coincide. With an explicit business `request_id`, the row stores
-the independently derived `effect_id` for audit, but storage still keys and
-deduplicates by `request_id`; callers must reuse the same explicit
-`request_id` for the same logical effect.
+`effect_id` coincide. With an explicit business `request_id`, consequential
+tools still derive `effect_id` first and treat it as the authoritative dedupe
+identity. If another `request_id` resolves to the same `effect_id`, Mycelium
+routes to the canonical row and records the supplied id in
+`request_id_aliases` for audit instead of creating a second row.
 
 Every successful claim increments `LedgerEntry.fence`. Every later mutation
 for that claim—decision, boundary, heartbeat/lease, provider reference,
@@ -623,6 +624,10 @@ Mycelium cannot stop a manual host from calling a provider outside its APIs.
 **Failure-mode catalog.** Stable AF-001…AF-012 definitions (shipped vs roadmap)
 live in [`docs/FAILURE_MODE_CATALOG.md`](docs/FAILURE_MODE_CATALOG.md).
 
+**Formal state model.** Optional TLA+ notes for the core EffectState protocol
+live in [`docs/spec/README.md`](docs/spec/README.md) and
+[`docs/spec/effect_state.tla`](docs/spec/effect_state.tla).
+
 **Failure & threat model.** What this core can and cannot protect you from is
 documented explicitly in
 [`docs/FAILURE_AND_THREAT_MODEL.md`](docs/FAILURE_AND_THREAT_MODEL.md): the threat
@@ -637,9 +642,10 @@ risk — read it before relying on the runtime to stop a double payment.
 ### Transition identity and host-owned `request_id`
 
 Pass an optional `request_id` when the host already has a stable business
-operation identity. Mycelium uses that string as the transition identity
-across retries — it is not hashed with args, and it is not forwarded into the
-wrapped tool.
+operation identity. Mycelium preserves that string for audit and deterministic
+redispatch routing, but consequential dedupe is anchored on the independently
+derived `effect_id`, not on host string equality. `request_id` is never hashed
+with args and is not forwarded into the wrapped tool.
 
 **The host must derive it from a server-owned record**, never from the model:
 
@@ -648,13 +654,15 @@ request_id = f"charge-order:{order_id}"
 charge(amount=10, recipient=acct, request_id=request_id)
 ```
 
-For `keyed_mutate` tools, use the same string as the provider idempotency key
-when the provider allows it (`Idempotency-Key: charge-order:ORD-123`). That
-keeps ledger identity and provider dedupe aligned.
+For `keyed_mutate` tools, declare `provider_idempotency_key_param`; by default
+Mycelium injects `effect_id` as that provider key when your call omits it, and
+persists/reuses the same value across retries. If you pass a key explicitly,
+that explicit value wins and is enforced on retry.
 
 | Inputs | → | What happens |
 |--------|---|--------------|
 | Same explicit `request_id` + same tool/scope/args | → | Same transition — return stored result or poll |
+| Different explicit `request_id` + same derived `effect_id` | → | Canonical prior row wins; second id is recorded in `request_id_aliases` |
 | Same explicit `request_id` + **different** tool, scope, or meaningful args | → | Fail-closed identity conflict (`ToolBoundaryError` / hard-block) |
 | `request_id` omitted (development / `derived`) | → | Unchanged derived identity (`tool_call_id` + scope + args + policy) |
 | `request_id` omitted (production / `require_explicit`) | → | `MissingRequestIdentityError` for consequential tools |
@@ -676,9 +684,10 @@ tools:
     provider_idempotency_key_param: idempotency_key
 ```
 
-That mints `charge_customer:order_id:ORD-123`. Pass the same stable value
-as the provider idempotency key yourself when the provider supports it —
-Mycelium does not silently assume the provider uses its request ID.
+That mints `charge_customer:order_id:ORD-123`. With
+`provider_idempotency_key_param` declared, keyed-mutate retries now inherit and
+reuse the stored provider key (auto-injected from `effect_id` when omitted), so
+provider dedupe stays aligned even when callers do not pass the key manually.
 
 When `request_id` is omitted, the derived transition key still encodes args
 (same `tool_call_id` + different args → different key). **By default Mycelium
@@ -1036,18 +1045,32 @@ Record `external_operation_ref` early (ideally the idempotency key before the pr
 
 ### Enforcing the same provider idempotency key (`provider_idempotency_key_param`)
 
-`retry_only_with_same_provider_idempotency_key` (the default for `keyed_mutate`) means "a retry is safe *only if* it reuses the same provider idempotency key so the provider dedupes." By default Mycelium trusts you to reuse it. To have Mycelium **enforce** it, declare which kwarg carries the key:
+`retry_only_with_same_provider_idempotency_key` (the default for
+`keyed_mutate`) means "a retry is safe *only if* it reuses the same provider
+idempotency key so the provider dedupes." Declare which kwarg carries that key:
 
 ```yaml
 tools:
   send_payment:
     side_effect_class: keyed_mutate          # retry_only_with_same_provider_idempotency_key
     provider_idempotency_key_param: idempotency_key
+    # optional override (default true for keyed_mutate + declared param):
+    # propagate_effect_id_as_provider_key: false
 ```
 
 or in code: `ToolTransitionBinding.for_tool(..., provider_idempotency_key_param="idempotency_key")`.
 
-With it declared, on a retry of a transition that failed before the effect:
+With it declared:
+
+- If the first attempt omits the kwarg, Mycelium injects `effect_id` as the
+  provider idempotency key after `ATTEMPTING` is recorded and before the tool
+  body runs.
+- The injected/explicit key is persisted on the ledger entry and reused on
+  retries; Mycelium does not derive a fresh key per retry.
+- If the call supplies a key explicitly, that explicit value wins and is then
+  enforced on subsequent retries.
+
+On a retry of a transition that failed before the effect:
 
 | Incoming key vs stored key | Gate |
 |----------------------------|------|
@@ -1070,7 +1093,11 @@ tools:
     provider_idempotency_key_ttl: 86400   # match provider key lifetime
 ```
 
-The declared key is excluded from the transition-key fingerprint, so a retry that swaps the key still resolves to the *same* transition and is caught rather than silently starting a new one. This is **opt-in**: tools that don't declare the param keep the previous cooperative behavior.
+The declared key is excluded from the transition-key fingerprint, so a retry
+that swaps the key still resolves to the *same* transition and is caught rather
+than silently starting a new one. Declaring
+`propagate_effect_id_as_provider_key: true` without
+`provider_idempotency_key_param` is rejected at config/binding construction.
 
 #### Payment-class identity (server-authoritative)
 

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -197,22 +197,25 @@ section; the tests are concrete `file::test_name` entries.
     `mark-dead` (unless overridden with direct evidence).
     *Where:* [Assert worker death](../README.md#operator-runbook-your-agent-hard-blocked).
 
-14. **Provider idempotency-key enforcement (opt-in).** With
-    `provider_idempotency_key_param` declared, a retry that presents a
-    different or missing key hard-blocks (it would risk a second, undeduped
-    effect). The declared key is excluded from the transition-key fingerprint
+14. **Provider idempotency-key enforcement + default propagation for keyed
+    mutate.** With `provider_idempotency_key_param` declared, a retry that
+    presents a different or missing key hard-blocks (it would risk a second,
+    undeduped effect). For `keyed_mutate`, when that kwarg is omitted on first
+    attempt, Mycelium defaults to propagating `effect_id` as the provider key
+    after the `ATTEMPTING` decision write and persists that value for future
+    retries. The declared key is excluded from the transition-key fingerprint
     so key-swapping retries are caught, not silently re-keyed.
     *Where:* [Enforcing the same provider idempotency key](../README.md#enforcing-the-same-provider-idempotency-key-provider_idempotency_key_param).
 
 15. **Effect identity and unified state are deterministic and legacy-safe.**
-    Identical derived redispatches map to one destination-aware SHA-256
-    `effect_id` / transition key; changing a meaningful argument or canonical
-    destination changes it. `EffectState` maps current and legacy rows onto
-    `INTENDED`, `ATTEMPTING`, `COMMITTED`, `ABORTED`, or `UNKNOWN`; the
-    COMMITTED view must agree with legacy `COMPLETED`. An explicit host-owned
-    `request_id` remains the storage key: the independently derived
-    `effect_id` is audit evidence, not a cross-row secondary dedupe index, so
-    the host must reuse the same request id for one logical effect.
+    Identical redispatches map to one destination-aware SHA-256 `effect_id`;
+    changing a meaningful argument or canonical destination changes it.
+    Consequential claims resolve by canonical `effect_id` and never create a
+    second row for a colliding explicit `request_id`; alternate host ids are
+    preserved as audit aliases on the canonical entry. The unified single-row
+    WAL intent model is `INTENDED -> ATTEMPTING -> COMMITTED|ABORTED|UNKNOWN`;
+    `EffectState` maps current and legacy rows onto those states, and the
+    COMMITTED view must agree with legacy `COMPLETED`.
     *Where:* [Transition identity and host-owned `request_id`](../README.md#transition-identity-and-host-owned-request_id).
 
 16. **Task-level idempotency.** The task ledger returns a stored result for a
@@ -282,10 +285,10 @@ than the code makes.
   changed args refuses the second body within the same run (`run_id` /
   `thread_id`; other runs isolated): soft → `ToolBoundaryError`, hard →
   `LedgerHardBlockError`. Derived transition keys still differ by args;
-  `on_args_drift: off` retains the old dual-execute escape hatch. An explicit
-  host-owned `request_id` is the storage key, and reuse with a different tool,
-  scope, or meaningful arguments is fail-closed even when drift checking is
-  off. Default soft pinned by
+  `on_args_drift: off` retains the old dual-execute escape hatch. Explicit
+  host `request_id` aliases are still drift-checked against the canonical row,
+  so reuse with a different tool, scope, or meaningful arguments is fail-closed
+  even when drift checking is off. Default soft pinned by
   `tests/test_args_drift.py::test_default_is_soft_not_off`; derived key split +
   `off` escape hatch by
   `tests/test_mengchheang_public_repro.py::test_semantic_identity`.
@@ -380,8 +383,8 @@ are cited once. "Where documented" links the README section.
 | Release stamps the record (never deleted) | README § [Operator runbook](../README.md#operator-runbook-your-agent-hard-blocked) | `test_operator_release.py::test_release_not_executed_grants_exactly_one_reexecution` (asserts `operator_resolution`/`resolved_by`) · `test_operator_release.py::test_postgres_release_not_executed_round_trip` |
 | Release emits signed audit receipts when configured | README § [Operator runbook](../README.md#operator-runbook-your-agent-hard-blocked) | `test_operator_release.py::test_release_emits_audit_receipt_when_emitter_configured` · `test_audit_receipt.py::test_emitter_signs_and_verifies_tool_receipt` · `test_audit_receipt.py::test_tampered_receipt_fails_verification` |
 | Worker-death gate (opt-in) | README § [Assert worker death](../README.md#operator-runbook-your-agent-hard-blocked) | `test_worker_death_signal.py::test_release_expired_refused_without_death_evidence` · `test_worker_death_signal.py::test_release_expired_allowed_with_asserted_death` · `test_worker_death_signal.py::test_mark_worker_dead_refuses_recent_heartbeat_without_override` · `test_worker_death_signal.py::test_read_only_reclaim_blocked_without_death_evidence` · `test_worker_death_signal.py::test_side_effecting_allow_blocked_without_death_evidence` |
-| Provider idempotency-key enforcement (opt-in) | README § [Enforcing the same provider idempotency key](../README.md#enforcing-the-same-provider-idempotency-key-provider_idempotency_key_param) | `test_provider_idempotency_key.py::test_gate_hard_blocks_different_provider_key` · `test_provider_idempotency_key.py::test_gate_hard_blocks_missing_incoming_key` · `test_provider_idempotency_key.py::test_gate_hard_blocks_missing_stored_key` · `test_provider_idempotency_key.py::test_declared_key_is_excluded_from_transition_key` · `test_provider_key_validity.py::test_same_key_expired_ttl_hard_blocks` · `test_provider_key_validity.py::test_unknown_same_key_valid_ttl_allows` · `test_provider_key_validity.py::test_unknown_same_key_expired_ttl_hard_blocks` · `test_provider_key_validity.py::test_unknown_same_key_prefers_reconciler_over_reexec` |
-| Deterministic effect identity + unified EffectState | README § [Effect-commit protocol](../README.md#effect-commit-protocol) / [Transition identity](../README.md#transition-identity-and-host-owned-request_id) | `test_effect_identity.py` · `test_effect_state_machine.py::test_effect_state_transition_matrix_and_illegal_cas_rejections` · `test_effect_state_machine.py::test_legacy_deserialization_resolves_unified_effect_state` · `test_property_transitions.py::test_transition_key_invariants` |
+| Provider idempotency-key enforcement + keyed-mutate auto-propagation | README § [Enforcing the same provider idempotency key](../README.md#enforcing-the-same-provider-idempotency-key-provider_idempotency_key_param) | `test_provider_idempotency_key.py::test_gate_hard_blocks_different_provider_key` · `test_provider_idempotency_key.py::test_gate_hard_blocks_missing_incoming_key` · `test_provider_idempotency_key.py::test_gate_hard_blocks_missing_stored_key` · `test_provider_idempotency_key.py::test_keyed_mutate_auto_injects_effect_id_key_when_missing` · `test_provider_idempotency_key.py::test_keyed_mutate_missing_key_retry_reuses_stored_effect_id` · `test_provider_key_validity.py::test_same_key_expired_ttl_hard_blocks` · `test_provider_key_validity.py::test_unknown_same_key_valid_ttl_allows` · `test_provider_key_validity.py::test_unknown_same_key_expired_ttl_hard_blocks` · `test_provider_key_validity.py::test_unknown_same_key_prefers_reconciler_over_reexec` |
+| Deterministic effect identity + authoritative `effect_id` dedupe + unified EffectState | README § [Effect-commit protocol](../README.md#effect-commit-protocol) / [Transition identity](../README.md#transition-identity-and-host-owned-request_id) | `test_effect_identity.py` · `test_effect_id_index.py` · `test_effect_state_machine.py::test_effect_state_transition_matrix_and_illegal_cas_rejections` · `test_effect_state_machine.py::test_legacy_deserialization_resolves_unified_effect_state` · `test_property_transitions.py::test_transition_key_invariants` |
 | Task-level idempotency | README § [Quickstart: task-level idempotency](../README.md#quickstart-task-level-idempotency) | `test_cli_run.py::test_run_instruments_sync_tool_and_task_across_processes` |
 | Secret-in-args (when enabled) | README § [Secret-in-args (AF-010)](../README.md#secret-in-args-af-010) | `test_secret_protection.py` · `test_verify.py::test_cli_smoke_each_scenario` (`secret-in-args`) |
 | Destination policy (when enabled) | README § [Entity / destination guard](../README.md#entity--destination-guard-unnumbered) | `test_entity_guard.py` · `test_verify.py::test_cli_smoke_each_scenario` (`entity-guard`) |
@@ -389,7 +392,7 @@ are cited once. "Where documented" links the README section.
 | Authority-window expiry (when enabled) | README § [Authority-window expiry](../README.md#authority-window-expiry) | `test_authority_window.py` · `test_verify.py::test_cli_smoke_each_scenario` (`authority-window`) |
 | Use-time currency (when enabled) | README § [Use-time currency (AF-012)](../README.md#use-time-currency-af-012) | `test_use_time_currency.py` · `test_verify.py::test_cli_smoke_each_scenario` (`use-time-currency`) |
 | Single-key state machine invariants (executions ≤ 1 + not-executed verdicts; COMPLETED terminal; CAS out of IN_FLIGHT) | this doc, § C / [NOT_EXECUTED reset CAS](../README.md#not_executed-reset-cas-v118) | `test_property_transitions.py::test_transition_key_invariants` (Hypothesis, file + Redis) · `test_payment_provider_mock.py::test_redispatch_storm_never_double_charges` |
-| Deterministic simulation invariant (legacy COMPLETED and unified EffectState.COMMITTED) | README § [`mycelium verify`](../README.md#mycelium-verify-exercise-the-guarantees) | `test_simulation.py::test_simulation_scenario_passes_on_shared_backend` · `test_verify.py::test_all_order_sqlite` |
+| Deterministic simulation invariants (legacy + exhaustive interleavings) | README § [`mycelium verify`](../README.md#mycelium-verify-exercise-the-guarantees) | `test_simulation.py::test_simulation_scenario_passes_on_shared_backend` · `test_simulation.py::test_state_machine_exhaustive_scenario_passes` · `test_verify.py::test_all_order_sqlite` |
 
 <sup>1</sup> `test_postgres_storage_atomic_claim` runs when `psycopg` is
 installed and `MYCELIUM_TEST_POSTGRES_DSN` is set; it skips otherwise.
@@ -431,10 +434,11 @@ Still can go wrong — even with everything above configured correctly:
   (server-authoritative, HMAC-derived keys) is the mitigation — the runtime
   enforces *same key on retry*, your application must mint stable, server-side
   keys.
-- **`effect_id` is not a second storage index.** With an explicit business
-  `request_id`, Mycelium records the independently derived `effect_id` for
-  audit and invariant checks but does not merge two differently keyed rows.
-  The host must reuse one stable request id for one logical effect.
+- **`effect_id` quality is only as good as your canonicalization inputs.** The
+  runtime now deduplicates consequential claims by `effect_id`; if a host omits
+  a materially distinct field from identity inputs, distinct operations can
+  collapse onto one canonical row. Keep identity inputs server-authoritative
+  and semantically complete.
 - **Manual hosts can bypass the decision boundary.** The ledger cannot stop
   application code from calling a provider directly. A manual integration
   must call `record_decision(...)` with the claim fence and wait for that write
@@ -472,9 +476,12 @@ Still can go wrong — even with everything above configured correctly:
   --scenario all --strict` to empirically exercise synthetic failure
   scenarios (redispatch, contention, crash windows, storage outage,
   ambiguous effects, reconcile, and deterministic simulation) against an
-  isolated namespace. The simulation scenario is skipped for memory storage;
-  on durable multiprocess-capable backends it checks both legacy COMPLETED and
-  unified EffectState.COMMITTED invariants plus stale-fence takeover. Verify never
+  isolated namespace. The `simulation` scenario is skipped for memory storage;
+  on durable multiprocess-capable backends it checks legacy COMPLETED +
+  EffectState.COMMITTED invariants, explicit-request alias dedupe, and stale
+  fence takeover. The `state-machine-exhaustive` scenario runs in memory and
+  systematically checks stale-fence refusals, reconcile outcomes, and
+  concurrent-intended claim races. Verify never
   runs application tools, never calls an LLM, and never contacts a real
   business provider. Some infrastructure properties (Redis persistence,
   host call-site identity) remain operator assertions or not verifiable

--- a/sdk/docs/spec/README.md
+++ b/sdk/docs/spec/README.md
@@ -1,0 +1,39 @@
+# Effect State Spec Notes
+
+`effect_state.tla` is a compact TLA+ model of the core `ActionLedger` state
+machine for consequential tools.
+
+## Mapping to runtime code
+
+- `Claim` models `ActionLedger.claim_side_effecting()` +
+  `LedgerStorage.try_claim_inflight()` CAS ownership/fence acquisition.
+- `RecordDecision` models `ActionLedger.record_decision()` as the only allowed
+  `INTENDED -> ATTEMPTING` mutation gate.
+- `Complete` models `ActionLedger.complete()` on the same fence/owner.
+- `Fail` models `ActionLedger.fail(..., failed_after_effect=False)` abort paths.
+- `MarkUnknown` models `mark_maybe_crossed()` / fail-after-effect ambiguity.
+- `StaleFenceWrite` models rejected stale-owner CAS writes after takeover.
+
+## Mapping to verify scenarios
+
+- `python -m mycelium verify --scenario simulation`
+  - durable backend crash windows and stale-fence takeover.
+  - asserts `check_at_most_one_committed_effect_state`,
+    `check_effect_state_consistency`, and `check_unique_effect_id_index`.
+- `python -m mycelium verify --scenario state-machine-exhaustive`
+  - deterministic in-memory interleavings: stale-fence refusals, reconcile
+    outcomes (`COMPLETED` / `NOT_EXECUTED` / `UNKNOWN`), and concurrent claims.
+  - re-checks the same invariant set after each interleaving.
+
+## Optional TLC run (not CI)
+
+1. Install [TLA+ Toolbox](https://lamport.azurewebsites.net/tla/toolbox.html)
+   or `tlc2`.
+2. Create a model for module `effect_state`.
+3. Provide:
+   - `EffectStates = {"INTENDED","ATTEMPTING","COMMITTED","ABORTED","UNKNOWN"}`
+   - `Workers = {"A","B"}`
+4. Check invariant `AtMostOneCommitted`.
+
+This model is documentation/proof aid only; CI correctness gates remain Python
+tests + `mycelium verify` scenarios.

--- a/sdk/docs/spec/effect_state.tla
+++ b/sdk/docs/spec/effect_state.tla
@@ -1,0 +1,93 @@
+---- MODULE effect_state ----
+EXTENDS Naturals, FiniteSets
+
+(*
+  Minimal model of the canonical effect row used by ActionLedger for one
+  dedupe identity (`effect_id`). It focuses on fenced state transitions and the
+  fail-closed UNKNOWN behavior.
+*)
+
+CONSTANTS EffectStates, Workers
+
+ASSUME EffectStates = {"INTENDED", "ATTEMPTING", "COMMITTED", "ABORTED", "UNKNOWN"}
+
+VARIABLES effect_state, fence, owner, decision_allowed, effect_id
+
+vars == <<effect_state, fence, owner, decision_allowed, effect_id>>
+
+Init ==
+  /\ effect_state = "INTENDED"
+  /\ fence = 0
+  /\ owner = "none"
+  /\ decision_allowed = FALSE
+  /\ effect_id = "effect-0"
+
+(* claim_side_effecting + storage.try_claim_inflight CAS *)
+Claim(w) ==
+  /\ w \in Workers
+  /\ owner = "none"
+  /\ effect_state = "INTENDED"
+  /\ fence' = fence + 1
+  /\ owner' = w
+  /\ UNCHANGED <<effect_state, decision_allowed, effect_id>>
+
+(* record_decision CAS: the only mutation gate that can enter ATTEMPTING *)
+RecordDecision(w, allow) ==
+  /\ w \in Workers
+  /\ owner = w
+  /\ effect_state = "INTENDED"
+  /\ decision_allowed' = allow
+  /\ effect_state' = IF allow THEN "ATTEMPTING" ELSE "ABORTED"
+  /\ UNCHANGED <<fence, owner, effect_id>>
+
+(* complete CAS *)
+Complete(w) ==
+  /\ w \in Workers
+  /\ owner = w
+  /\ effect_state = "ATTEMPTING"
+  /\ decision_allowed = TRUE
+  /\ effect_state' = "COMMITTED"
+  /\ owner' = "none"
+  /\ UNCHANGED <<fence, decision_allowed, effect_id>>
+
+(* fail(..., failed_after_effect=FALSE) CAS *)
+Fail(w) ==
+  /\ w \in Workers
+  /\ owner = w
+  /\ effect_state \in {"INTENDED", "ATTEMPTING"}
+  /\ effect_state' = "ABORTED"
+  /\ owner' = "none"
+  /\ UNCHANGED <<fence, decision_allowed, effect_id>>
+
+(* mark_maybe_crossed / fail(..., failed_after_effect=TRUE) CAS *)
+MarkUnknown(w) ==
+  /\ w \in Workers
+  /\ owner = w
+  /\ effect_state = "ATTEMPTING"
+  /\ effect_state' = "UNKNOWN"
+  /\ owner' = "none"
+  /\ UNCHANGED <<fence, decision_allowed, effect_id>>
+
+(* stale-fence mutation attempt: CAS rejects and state is unchanged *)
+StaleFenceWrite(w, stale_fence) ==
+  /\ w \in Workers
+  /\ stale_fence < fence
+  /\ UNCHANGED vars
+
+Next ==
+  \/ \E w \in Workers: Claim(w)
+  \/ \E w \in Workers: RecordDecision(w, TRUE)
+  \/ \E w \in Workers: RecordDecision(w, FALSE)
+  \/ \E w \in Workers: Complete(w)
+  \/ \E w \in Workers: Fail(w)
+  \/ \E w \in Workers: MarkUnknown(w)
+  \/ \E w \in Workers: \E stale_fence \in 0..fence: StaleFenceWrite(w, stale_fence)
+
+Spec == Init /\ [][Next]_vars
+
+CommittedEffectIds == IF effect_state = "COMMITTED" THEN {effect_id} ELSE {}
+AtMostOneCommitted == Cardinality(CommittedEffectIds) <= 1
+
+THEOREM Spec => []AtMostOneCommitted
+
+====

--- a/sdk/mycelium/action_ledger.py
+++ b/sdk/mycelium/action_ledger.py
@@ -62,6 +62,7 @@ from mycelium.transition import (
     resolve_lease_validity,
     resolve_scope,
     resolve_terminal_outcome,
+    should_propagate_effect_id_as_provider_key,
     terminal_from_legacy_status,
 )
 from mycelium.transition_resolution import (
@@ -667,23 +668,16 @@ class LedgerEntry:
     effect_protocol_required: bool = False
 
     # Stable effect identity (mycelium.transition.derive_effect_id_for_call):
-    # a hash of (scope, tool, canonicalized args/kwargs, destination) that is
-    # deterministic and destination-aware, independent of which request_id a
-    # host happened to supply. ``request_id`` remains the storage key (every
-    # existing backend and test keys rows by it) — effect_id is an additional
-    # durable field for redispatch-collision auditing. When request_id is
-    # *derived* (the default — no explicit request_id/request_id_from kwarg),
-    # request_id already equals effect_id today (derive_request_id falls back
-    # to the same transition-key derivation), so the two collide naturally.
-    # When a host supplies an *explicit* request_id (its own business/audit
-    # id), effect_id is the independent dedup identity computed from the call
-    # shape alone; two different explicit request_ids for what is otherwise
-    # the same (tool, params, destination) are NOT unified into one storage
-    # row by this change (that would require a cross-backend secondary index
-    # keyed by effect_id, which is out of scope here) — hosts that redispatch
-    # the same logical effect must reuse the same request_id, as documented
-    # elsewhere. ``None`` for unclassified claims (no binding to derive from).
+    # deterministic hash of (scope, tool, canonicalized args/kwargs,
+    # destination). This is the authoritative dedup identity for consequential
+    # tools: storage backends maintain an effect_id -> canonical request_id
+    # mapping and claim paths resolve through it before any side-effect write.
+    # ``request_id`` remains the physical row key for backward compatibility.
+    # Unclassified claim() rows still fall back to request_id.
     effect_id: str | None = None
+    # Audit trail of host-supplied request ids that resolved onto this
+    # canonical effect row via effect_id dedupe (includes request_id itself).
+    request_id_aliases: tuple[str, ...] = ()
     # Schema version for this row's shape. See LEDGER_ENTRY_SCHEMA_VERSION.
     schema_version: int = LEDGER_ENTRY_SCHEMA_VERSION
 
@@ -702,6 +696,12 @@ class LedgerEntry:
         # idempotency_key.
         if self.effect_id is None:
             object.__setattr__(self, "effect_id", self.request_id)
+        aliases = tuple(
+            str(item) for item in self.request_id_aliases if item is not None and str(item)
+        )
+        if self.request_id not in aliases:
+            aliases = aliases + (self.request_id,)
+        object.__setattr__(self, "request_id_aliases", aliases)
 
     def resolved_terminal_outcome(self, *, now: float | None = None) -> TerminalOutcome:
         return resolve_terminal_outcome(
@@ -770,6 +770,7 @@ class LedgerEntry:
             "effect_phase": self.effect_phase,
             "effect_protocol_required": self.effect_protocol_required,
             "effect_id": self.effect_id,
+            "request_id_aliases": list(self.request_id_aliases),
             "schema_version": self.schema_version,
             "parent_request_id": self.parent_request_id,
             "handoff_id": self.handoff_id,
@@ -827,6 +828,11 @@ class LedgerEntry:
             # request_id, which is exactly what it would equal for the
             # (default) derived-request_id path anyway.
             effect_id=str(data.get("effect_id") or request_id),
+            request_id_aliases=tuple(
+                str(item)
+                for item in (data.get("request_id_aliases") or (request_id,))
+                if item is not None and str(item)
+            ),
             schema_version=int(data.get("schema_version") or 1),
             parent_request_id=(
                 str(data["parent_request_id"])
@@ -939,6 +945,31 @@ class LedgerStorage:
         """Return all entries. Intended for debugging/auditing only."""
         raise NotImplementedError
 
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        """Resolve ``effect_id`` to its canonical ``request_id``.
+
+        Default implementation scans all rows (legacy-safe, deterministic).
+        Backends with secondary indexes should override.
+        """
+        candidates: list[LedgerEntry] = []
+        for entry in self.list_all():
+            ref = str(getattr(entry, "effect_id", None) or entry.request_id)
+            if ref == effect_id:
+                candidates.append(entry)
+        if not candidates:
+            return None
+        candidates.sort(
+            key=lambda item: (float(getattr(item, "started_at", 0.0) or 0.0), item.request_id)
+        )
+        return candidates[0].request_id
+
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        """Return the canonical row for ``effect_id``, if present."""
+        request_id = self.resolve_request_id(effect_id)
+        if request_id is None:
+            return None
+        return self.get(request_id)
+
 
 class InMemoryLedgerStorage(LedgerStorage):
     """Default in-memory storage. Survives within the process only.
@@ -950,7 +981,29 @@ class InMemoryLedgerStorage(LedgerStorage):
 
     def __init__(self) -> None:
         self._entries: dict[str, LedgerEntry] = {}
+        self._effect_index: dict[str, str] = {}
         self._lock = threading.RLock()
+
+    @staticmethod
+    def _effect_ref(entry: LedgerEntry) -> str:
+        return str(entry.effect_id or entry.request_id)
+
+    def _resolve_effect_locked(self, effect_id: str) -> str | None:
+        canonical = self._effect_index.get(effect_id)
+        if canonical is not None:
+            row = self._entries.get(canonical)
+            if row is not None and self._effect_ref(row) == effect_id:
+                return canonical
+            self._effect_index.pop(effect_id, None)
+        candidates = [row for row in self._entries.values() if self._effect_ref(row) == effect_id]
+        if not candidates:
+            return None
+        candidates.sort(
+            key=lambda item: (float(getattr(item, "started_at", 0.0) or 0.0), item.request_id)
+        )
+        canonical = candidates[0].request_id
+        self._effect_index[effect_id] = canonical
+        return canonical
 
     def get(self, request_id: str) -> LedgerEntry | None:
         with self._lock:
@@ -958,7 +1011,17 @@ class InMemoryLedgerStorage(LedgerStorage):
 
     def set(self, entry: LedgerEntry) -> None:
         with self._lock:
+            effect_id = self._effect_ref(entry)
+            canonical = self._resolve_effect_locked(effect_id)
+            if (
+                canonical is not None
+                and canonical != entry.request_id
+                and entry.request_id not in self._entries
+            ):
+                return
             self._entries[entry.request_id] = entry
+            if canonical is None or canonical == entry.request_id:
+                self._effect_index[effect_id] = entry.request_id
 
     def try_claim_inflight(
         self,
@@ -967,7 +1030,25 @@ class InMemoryLedgerStorage(LedgerStorage):
         lease_ttl: float = DEFAULT_LEASE_TTL,
     ) -> tuple[str, LedgerEntry | None]:
         with self._lock:
-            return default_try_claim_inflight(self, entry, lease_ttl=lease_ttl)
+            now = time.time()
+            effect_id = self._effect_ref(entry)
+            canonical = self._resolve_effect_locked(effect_id)
+            active_request_id = canonical or entry.request_id
+            existing = self._entries.get(active_request_id)
+            outcome = claim_inflight_outcome(existing, now=now)
+            if outcome == "completed":
+                return "completed", existing
+            if outcome == "in_flight":
+                return "in_flight", existing
+            claim_entry = (
+                entry
+                if active_request_id == entry.request_id
+                else replace(entry, request_id=active_request_id)
+            )
+            leased = with_lease(claim_entry, now=now, lease_ttl=lease_ttl, prior=existing)
+            self._entries[active_request_id] = leased
+            self._effect_index[effect_id] = active_request_id
+            return "claimed", None
 
     def try_transition(
         self,
@@ -1005,6 +1086,17 @@ class InMemoryLedgerStorage(LedgerStorage):
         with self._lock:
             return list(self._entries.values())
 
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        with self._lock:
+            return self._resolve_effect_locked(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        with self._lock:
+            request_id = self._resolve_effect_locked(effect_id)
+            if request_id is None:
+                return None
+            return self._entries.get(request_id)
+
 
 class FileLedgerStorage(LedgerStorage):
     """JSON-file-backed storage with ``fcntl`` + threading locking.
@@ -1015,8 +1107,88 @@ class FileLedgerStorage(LedgerStorage):
     """
 
     def __init__(self, path: str | Path) -> None:
-        self._file = LockedJsonDictFile(path)
+        ledger_path = Path(path)
+        self._file = LockedJsonDictFile(ledger_path)
+        self._effect_index_path = ledger_path.with_suffix(ledger_path.suffix + ".effect-index.json")
         self._lock = threading.Lock()
+
+    @staticmethod
+    def _effect_ref_from_raw(raw: dict[str, Any], request_id: str) -> str:
+        return str(raw.get("effect_id") or request_id)
+
+    @staticmethod
+    def _started_at_from_raw(raw: dict[str, Any]) -> float:
+        value = raw.get("started_at")
+        try:
+            return float(value) if value is not None else 0.0
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _load_effect_index_unlocked(self) -> dict[str, str]:
+        if not self._effect_index_path.exists():
+            return {}
+        try:
+            with self._effect_index_path.open("r", encoding="utf-8") as handle:
+                loaded = json.load(handle)
+        except (json.JSONDecodeError, OSError):
+            return {}
+        if not isinstance(loaded, dict):
+            return {}
+        index: dict[str, str] = {}
+        for effect_id, request_id in loaded.items():
+            if (
+                isinstance(effect_id, str)
+                and effect_id
+                and isinstance(request_id, str)
+                and request_id
+            ):
+                index[effect_id] = request_id
+        return index
+
+    def _save_effect_index_unlocked(self, index: dict[str, str]) -> None:
+        tmp = self._effect_index_path.with_suffix(self._effect_index_path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as handle:
+            json.dump(index, handle, indent=2, default=str)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, self._effect_index_path)
+        try:
+            dir_fd = os.open(str(self._effect_index_path.parent), os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(dir_fd)
+        except OSError:
+            pass
+        finally:
+            os.close(dir_fd)
+
+    def _resolve_effect_locked(
+        self,
+        data: dict[str, dict[str, Any]],
+        index: dict[str, str],
+        effect_id: str,
+    ) -> tuple[str | None, bool]:
+        dirty = False
+        canonical = index.get(effect_id)
+        if canonical is not None:
+            raw = data.get(canonical)
+            if raw is not None and self._effect_ref_from_raw(raw, canonical) == effect_id:
+                return canonical, False
+            index.pop(effect_id, None)
+            dirty = True
+        candidates: list[tuple[float, str]] = []
+        for request_id, raw in data.items():
+            if self._effect_ref_from_raw(raw, request_id) == effect_id:
+                candidates.append((self._started_at_from_raw(raw), request_id))
+        if not candidates:
+            return None, dirty
+        candidates.sort(key=lambda item: (item[0], item[1]))
+        canonical = candidates[0][1]
+        if index.get(effect_id) != canonical:
+            index[effect_id] = canonical
+            dirty = True
+        return canonical, dirty
 
     def get(self, request_id: str) -> LedgerEntry | None:
         def read(data: dict[str, dict[str, Any]]) -> LedgerEntry | None:
@@ -1030,7 +1202,24 @@ class FileLedgerStorage(LedgerStorage):
 
     def set(self, entry: LedgerEntry) -> None:
         def mutate(data: dict[str, dict[str, Any]]) -> None:
+            index = self._load_effect_index_unlocked()
+            effect_id = str(entry.effect_id or entry.request_id)
+            canonical, dirty = self._resolve_effect_locked(data, index, effect_id)
+            if (
+                canonical is not None
+                and canonical != entry.request_id
+                and entry.request_id not in data
+            ):
+                if dirty:
+                    self._save_effect_index_unlocked(index)
+                return
             data[entry.request_id] = entry.to_dict()
+            if canonical is None or canonical == entry.request_id:
+                if index.get(effect_id) != entry.request_id:
+                    index[effect_id] = entry.request_id
+                    dirty = True
+            if dirty:
+                self._save_effect_index_unlocked(index)
 
         with self._lock:
             self._file.read_modify_write(mutate)
@@ -1044,18 +1233,36 @@ class FileLedgerStorage(LedgerStorage):
         outcome: list[tuple[str, LedgerEntry | None]] = []
 
         def mutate(data: dict[str, dict[str, Any]]) -> None:
-            raw = data.get(entry.request_id)
+            index = self._load_effect_index_unlocked()
+            effect_id = str(entry.effect_id or entry.request_id)
+            canonical, dirty = self._resolve_effect_locked(data, index, effect_id)
+            active_request_id = canonical or entry.request_id
+            raw = data.get(active_request_id)
             existing = LedgerEntry.from_dict(raw) if raw is not None else None
             now = time.time()
             result = claim_inflight_outcome(existing, now=now)
             if result == "completed":
+                if dirty:
+                    self._save_effect_index_unlocked(index)
                 outcome.append(("completed", existing))
                 return
             if result == "in_flight":
+                if dirty:
+                    self._save_effect_index_unlocked(index)
                 outcome.append(("in_flight", existing))
                 return
-            leased = with_lease(entry, now=now, lease_ttl=lease_ttl, prior=existing)
-            data[entry.request_id] = leased.to_dict()
+            claim_entry = (
+                entry
+                if active_request_id == entry.request_id
+                else replace(entry, request_id=active_request_id)
+            )
+            leased = with_lease(claim_entry, now=now, lease_ttl=lease_ttl, prior=existing)
+            data[active_request_id] = leased.to_dict()
+            if index.get(effect_id) != active_request_id:
+                index[effect_id] = active_request_id
+                dirty = True
+            if dirty:
+                self._save_effect_index_unlocked(index)
             outcome.append(("claimed", None))
 
         with self._lock:
@@ -1075,6 +1282,8 @@ class FileLedgerStorage(LedgerStorage):
         result: list[bool] = []
 
         def mutate(data: dict[str, dict[str, Any]]) -> None:
+            index = self._load_effect_index_unlocked()
+            dirty = False
             raw = data.get(entry.request_id)
             if raw is None:
                 result.append(False)
@@ -1098,6 +1307,15 @@ class FileLedgerStorage(LedgerStorage):
                 result.append(False)
                 return
             data[entry.request_id] = entry.to_dict()
+            effect_id = str(entry.effect_id or entry.request_id)
+            canonical, canonical_dirty = self._resolve_effect_locked(data, index, effect_id)
+            dirty = dirty or canonical_dirty
+            if canonical is None or canonical == entry.request_id:
+                if index.get(effect_id) != entry.request_id:
+                    index[effect_id] = entry.request_id
+                    dirty = True
+            if dirty:
+                self._save_effect_index_unlocked(index)
             result.append(True)
 
         with self._lock:
@@ -1105,8 +1323,38 @@ class FileLedgerStorage(LedgerStorage):
         return result[0]
 
     def list_all(self) -> list[LedgerEntry]:
-        data = self._file.load()
-        return [LedgerEntry.from_dict(raw) for raw in data.values()]
+        def read(data: dict[str, dict[str, Any]]) -> list[LedgerEntry]:
+            return [LedgerEntry.from_dict(raw) for raw in data.values()]
+
+        with self._lock:
+            return self._file.read_modify_write_no_save(read)
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        def read(data: dict[str, dict[str, Any]]) -> str | None:
+            index = self._load_effect_index_unlocked()
+            canonical, dirty = self._resolve_effect_locked(data, index, effect_id)
+            if dirty:
+                self._save_effect_index_unlocked(index)
+            return canonical
+
+        with self._lock:
+            return self._file.read_modify_write_no_save(read)
+
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        def read(data: dict[str, dict[str, Any]]) -> LedgerEntry | None:
+            index = self._load_effect_index_unlocked()
+            canonical, dirty = self._resolve_effect_locked(data, index, effect_id)
+            if dirty:
+                self._save_effect_index_unlocked(index)
+            if canonical is None:
+                return None
+            raw = data.get(canonical)
+            if raw is None:
+                return None
+            return LedgerEntry.from_dict(raw)
+
+        with self._lock:
+            return self._file.read_modify_write_no_save(read)
 
 
 class ActionLedger:
@@ -1238,6 +1486,14 @@ class ActionLedger:
         with _storage_errors("list_all"):
             return self._storage.list_all()
 
+    def _resolve_request_id_for_effect(self, effect_id: str) -> str | None:
+        with _storage_errors("resolve_request_id"):
+            return self._storage.resolve_request_id(effect_id)
+
+    def _get_entry_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        with _storage_errors("get_by_effect_id"):
+            return self._storage.get_by_effect_id(effect_id)
+
     def _enforce_args_drift(
         self,
         tool: str,
@@ -1247,6 +1503,7 @@ class ActionLedger:
         request_id: str,
         existing: LedgerEntry | None,
         binding: ToolTransitionBinding | None = None,
+        incoming_request_id: str | None = None,
     ) -> None:
         """Block when the same dispatch ticket is reused with different args.
 
@@ -1281,11 +1538,42 @@ class ActionLedger:
         except ValueError:
             explicit = None
 
+        alias_redispatch = (
+            incoming_request_id is not None
+            and incoming_request_id != request_id
+            and existing is not None
+        )
         if existing is not None:
             stored_fp = _args_drift_fingerprint(
                 tuple(existing.args), dict(existing.kwargs), exclude=exclude
             )
-            if explicit is not None and (
+            if alias_redispatch:
+                alias_kwargs = {
+                    key: value for key, value in kwargs.items() if key != "request_id"
+                }
+                alias_fp = _args_drift_fingerprint(args, alias_kwargs, exclude=exclude)
+                stored_alias_kwargs = {
+                    key: value
+                    for key, value in dict(existing.kwargs).items()
+                    if key != "request_id"
+                }
+                stored_alias_fp = _args_drift_fingerprint(
+                    tuple(existing.args), stored_alias_kwargs, exclude=exclude
+                )
+                if (
+                    existing.tool != tool
+                    or (
+                        not alias_redispatch
+                        and _identity_scopes_differ(existing, kwargs, binding)
+                    )
+                    or stored_alias_fp != alias_fp
+                ):
+                    self._raise_identity_conflict(
+                        tool,
+                        request_id=incoming_request_id,
+                        conflict=existing,
+                    )
+            elif explicit is not None and (
                 existing.tool != tool
                 or _identity_scopes_differ(existing, kwargs, binding)
                 or stored_fp != incoming_fp
@@ -1293,7 +1581,7 @@ class ActionLedger:
                 # Host-owned request_id is the identity: mismatch is
                 # fail-closed even when on_args_drift is off.
                 self._raise_identity_conflict(tool, request_id=request_id, conflict=existing)
-            if stored_fp != incoming_fp:
+            elif stored_fp != incoming_fp:
                 conflict = existing
 
         if self._on_args_drift == ARGS_DRIFT_OFF:
@@ -1758,6 +2046,8 @@ class ActionLedger:
         *,
         binding: ToolTransitionBinding | None = None,
         _provider_key_first_attempt_at: float | None = None,
+        _provider_idempotency_key: str | None = None,
+        _effect_id: str | None = None,
     ) -> LedgerEntry:
         bound = _bind_args(args, kwargs)
         boundary = (
@@ -1765,9 +2055,9 @@ class ActionLedger:
             if binding is not None
             else SideEffectBoundary.NOT_CROSSED.value
         )
-        provider_key = (
-            extract_provider_idempotency_key(kwargs, binding) if binding is not None else None
-        )
+        provider_key = _provider_idempotency_key
+        if provider_key is None and binding is not None:
+            provider_key = extract_provider_idempotency_key(kwargs, binding)
         if provider_key is not None and _provider_key_first_attempt_at is None:
             pkey_first_attempt: float | None = time.time()
         else:
@@ -1788,7 +2078,13 @@ class ActionLedger:
         # derive_request_id's fallback, so request_id == effect_id whenever
         # request_id itself was derived (the default) rather than explicit.
         effect_id = (
-            derive_effect_id_for_call(tool, args, kwargs, binding) if binding is not None else None
+            _effect_id
+            if _effect_id is not None
+            else (
+                derive_effect_id_for_call(tool, args, kwargs, binding)
+                if binding is not None
+                else None
+            )
         )
         return LedgerEntry(
             request_id=request_id,
@@ -2534,6 +2830,7 @@ class ActionLedger:
             if existing.provider_idempotency_key is not None
             else None
         )
+        explicit_provider_key = extract_provider_idempotency_key(kwargs, binding)
         fresh = self._new_inflight_entry(
             request_id,
             tool,
@@ -2541,6 +2838,11 @@ class ActionLedger:
             kwargs,
             binding=binding,
             _provider_key_first_attempt_at=pkey_first,
+            _provider_idempotency_key=(
+                explicit_provider_key
+                if explicit_provider_key is not None
+                else existing.provider_idempotency_key
+            ),
         )
         now = time.time()
         fresh = replace(
@@ -2558,6 +2860,56 @@ class ActionLedger:
             return None
         _outcome_reexec_authorized.set(True)
         return fresh
+
+    def _record_request_id_alias(self, canonical_request_id: str, supplied_request_id: str) -> None:
+        """Best-effort audit stamp for explicit request-id aliases."""
+        if canonical_request_id == supplied_request_id:
+            return
+        existing = self.get(canonical_request_id)
+        if existing is None:
+            return
+        if supplied_request_id in existing.request_id_aliases:
+            return
+        updated = replace(
+            existing,
+            request_id_aliases=existing.request_id_aliases + (supplied_request_id,),
+        )
+        self._try_transition(
+            updated,
+            expected_from=frozenset({existing.terminal_outcome}),
+            expected_owner=existing.owner,
+            expected_fence=existing.fence,
+        )
+
+    def _canonical_request_id_for_effect(
+        self,
+        *,
+        effect_id: str,
+        request_id: str,
+    ) -> str:
+        canonical = self._resolve_request_id_for_effect(effect_id)
+        if canonical is None:
+            return request_id
+        if canonical != request_id:
+            self._record_request_id_alias(canonical, request_id)
+        return canonical
+
+    @staticmethod
+    def _effective_incoming_provider_key(
+        *,
+        binding: ToolTransitionBinding,
+        kwargs: dict[str, Any],
+        effect_id: str,
+        existing: LedgerEntry | None,
+    ) -> str | None:
+        incoming = extract_provider_idempotency_key(kwargs, binding)
+        if incoming is not None:
+            return incoming
+        if not should_propagate_effect_id_as_provider_key(binding):
+            return None
+        if existing is not None and existing.provider_idempotency_key is not None:
+            return existing.provider_idempotency_key
+        return effect_id
 
     def claim_side_effecting(
         self,
@@ -2577,17 +2929,30 @@ class ActionLedger:
         interval = self._poll_interval if poll_interval is None else poll_interval
         timeout = self._poll_timeout if poll_timeout is None else poll_timeout
         poll_deadline = time.time() + timeout if timeout is not None else None
-        incoming_key = extract_provider_idempotency_key(kwargs, binding)
+        effect_id = derive_effect_id_for_call(tool, args, kwargs, binding)
 
         while True:
-            existing = self.get(request_id)
+            claim_kwargs = _claim_kwargs(dict(kwargs), _drop_ledger_keys(dict(kwargs)))
+            canonical_request_id = self._canonical_request_id_for_effect(
+                effect_id=effect_id,
+                request_id=request_id,
+            )
+            existing = self.get(canonical_request_id)
+            explicit_provider_key = extract_provider_idempotency_key(kwargs, binding)
+            incoming_key = self._effective_incoming_provider_key(
+                binding=binding,
+                kwargs=kwargs,
+                effect_id=effect_id,
+                existing=existing,
+            )
             self._enforce_args_drift(
                 tool,
                 args,
-                kwargs,
-                request_id=request_id,
+                claim_kwargs,
+                request_id=canonical_request_id,
                 existing=existing,
                 binding=binding,
+                incoming_request_id=request_id,
             )
             if existing is not None:
                 gate = resolve_side_effect_gate(
@@ -2596,19 +2961,19 @@ class ActionLedger:
                     incoming_provider_idempotency_key=incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
-                    self.repair_transition(request_id)
+                    self.repair_transition(canonical_request_id)
                     continue
                 if gate == TransitionGate.RETURN:
-                    return existing
+                    return self.get(canonical_request_id) or existing
                 if gate == TransitionGate.HARD_BLOCK:
                     entry = self._reconcile_or_hard_block(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                         if getattr(_reconcile_cas_lost, "val", False):
                             _reconcile_cas_lost.val = False
                             self._poll_side_effecting(
-                                request_id,
+                                canonical_request_id,
                                 tool=tool,
                                 interval=interval,
                                 poll_deadline=poll_deadline,
@@ -2617,7 +2982,7 @@ class ActionLedger:
                     return entry
                 if gate == TransitionGate.POLL:
                     self._poll_side_effecting(
-                        request_id,
+                        canonical_request_id,
                         tool=tool,
                         interval=interval,
                         poll_deadline=poll_deadline,
@@ -2625,13 +2990,13 @@ class ActionLedger:
                     continue
                 if gate == TransitionGate.ALLOW:
                     settled = self._prefer_settle_before_unknown_allow(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if settled is not None:
                         return settled
                     if existing.resolved_terminal_outcome() == TerminalOutcome.UNKNOWN:
                         reset = self._reset_unknown_for_same_key_retry(
-                            request_id,
+                            canonical_request_id,
                             tool,
                             args,
                             kwargs,
@@ -2643,18 +3008,20 @@ class ActionLedger:
                             return reset
                         if self._blind_never_retries(tool, binding, existing):
                             return self._raise_hard_block(
-                                request_id, tool, existing, binding=binding
+                                canonical_request_id, tool, existing, binding=binding
                             )
                         continue
                     if self._blind_never_retries(tool, binding, existing):
-                        return self._raise_hard_block(request_id, tool, existing, binding=binding)
+                        return self._raise_hard_block(
+                            canonical_request_id, tool, existing, binding=binding
+                        )
                     if self._reclaim_requires_death_signal and not has_worker_death_evidence(
                         existing,
                         now=time.time(),
                         presumed_dead_after=self._presumed_dead_after,
                     ):
                         self._poll_side_effecting(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
@@ -2667,36 +3034,53 @@ class ActionLedger:
                 else None
             )
             entry = self._new_inflight_entry(
-                request_id,
+                canonical_request_id,
                 tool,
                 args,
-                kwargs,
+                claim_kwargs,
                 binding=binding,
                 _provider_key_first_attempt_at=_old_pkey_attempt,
+                _provider_idempotency_key=(
+                    explicit_provider_key
+                    if explicit_provider_key is not None
+                    else (
+                        existing.provider_idempotency_key
+                        if existing is not None
+                        else None
+                    )
+                ),
+                _effect_id=effect_id,
             )
             outcome, existing = self._try_claim_inflight(entry, lease_ttl=ttl)
             if outcome == "completed" and existing is not None:
                 return existing
             if outcome == "in_flight" and existing is not None:
+                canonical_request_id = existing.request_id
+                incoming_key = self._effective_incoming_provider_key(
+                    binding=binding,
+                    kwargs=kwargs,
+                    effect_id=effect_id,
+                    existing=existing,
+                )
                 gate = resolve_side_effect_gate(
                     existing,
                     binding,
                     incoming_provider_idempotency_key=incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
-                    self.repair_transition(request_id)
+                    self.repair_transition(canonical_request_id)
                     continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
                     entry = self._reconcile_or_hard_block(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                         if getattr(_reconcile_cas_lost, "val", False):
                             _reconcile_cas_lost.val = False
                             self._poll_side_effecting(
-                                request_id,
+                                canonical_request_id,
                                 tool=tool,
                                 interval=interval,
                                 poll_deadline=poll_deadline,
@@ -2707,7 +3091,7 @@ class ActionLedger:
                     tool, binding, existing
                 ):
                     self._poll_side_effecting(
-                        request_id,
+                        canonical_request_id,
                         tool=tool,
                         interval=interval,
                         poll_deadline=poll_deadline,
@@ -2720,31 +3104,32 @@ class ActionLedger:
                         presumed_dead_after=self._presumed_dead_after,
                     ):
                         self._poll_side_effecting(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
                         )
                         continue
                 self._poll_side_effecting(
-                    request_id,
+                    canonical_request_id,
                     tool=tool,
                     interval=interval,
                     poll_deadline=poll_deadline,
                 )
                 continue
             if outcome == "claimed":
-                claimed = self.get(request_id)
+                claimed = self.get(canonical_request_id)
                 return claimed if claimed is not None else entry
             if existing is not None:
+                canonical_request_id = existing.request_id
                 entry = self._reconcile_or_hard_block(
-                    request_id, tool, args, kwargs, existing, binding
+                    canonical_request_id, tool, args, kwargs, existing, binding
                 )
                 if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                     if getattr(_reconcile_cas_lost, "val", False):
                         _reconcile_cas_lost.val = False
                         self._poll_side_effecting(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
@@ -2753,7 +3138,8 @@ class ActionLedger:
                     return entry
                 return entry
             raise LedgerError(
-                f"Unexpected claim outcome {outcome!r} for side-effecting tool {tool!r}"
+                f"Unexpected claim outcome {outcome!r} for side-effecting tool {tool!r} "
+                f"(request_id={canonical_request_id!r})"
             )
 
     def _poll_side_effecting(
@@ -2833,17 +3219,30 @@ class ActionLedger:
         interval = self._poll_interval if poll_interval is None else poll_interval
         timeout = self._poll_timeout if poll_timeout is None else poll_timeout
         poll_deadline = time.time() + timeout if timeout is not None else None
-        incoming_key = extract_provider_idempotency_key(kwargs, binding)
+        effect_id = derive_effect_id_for_call(tool, args, kwargs, binding)
 
         while True:
-            existing = self.get(request_id)
+            claim_kwargs = _claim_kwargs(dict(kwargs), _drop_ledger_keys(dict(kwargs)))
+            canonical_request_id = self._canonical_request_id_for_effect(
+                effect_id=effect_id,
+                request_id=request_id,
+            )
+            existing = self.get(canonical_request_id)
+            explicit_provider_key = extract_provider_idempotency_key(kwargs, binding)
+            incoming_key = self._effective_incoming_provider_key(
+                binding=binding,
+                kwargs=kwargs,
+                effect_id=effect_id,
+                existing=existing,
+            )
             self._enforce_args_drift(
                 tool,
                 args,
-                kwargs,
-                request_id=request_id,
+                claim_kwargs,
+                request_id=canonical_request_id,
                 existing=existing,
                 binding=binding,
+                incoming_request_id=request_id,
             )
             if existing is not None:
                 gate = resolve_side_effect_gate(
@@ -2852,19 +3251,19 @@ class ActionLedger:
                     incoming_provider_idempotency_key=incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
-                    self.repair_transition(request_id)
+                    self.repair_transition(canonical_request_id)
                     continue
                 if gate == TransitionGate.RETURN:
-                    return existing
+                    return self.get(canonical_request_id) or existing
                 if gate == TransitionGate.HARD_BLOCK:
                     entry = await self._reconcile_or_hard_block_async(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                         if getattr(_reconcile_cas_lost, "val", False):
                             _reconcile_cas_lost.val = False
                             await self._poll_side_effecting_async(
-                                request_id,
+                                canonical_request_id,
                                 tool=tool,
                                 interval=interval,
                                 poll_deadline=poll_deadline,
@@ -2873,7 +3272,7 @@ class ActionLedger:
                     return entry
                 if gate == TransitionGate.POLL:
                     await self._poll_side_effecting_async(
-                        request_id,
+                        canonical_request_id,
                         tool=tool,
                         interval=interval,
                         poll_deadline=poll_deadline,
@@ -2881,13 +3280,13 @@ class ActionLedger:
                     continue
                 if gate == TransitionGate.ALLOW:
                     settled = await self._prefer_settle_before_unknown_allow_async(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if settled is not None:
                         return settled
                     if existing.resolved_terminal_outcome() == TerminalOutcome.UNKNOWN:
                         reset = self._reset_unknown_for_same_key_retry(
-                            request_id,
+                            canonical_request_id,
                             tool,
                             args,
                             kwargs,
@@ -2899,18 +3298,20 @@ class ActionLedger:
                             return reset
                         if self._blind_never_retries(tool, binding, existing):
                             return self._raise_hard_block(
-                                request_id, tool, existing, binding=binding
+                                canonical_request_id, tool, existing, binding=binding
                             )
                         continue
                     if self._blind_never_retries(tool, binding, existing):
-                        return self._raise_hard_block(request_id, tool, existing, binding=binding)
+                        return self._raise_hard_block(
+                            canonical_request_id, tool, existing, binding=binding
+                        )
                     if self._reclaim_requires_death_signal and not has_worker_death_evidence(
                         existing,
                         now=time.time(),
                         presumed_dead_after=self._presumed_dead_after,
                     ):
                         await self._poll_side_effecting_async(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
@@ -2923,36 +3324,53 @@ class ActionLedger:
                 else None
             )
             entry = self._new_inflight_entry(
-                request_id,
+                canonical_request_id,
                 tool,
                 args,
-                kwargs,
+                claim_kwargs,
                 binding=binding,
                 _provider_key_first_attempt_at=_old_pkey_attempt,
+                _provider_idempotency_key=(
+                    explicit_provider_key
+                    if explicit_provider_key is not None
+                    else (
+                        existing.provider_idempotency_key
+                        if existing is not None
+                        else None
+                    )
+                ),
+                _effect_id=effect_id,
             )
             outcome, existing = self._try_claim_inflight(entry, lease_ttl=ttl)
             if outcome == "completed" and existing is not None:
                 return existing
             if outcome == "in_flight" and existing is not None:
+                canonical_request_id = existing.request_id
+                incoming_key = self._effective_incoming_provider_key(
+                    binding=binding,
+                    kwargs=kwargs,
+                    effect_id=effect_id,
+                    existing=existing,
+                )
                 gate = resolve_side_effect_gate(
                     existing,
                     binding,
                     incoming_provider_idempotency_key=incoming_key,
                 )
                 if gate == TransitionGate.REPAIR:
-                    self.repair_transition(request_id)
+                    self.repair_transition(canonical_request_id)
                     continue
                 if gate == TransitionGate.RETURN:
                     return existing
                 if gate == TransitionGate.HARD_BLOCK:
                     entry = await self._reconcile_or_hard_block_async(
-                        request_id, tool, args, kwargs, existing, binding
+                        canonical_request_id, tool, args, kwargs, existing, binding
                     )
                     if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                         if getattr(_reconcile_cas_lost, "val", False):
                             _reconcile_cas_lost.val = False
                             await self._poll_side_effecting_async(
-                                request_id,
+                                canonical_request_id,
                                 tool=tool,
                                 interval=interval,
                                 poll_deadline=poll_deadline,
@@ -2963,7 +3381,7 @@ class ActionLedger:
                     tool, binding, existing
                 ):
                     await self._poll_side_effecting_async(
-                        request_id,
+                        canonical_request_id,
                         tool=tool,
                         interval=interval,
                         poll_deadline=poll_deadline,
@@ -2976,31 +3394,32 @@ class ActionLedger:
                         presumed_dead_after=self._presumed_dead_after,
                     ):
                         await self._poll_side_effecting_async(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
                         )
                         continue
                 await self._poll_side_effecting_async(
-                    request_id,
+                    canonical_request_id,
                     tool=tool,
                     interval=interval,
                     poll_deadline=poll_deadline,
                 )
                 continue
             if outcome == "claimed":
-                claimed = self.get(request_id)
+                claimed = self.get(canonical_request_id)
                 return claimed if claimed is not None else entry
             if existing is not None:
+                canonical_request_id = existing.request_id
                 entry = await self._reconcile_or_hard_block_async(
-                    request_id, tool, args, kwargs, existing, binding
+                    canonical_request_id, tool, args, kwargs, existing, binding
                 )
                 if entry.resolved_terminal_outcome() == TerminalOutcome.IN_FLIGHT:
                     if getattr(_reconcile_cas_lost, "val", False):
                         _reconcile_cas_lost.val = False
                         await self._poll_side_effecting_async(
-                            request_id,
+                            canonical_request_id,
                             tool=tool,
                             interval=interval,
                             poll_deadline=poll_deadline,
@@ -3009,7 +3428,8 @@ class ActionLedger:
                     return entry
                 return entry
             raise LedgerError(
-                f"Unexpected claim outcome {outcome!r} for side-effecting tool {tool!r}"
+                f"Unexpected claim outcome {outcome!r} for side-effecting tool {tool!r} "
+                f"(request_id={canonical_request_id!r})"
             )
 
     async def _poll_side_effecting_async(
@@ -3255,6 +3675,57 @@ class ActionLedger:
         ):
             raise LedgerOutcomeAlreadySetError(
                 f"Cannot attach external operation ref to {request_id!r}: transition superseded"
+            )
+        return entry
+
+    def attach_provider_idempotency_key(
+        self,
+        request_id: str,
+        provider_key: str,
+        *,
+        expected_owner: str | None = None,
+        expected_fence: int | None = None,
+    ) -> LedgerEntry:
+        """Persist provider idempotency key on the claimed transition row.
+
+        Used by wrapper-path auto-propagation (effect_id -> provider key):
+        after ATTEMPTING decision CAS succeeds, before tool body starts.
+        """
+        existing = self._get_entry(request_id)
+        if existing is None:
+            raise LedgerError(
+                f"Cannot attach provider idempotency key to unknown request {request_id!r}"
+            )
+        if expected_fence is None:
+            raise LedgerError(
+                f"Attaching provider idempotency key to {request_id!r} requires the claim fence"
+            )
+        key = str(provider_key)
+        stored_provider_key = existing.provider_idempotency_key
+        if stored_provider_key is not None and stored_provider_key != key:
+            raise LedgerOutcomeAlreadySetError(
+                f"Cannot attach provider idempotency key to {request_id!r}: key mismatch "
+                f"({existing.provider_idempotency_key!r} != {key!r})"
+            )
+        first_attempt = existing.provider_key_first_attempt_at
+        if first_attempt is None:
+            first_attempt = time.time()
+        entry = replace(
+            existing,
+            provider_idempotency_key=key,
+            provider_key_first_attempt_at=first_attempt,
+        )
+        if not self._try_transition(
+            entry,
+            expected_from=frozenset({existing.terminal_outcome}),
+            expected_owner=expected_owner,
+            expected_fence=expected_fence,
+            expected_effect_state=(
+                EffectState.ATTEMPTING.value if existing.effect_protocol_required else None
+            ),
+        ):
+            raise LedgerOutcomeAlreadySetError(
+                f"Cannot attach provider idempotency key to {request_id!r}: transition superseded"
             )
         return entry
 
@@ -4299,6 +4770,51 @@ def _raise_denied_decision(request_id: str, decision: Any) -> None:
         )
 
 
+def _ensure_provider_key_for_execution(
+    *,
+    ledger: ActionLedger,
+    request_id: str,
+    transition_binding: ToolTransitionBinding | None,
+    claimed_entry: LedgerEntry,
+    clean_kwargs: dict[str, Any],
+    call_mapping: dict[str, Any],
+    owner: str | None,
+    fence: int,
+) -> LedgerEntry:
+    """Inject and persist provider key from effect_id when policy requests it."""
+    if transition_binding is None:
+        return claimed_entry
+    param = transition_binding.provider_idempotency_key_param
+    if param is None:
+        return claimed_entry
+    if clean_kwargs.get(param) is not None:
+        return claimed_entry
+    if not should_propagate_effect_id_as_provider_key(transition_binding):
+        return claimed_entry
+    provider_key = claimed_entry.provider_idempotency_key or claimed_entry.effect_id
+    if provider_key is None:
+        raise LedgerError(
+            f"Cannot derive provider idempotency key for {request_id!r}: missing effect_id"
+        )
+    updated = ledger.attach_provider_idempotency_key(
+        request_id,
+        provider_key,
+        expected_owner=owner,
+        expected_fence=fence,
+    )
+    clean_kwargs[param] = provider_key
+    call_mapping[param] = provider_key
+    active = _active_transition_var.get()
+    if active is not None and active.request_id == request_id:
+        _active_transition_var.set(
+            replace(
+                active,
+                call_kwargs={**dict(active.call_kwargs), param: provider_key},
+            )
+        )
+    return updated
+
+
 def _identity_lookup_kwargs(
     func: Callable[..., Any],
     args: tuple[Any, ...],
@@ -4375,6 +4891,7 @@ def _run_ledgered(
                 request_id,
             )
         raise
+    request_id = existing.request_id
     if existing.is_terminal_completed():
         ledger._emit_outcome(
             request_id=request_id,
@@ -4542,6 +5059,16 @@ def _run_ledgered(
         if policy_blocked is not None:
             raise policy_blocked
         _raise_denied_decision(request_id, decision)
+        existing = _ensure_provider_key_for_execution(
+            ledger=ledger,
+            request_id=request_id,
+            transition_binding=transition_binding,
+            claimed_entry=existing,
+            clean_kwargs=clean_kwargs,
+            call_mapping=call_mapping,
+            owner=owner,
+            fence=fence,
+        )
 
         ledger._emit_outcome(
             request_id=request_id,
@@ -4741,6 +5268,7 @@ async def _run_ledgered_async(
                 request_id,
             )
         raise
+    request_id = existing.request_id
     if existing.is_terminal_completed():
         ledger._emit_outcome(
             request_id=request_id,
@@ -4908,6 +5436,16 @@ async def _run_ledgered_async(
         if policy_blocked is not None:
             raise policy_blocked
         _raise_denied_decision(request_id, decision)
+        existing = _ensure_provider_key_for_execution(
+            ledger=ledger,
+            request_id=request_id,
+            transition_binding=transition_binding,
+            claimed_entry=existing,
+            clean_kwargs=clean_kwargs,
+            call_mapping=call_mapping,
+            owner=owner,
+            fence=fence,
+        )
 
         ledger._emit_outcome(
             request_id=request_id,

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -359,6 +359,7 @@ class ToolConfig:
     capability: ToolCapability | None = None
     provider_idempotency_key_param: str | None = None
     provider_idempotency_key_ttl: float | None = None
+    propagate_effect_id_as_provider_key: bool = False
     request_id_from: str | None = None
     callable_path: str | None = None
     # Per-tool loop_guard: None=inherit global, False=disable, dict=overrides
@@ -1750,6 +1751,9 @@ class MyceliumConfig:
             provider_idempotency_key_ttl=(
                 tool_config.provider_idempotency_key_ttl
             ),
+            propagate_effect_id_as_provider_key=(
+                tool_config.propagate_effect_id_as_provider_key
+            ),
             request_id_from=tool_config.request_id_from,
         )
 
@@ -2238,6 +2242,20 @@ def _parse_tool_config(
             )
         provider_idempotency_key_ttl = float(value)
 
+    propagate_effect_id_as_provider_key = False
+    if "propagate_effect_id_as_provider_key" in raw:
+        value = raw["propagate_effect_id_as_provider_key"]
+        if not isinstance(value, bool):
+            raise ConfigError(
+                f"tool '{name}': propagate_effect_id_as_provider_key must be a bool"
+            )
+        propagate_effect_id_as_provider_key = value
+    if propagate_effect_id_as_provider_key and provider_idempotency_key_param is None:
+        raise ConfigError(
+            f"tool '{name}': propagate_effect_id_as_provider_key requires "
+            "provider_idempotency_key_param"
+        )
+
     request_id_from: str | None = None
     if "request_id_from" in raw:
         value = raw["request_id_from"]
@@ -2368,6 +2386,7 @@ def _parse_tool_config(
         capability=capability,
         provider_idempotency_key_param=provider_idempotency_key_param,
         provider_idempotency_key_ttl=provider_idempotency_key_ttl,
+        propagate_effect_id_as_provider_key=propagate_effect_id_as_provider_key,
         request_id_from=request_id_from,
         callable_path=callable_path,
         loop_guard=loop_guard_cfg,
@@ -2477,6 +2496,7 @@ def _apply_action_ledger_tools(
             spendability=existing.spendability,
             provider_idempotency_key_param=existing.provider_idempotency_key_param,
             provider_idempotency_key_ttl=existing.provider_idempotency_key_ttl,
+            propagate_effect_id_as_provider_key=existing.propagate_effect_id_as_provider_key,
             request_id_from=existing.request_id_from,
             callable_path=existing.callable_path,
             loop_guard=existing.loop_guard,

--- a/sdk/mycelium/storage/postgres_ledger.py
+++ b/sdk/mycelium/storage/postgres_ledger.py
@@ -6,6 +6,7 @@ import json
 import re
 import time
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any, TypeVar
 
 from mycelium.storage._helpers import ClaimOutcome, claim_inflight_outcome, with_lease
@@ -62,14 +63,26 @@ class PostgresEntryStorage:
     def _table_id(self) -> Any:
         return self._sql.Identifier(self._table)
 
+    def _effect_index_id(self) -> Any:
+        return self._sql.Identifier(f"{self._table}_effect_id_unique")
+
+    @staticmethod
+    def _effect_id_for_entry(entry: Any) -> str:
+        return str(getattr(entry, "effect_id", None) or entry.request_id)
+
     def _ensure_schema(self) -> None:
         if self._schema_ready:
             return
         query = self._sql.SQL(
             "CREATE TABLE IF NOT EXISTS {} (request_id TEXT PRIMARY KEY, payload JSONB NOT NULL)"
         ).format(self._table_id())
+        effect_index = self._sql.SQL(
+            "CREATE UNIQUE INDEX IF NOT EXISTS {} ON {} "
+            "((COALESCE(payload->>'effect_id', request_id)))"
+        ).format(self._effect_index_id(), self._table_id())
         with self._psycopg.connect(self._dsn) as conn:
             conn.execute(query)
+            conn.execute(effect_index)
             conn.commit()
         self._schema_ready = True
 
@@ -87,11 +100,21 @@ class PostgresEntryStorage:
     def set(self, entry: E) -> None:
         self._ensure_schema()
         payload = json.loads(json.dumps(entry.to_dict(), default=str))
+        effect_id = self._effect_id_for_entry(entry)
+        lookup_query = self._sql.SQL(
+            "SELECT request_id FROM {} "
+            "WHERE COALESCE(payload->>'effect_id', request_id) = %s "
+            "LIMIT 1"
+        ).format(self._table_id())
         query = self._sql.SQL(
             "INSERT INTO {} (request_id, payload) VALUES (%s, %s::jsonb) "
             "ON CONFLICT (request_id) DO UPDATE SET payload = EXCLUDED.payload"
         ).format(self._table_id())
         with self._psycopg.connect(self._dsn) as conn:
+            existing = conn.execute(lookup_query, (effect_id,)).fetchone()
+            if existing is not None and str(existing[0]) != entry.request_id:
+                conn.commit()
+                return
             conn.execute(query, (entry.request_id, json.dumps(payload)))
             conn.commit()
 
@@ -103,14 +126,22 @@ class PostgresEntryStorage:
     ) -> tuple[ClaimOutcome, E | None]:
         self._ensure_schema()
         now = time.time()
+        effect_id = self._effect_id_for_entry(entry)
         fresh = with_lease(entry, now=now, lease_ttl=lease_ttl)
         payload = json.loads(json.dumps(fresh.to_dict(), default=str))
         insert_query = self._sql.SQL(
             "INSERT INTO {} (request_id, payload) VALUES (%s, %s::jsonb) "
-            "ON CONFLICT (request_id) DO NOTHING RETURNING request_id"
+            "ON CONFLICT DO NOTHING RETURNING request_id"
         ).format(self._table_id())
         select_for_update = self._sql.SQL(
-            "SELECT payload FROM {} WHERE request_id = %s FOR UPDATE"
+            "SELECT request_id, payload FROM {} WHERE request_id = %s FOR UPDATE"
+        ).format(self._table_id())
+        select_by_effect = self._sql.SQL(
+            "SELECT request_id, payload FROM {} "
+            "WHERE COALESCE(payload->>'effect_id', request_id) = %s "
+            "ORDER BY request_id "
+            "LIMIT 1 "
+            "FOR UPDATE"
         ).format(self._table_id())
         update_reclaim = self._sql.SQL(
             "UPDATE {} SET payload = %s::jsonb WHERE request_id = %s RETURNING request_id"
@@ -127,20 +158,41 @@ class PostgresEntryStorage:
 
                 row = conn.execute(select_for_update, (entry.request_id,)).fetchone()
                 if row is None:
-                    return "claimed", None
+                    row = conn.execute(select_by_effect, (effect_id,)).fetchone()
+                if row is None:
+                    inserted = conn.execute(
+                        insert_query,
+                        (entry.request_id, json.dumps(payload)),
+                    ).fetchone()
+                    if inserted is not None:
+                        return "claimed", None
+                    row = conn.execute(select_by_effect, (effect_id,)).fetchone()
+                    if row is None:
+                        return "in_flight", None
 
-                existing = self._from_dict(_payload_dict(row[0]))
+                active_request_id = str(row[0])
+                existing = self._from_dict(_payload_dict(row[1]))
                 outcome = claim_inflight_outcome(existing, now=now)
                 if outcome == "completed":
                     return "completed", existing
                 if outcome == "in_flight":
                     return "in_flight", existing
 
-                reclaim_entry = with_lease(entry, now=now, lease_ttl=lease_ttl, prior=existing)
+                claim_entry = (
+                    entry
+                    if active_request_id == entry.request_id
+                    else replace(entry, request_id=active_request_id)
+                )
+                reclaim_entry = with_lease(
+                    claim_entry,
+                    now=now,
+                    lease_ttl=lease_ttl,
+                    prior=existing,
+                )
                 reclaim_payload = json.loads(json.dumps(reclaim_entry.to_dict(), default=str))
                 reclaimed = conn.execute(
                     update_reclaim,
-                    (json.dumps(reclaim_payload), entry.request_id),
+                    (json.dumps(reclaim_payload), active_request_id),
                 ).fetchone()
                 if reclaimed is not None:
                     return "claimed", None
@@ -206,6 +258,25 @@ class PostgresEntryStorage:
             rows = conn.execute(query).fetchall()
         return [self._from_dict(_payload_dict(row[0])) for row in rows]
 
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        self._ensure_schema()
+        query = self._sql.SQL(
+            "SELECT request_id FROM {} "
+            "WHERE COALESCE(payload->>'effect_id', request_id) = %s "
+            "ORDER BY request_id LIMIT 1"
+        ).format(self._table_id())
+        with self._psycopg.connect(self._dsn) as conn:
+            row = conn.execute(query, (effect_id,)).fetchone()
+        if row is None:
+            return None
+        return str(row[0])
+
+    def get_by_effect_id(self, effect_id: str) -> E | None:
+        request_id = self.resolve_request_id(effect_id)
+        if request_id is None:
+            return None
+        return self.get(request_id)
+
 
 class PostgresLedgerStorage:
     """Postgres storage for :class:`~mycelium.action_ledger.LedgerEntry`."""
@@ -240,6 +311,12 @@ class PostgresLedgerStorage:
 
     def list_all(self) -> list[Any]:
         return self._inner.list_all()
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        return self._inner.resolve_request_id(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> Any | None:
+        return self._inner.get_by_effect_id(effect_id)
 
     def try_transition(
         self,
@@ -294,3 +371,9 @@ class PostgresTaskLedgerStorage:
 
     def list_all(self) -> list[Any]:
         return self._inner.list_all()
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        return self._inner.resolve_request_id(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> Any | None:
+        return self._inner.get_by_effect_id(effect_id)

--- a/sdk/mycelium/storage/redis_ledger.py
+++ b/sdk/mycelium/storage/redis_ledger.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any, TypeVar
 
 from mycelium.storage._helpers import ClaimOutcome
@@ -53,6 +54,18 @@ class RedisEntryStorage:
         # Sibling namespace so list_all(prefix*) never treats tombs as entries.
         base = self._prefix.rstrip(":")
         return f"{base}-tomb:{request_id}"
+
+    def _effect_key(self, effect_id: str) -> str:
+        base = self._prefix.rstrip(":")
+        return f"{base}-effect:{effect_id}"
+
+    @staticmethod
+    def _effect_id_for_entry(entry: Any) -> str:
+        return str(getattr(entry, "effect_id", None) or entry.request_id)
+
+    @staticmethod
+    def _effect_id_from_payload(payload: dict[str, Any], request_id: str) -> str:
+        return str(payload.get("effect_id") or request_id)
 
     @staticmethod
     def _fence_from_payload(raw: str | None) -> int:
@@ -116,15 +129,73 @@ class RedisEntryStorage:
                         return None
                     tomb = self._from_dict(json.loads(tomb_raw))
                     ghost = self._ghost_from_tombstone(tomb, now=now)
+                    effect_id = self._effect_id_for_entry(ghost)
+                    effect_key = self._effect_key(effect_id)
+                    pipe.watch(effect_key)
+                    canonical = pipe.get(effect_key)
+                    if canonical is not None and str(canonical) != request_id:
+                        canonical_request_id = str(canonical)
+                        canonical_raw = pipe.get(self._key(canonical_request_id))
+                        if canonical_raw is not None:
+                            return self._from_dict(json.loads(canonical_raw))
+                        canonical_tomb = pipe.get(self._tombstone_key(canonical_request_id))
+                        if canonical_tomb is not None:
+                            return self._from_dict(json.loads(canonical_tomb))
+                        return None
                     payload = json.dumps(ghost.to_dict(), default=str)
                     pipe.multi()
                     pipe.set(key, payload)
                     pipe.set(tomb_key, payload)
+                    if canonical is None:
+                        pipe.set(effect_key, request_id)
                     pipe.execute()
                     return ghost
             except WatchError:
                 continue
         raise RuntimeError("Redis tombstone restoration exhausted WATCH retries")
+
+    def _scan_request_id_for_effect(self, effect_id: str) -> str | None:
+        pattern = f"{self._prefix}*"
+        candidates: list[tuple[float, str]] = []
+        for key in self._client.scan_iter(match=pattern):
+            raw = self._client.get(key)
+            if raw is None:
+                continue
+            payload = json.loads(raw)
+            request_id = str(payload.get("request_id") or "").strip()
+            if not request_id:
+                continue
+            if self._effect_id_from_payload(payload, request_id) != effect_id:
+                continue
+            started = payload.get("started_at")
+            try:
+                started_at = float(started) if started is not None else 0.0
+            except (TypeError, ValueError):
+                started_at = 0.0
+            candidates.append((started_at, request_id))
+        if not candidates:
+            return None
+        candidates.sort(key=lambda item: (item[0], item[1]))
+        return candidates[0][1]
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        effect_key = self._effect_key(effect_id)
+        mapped = self._client.get(effect_key)
+        if mapped:
+            canonical = str(mapped)
+            if self.get(canonical) is not None:
+                return canonical
+        canonical = self._scan_request_id_for_effect(effect_id)
+        if canonical is None:
+            return None
+        self._client.setnx(effect_key, canonical)
+        return canonical
+
+    def get_by_effect_id(self, effect_id: str) -> E | None:
+        request_id = self.resolve_request_id(effect_id)
+        if request_id is None:
+            return None
+        return self.get(request_id)
 
     def get(self, request_id: str) -> E | None:
         raw = self._client.get(self._key(request_id))
@@ -138,11 +209,21 @@ class RedisEntryStorage:
         payload = json.dumps(entry.to_dict(), default=str)
         key = self._key(entry.request_id)
         tomb_key = self._tombstone_key(entry.request_id)
+        effect_id = self._effect_id_for_entry(entry)
+        effect_key = self._effect_key(effect_id)
         incoming_fence = int(getattr(entry, "fence", 0) or 0)
         for _ in range(32):
             try:
                 with self._client.pipeline(transaction=True) as pipe:
-                    pipe.watch(key, tomb_key)
+                    pipe.watch(key, tomb_key, effect_key)
+                    canonical = pipe.get(effect_key)
+                    if (
+                        canonical is not None
+                        and str(canonical) != entry.request_id
+                        and pipe.get(key) is None
+                        and pipe.get(tomb_key) is None
+                    ):
+                        return
                     stored_fence = max(
                         self._fence_from_payload(pipe.get(key)),
                         self._fence_from_payload(pipe.get(tomb_key)),
@@ -155,6 +236,8 @@ class RedisEntryStorage:
                     else:
                         pipe.set(key, payload)
                     pipe.set(tomb_key, payload)
+                    if canonical is None:
+                        pipe.set(effect_key, entry.request_id)
                     pipe.execute()
                     return
             except WatchError:
@@ -169,13 +252,21 @@ class RedisEntryStorage:
     ) -> tuple[ClaimOutcome, E | None]:
         from mycelium.storage._helpers import claim_inflight_outcome, with_lease
 
-        key = self._key(entry.request_id)
+        effect_id = self._effect_id_for_entry(entry)
         ttl = int(max(self._in_flight_ttl or lease_ttl or 0, lease_ttl * 4))
 
         for _ in range(32):
+            canonical_request_id = self.resolve_request_id(effect_id)
+            active_request_id = canonical_request_id or entry.request_id
+            key = self._key(active_request_id)
+            claim_entry = (
+                entry
+                if active_request_id == entry.request_id
+                else replace(entry, request_id=active_request_id)
+            )
             existing_raw = self._client.get(key)
             if existing_raw is None:
-                restored = self._restore_from_tombstone(entry.request_id)
+                restored = self._restore_from_tombstone(active_request_id)
                 if restored is not None:
                     existing = restored
                     now = time.time()
@@ -185,13 +276,19 @@ class RedisEntryStorage:
                     if outcome == "in_flight":
                         return "in_flight", existing
                     # EXPIRED / retryable → CAS reclaim path below
-                    reclaimed = self._try_reclaim(key, entry, ttl, lease_ttl)
+                    reclaimed = self._try_reclaim(
+                        key,
+                        claim_entry,
+                        ttl,
+                        lease_ttl,
+                        effect_id=effect_id,
+                    )
                     if reclaimed is not None:
                         return reclaimed
                     continue
 
-                leased = with_lease(entry, now=time.time(), lease_ttl=lease_ttl)
-                if self._try_initial_claim(key, leased, ttl):
+                leased = with_lease(claim_entry, now=time.time(), lease_ttl=lease_ttl)
+                if self._try_initial_claim(key, leased, ttl, effect_id=effect_id):
                     return "claimed", None
                 continue
 
@@ -203,20 +300,30 @@ class RedisEntryStorage:
             if outcome == "in_flight":
                 return "in_flight", existing
 
-            reclaimed = self._try_reclaim(key, entry, ttl, lease_ttl)
+            reclaimed = self._try_reclaim(
+                key,
+                claim_entry,
+                ttl,
+                lease_ttl,
+                effect_id=effect_id,
+            )
             if reclaimed is not None:
                 return reclaimed
 
         raise RuntimeError("Redis claim exhausted WATCH retries")
 
-    def _try_initial_claim(self, key: str, entry: E, ttl: int) -> bool:
+    def _try_initial_claim(self, key: str, entry: E, ttl: int, *, effect_id: str) -> bool:
         from redis.exceptions import WatchError
 
         tomb_key = self._tombstone_key(entry.request_id)
+        effect_key = self._effect_key(effect_id)
         payload = json.dumps(entry.to_dict(), default=str)
         try:
             with self._client.pipeline(transaction=True) as pipe:
-                pipe.watch(key, tomb_key)
+                pipe.watch(key, tomb_key, effect_key)
+                canonical = pipe.get(effect_key)
+                if canonical is not None and str(canonical) != entry.request_id:
+                    return False
                 if pipe.get(key) is not None or pipe.get(tomb_key) is not None:
                     return False
                 pipe.multi()
@@ -225,6 +332,8 @@ class RedisEntryStorage:
                 else:
                     pipe.set(key, payload)
                 pipe.set(tomb_key, payload)
+                if canonical is None:
+                    pipe.set(effect_key, entry.request_id)
                 pipe.execute()
                 return True
         except WatchError:
@@ -236,6 +345,8 @@ class RedisEntryStorage:
         entry: E,
         ttl: int,
         lease_ttl: float,
+        *,
+        effect_id: str,
     ) -> tuple[ClaimOutcome, E | None] | None:
         """CAS reclaim: only overwrite if the stored entry is still
         reclaimable per :func:`claim_inflight_outcome`. Returns ``None``
@@ -245,9 +356,10 @@ class RedisEntryStorage:
         from mycelium.storage._helpers import claim_inflight_outcome, with_lease
 
         now = time.time()
+        effect_key = self._effect_key(effect_id)
         try:
             with self._client.pipeline(transaction=True) as pipe:
-                pipe.watch(key)
+                pipe.watch(key, effect_key)
                 raw = pipe.get(key)
                 if raw is None:
                     # Key evaporated under the watch — tombstone may still exist.
@@ -255,6 +367,10 @@ class RedisEntryStorage:
                     if restored is not None:
                         return "in_flight", restored
                     return None
+                canonical = pipe.get(effect_key)
+                if canonical is not None and str(canonical) != entry.request_id:
+                    current = self._from_dict(json.loads(raw))
+                    return "in_flight", current
                 current = self._from_dict(json.loads(raw))
                 rerun = claim_inflight_outcome(current, now=time.time())
                 if rerun != "claimed":
@@ -268,6 +384,8 @@ class RedisEntryStorage:
                 else:
                     pipe.set(key, payload)
                 pipe.set(self._tombstone_key(entry.request_id), payload)
+                if canonical is None:
+                    pipe.set(effect_key, entry.request_id)
                 pipe.execute()
                 return ("claimed", None)
         except WatchError:
@@ -288,11 +406,13 @@ class RedisEntryStorage:
         from mycelium.storage._helpers import lease_allows_renew
 
         key = self._key(entry.request_id)
+        effect_id = self._effect_id_for_entry(entry)
+        effect_key = self._effect_key(effect_id)
         payload = json.dumps(entry.to_dict(), default=str)
         for _ in range(32):
             try:
                 with self._client.pipeline(transaction=True) as pipe:
-                    pipe.watch(key)
+                    pipe.watch(key, effect_key)
                     raw = pipe.get(key)
                     if raw is None:
                         # TTL eviction mid-transition: restore history, then retry.
@@ -320,9 +440,12 @@ class RedisEntryStorage:
                         now=require_lease_held_at,
                     ):
                         return False
+                    canonical = pipe.get(effect_key)
                     pipe.multi()
                     pipe.set(key, payload)
                     pipe.set(self._tombstone_key(entry.request_id), payload)
+                    if canonical is None:
+                        pipe.set(effect_key, entry.request_id)
                     pipe.execute()
                     return True
             except WatchError:
@@ -374,6 +497,12 @@ class RedisLedgerStorage:
 
     def list_all(self) -> list[Any]:
         return self._inner.list_all()
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        return self._inner.resolve_request_id(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> Any | None:
+        return self._inner.get_by_effect_id(effect_id)
 
     def try_transition(
         self,
@@ -449,3 +578,9 @@ class RedisTaskLedgerStorage:
 
     def list_all(self) -> list[Any]:
         return self._inner.list_all()
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        return self._inner.resolve_request_id(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> Any | None:
+        return self._inner.get_by_effect_id(effect_id)

--- a/sdk/mycelium/storage/sqlite_ledger.py
+++ b/sdk/mycelium/storage/sqlite_ledger.py
@@ -8,6 +8,7 @@ import sqlite3
 import threading
 import time
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -65,12 +66,24 @@ class SqliteEntryStorage:
         conn.row_factory = sqlite3.Row
         return conn
 
+    @staticmethod
+    def _effect_id_for_entry(entry: Any) -> str:
+        return str(getattr(entry, "effect_id", None) or entry.request_id)
+
+    @staticmethod
+    def _effect_id_from_row(request_id: str, payload: dict[str, Any]) -> str:
+        return str(payload.get("effect_id") or request_id)
+
     def _ensure_schema(self, conn: sqlite3.Connection) -> None:
         if self._schema_ready:
             return
         conn.execute(
             f"CREATE TABLE IF NOT EXISTS {self._table} ("
             "request_id TEXT PRIMARY KEY, payload TEXT NOT NULL)"
+        )
+        conn.execute(
+            f"CREATE UNIQUE INDEX IF NOT EXISTS {self._table}_effect_id_unique "
+            f"ON {self._table} (COALESCE(json_extract(payload, '$.effect_id'), request_id))"
         )
         conn.commit()
         self._schema_ready = True
@@ -89,9 +102,19 @@ class SqliteEntryStorage:
 
     def set(self, entry: E) -> None:
         payload = json.dumps(entry.to_dict(), default=str)
+        effect_id = self._effect_id_for_entry(entry)
         with self._lock:
             with self._connect() as conn:
                 self._ensure_schema(conn)
+                existing = conn.execute(
+                    f"SELECT request_id FROM {self._table} "
+                    "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ? "
+                    "LIMIT 1",
+                    (effect_id,),
+                ).fetchone()
+                if existing is not None and str(existing["request_id"]) != entry.request_id:
+                    conn.commit()
+                    return
                 conn.execute(
                     f"INSERT INTO {self._table} (request_id, payload) VALUES (?, ?) "
                     "ON CONFLICT(request_id) DO UPDATE SET payload = excluded.payload",
@@ -106,8 +129,10 @@ class SqliteEntryStorage:
         lease_ttl: float = 3600.0,
     ) -> tuple[ClaimOutcome, E | None]:
         now = time.time()
-        fresh = with_lease(entry, now=now, lease_ttl=lease_ttl)
-        fresh_payload = json.dumps(fresh.to_dict(), default=str)
+        effect_id = self._effect_id_for_entry(entry)
+        fresh_payload = json.dumps(
+            with_lease(entry, now=now, lease_ttl=lease_ttl).to_dict(), default=str
+        )
 
         with self._lock:
             with self._connect() as conn:
@@ -123,18 +148,37 @@ class SqliteEntryStorage:
                         return "claimed", None
 
                     row = conn.execute(
-                        f"SELECT payload FROM {self._table} WHERE request_id = ?",
+                        f"SELECT request_id, payload FROM {self._table} WHERE request_id = ?",
                         (entry.request_id,),
                     ).fetchone()
                     if row is None:
-                        # Rare race: deleted between IGNORE miss and SELECT.
-                        conn.execute(
-                            f"INSERT INTO {self._table} (request_id, payload) VALUES (?, ?)",
+                        row = conn.execute(
+                            f"SELECT request_id, payload FROM {self._table} "
+                            "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ? "
+                            "ORDER BY request_id LIMIT 1",
+                            (effect_id,),
+                        ).fetchone()
+                    if row is None:
+                        # Rare race: row vanished between IGNORE miss and lookup.
+                        inserted = conn.execute(
+                            f"INSERT OR IGNORE INTO {self._table} "
+                            "(request_id, payload) VALUES (?, ?)",
                             (entry.request_id, fresh_payload),
                         )
-                        conn.commit()
-                        return "claimed", None
+                        if inserted.rowcount == 1:
+                            conn.commit()
+                            return "claimed", None
+                        row = conn.execute(
+                            f"SELECT request_id, payload FROM {self._table} "
+                            "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ? "
+                            "ORDER BY request_id LIMIT 1",
+                            (effect_id,),
+                        ).fetchone()
+                        if row is None:
+                            conn.commit()
+                            return "in_flight", None
 
+                    active_request_id = str(row["request_id"])
                     existing = self._from_dict(_payload_dict(row["payload"]))
                     outcome = claim_inflight_outcome(existing, now=now)
                     if outcome == "completed":
@@ -144,10 +188,17 @@ class SqliteEntryStorage:
                         conn.commit()
                         return "in_flight", existing
 
-                    reclaimed = with_lease(entry, now=now, lease_ttl=lease_ttl, prior=existing)
+                    claim_entry = (
+                        entry
+                        if active_request_id == entry.request_id
+                        else replace(entry, request_id=active_request_id)
+                    )
+                    reclaimed = with_lease(
+                        claim_entry, now=now, lease_ttl=lease_ttl, prior=existing
+                    )
                     conn.execute(
                         f"UPDATE {self._table} SET payload = ? WHERE request_id = ?",
-                        (json.dumps(reclaimed.to_dict(), default=str), entry.request_id),
+                        (json.dumps(reclaimed.to_dict(), default=str), active_request_id),
                     )
                     conn.commit()
                     return "claimed", None
@@ -207,6 +258,41 @@ class SqliteEntryStorage:
                 rows = conn.execute(f"SELECT payload FROM {self._table}").fetchall()
         return [self._from_dict(_payload_dict(row["payload"])) for row in rows]
 
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_schema(conn)
+                row = conn.execute(
+                    f"SELECT request_id FROM {self._table} "
+                    "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ? "
+                    "ORDER BY request_id LIMIT 1",
+                    (effect_id,),
+                ).fetchone()
+                if row is not None:
+                    return str(row["request_id"])
+                rows = conn.execute(f"SELECT request_id, payload FROM {self._table}").fetchall()
+        candidates: list[tuple[float, str]] = []
+        for row in rows:
+            request_id = str(row["request_id"])
+            payload = _payload_dict(row["payload"])
+            if self._effect_id_from_row(request_id, payload) == effect_id:
+                started = payload.get("started_at")
+                try:
+                    started_at = float(started) if started is not None else 0.0
+                except (TypeError, ValueError):
+                    started_at = 0.0
+                candidates.append((started_at, request_id))
+        if not candidates:
+            return None
+        candidates.sort(key=lambda item: (item[0], item[1]))
+        return candidates[0][1]
+
+    def get_by_effect_id(self, effect_id: str) -> E | None:
+        request_id = self.resolve_request_id(effect_id)
+        if request_id is None:
+            return None
+        return self.get(request_id)
+
 
 class SqliteLedgerStorage:
     """SQLite storage for :class:`~mycelium.action_ledger.LedgerEntry`."""
@@ -241,6 +327,12 @@ class SqliteLedgerStorage:
 
     def list_all(self) -> list[Any]:
         return self._inner.list_all()
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        return self._inner.resolve_request_id(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> Any | None:
+        return self._inner.get_by_effect_id(effect_id)
 
     def try_transition(
         self,
@@ -295,3 +387,9 @@ class SqliteTaskLedgerStorage:
 
     def list_all(self) -> list[Any]:
         return self._inner.list_all()
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        return self._inner.resolve_request_id(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> Any | None:
+        return self._inner.get_by_effect_id(effect_id)

--- a/sdk/mycelium/templates/mycelium.template.yaml
+++ b/sdk/mycelium/templates/mycelium.template.yaml
@@ -42,9 +42,15 @@
 # provider_idempotency_key_param (optional, per tool): names the kwarg that
 #   carries the provider idempotency key. When set, a
 #   retry_only_with_same_provider_idempotency_key retry is ALLOWED only if it
-#   reuses the same key, else HARD_BLOCK. Omit to keep the cooperative default.
+#   reuses the same key, else HARD_BLOCK. For keyed_mutate tools, when this
+#   param is declared and a call omits the kwarg, Mycelium auto-injects
+#   effect_id as the provider key (after ATTEMPTING decision CAS, before body).
+#   Omit the param to keep the cooperative default.
 #   e.g.  your_keyed_mutate_tool: {side_effect_class: keyed_mutate,
 #                                  provider_idempotency_key_param: idempotency_key}
+# propagate_effect_id_as_provider_key (optional bool): for non-keyed classes,
+#   opt-in to the same "inject effect_id when missing" behavior. Requires
+#   provider_idempotency_key_param.
 # provider_idempotency_key_ttl (optional, per tool; seconds): validity window
 #   for the provider idempotency key. On a same-key retry, if the elapsed time
 #   since the first attempt exceeds this TTL, the gate HARD_BLOCKs (provider

--- a/sdk/mycelium/transition.py
+++ b/sdk/mycelium/transition.py
@@ -751,6 +751,11 @@ class ToolTransitionBinding:
     explicit_capability: ToolCapability | None = None
     provider_idempotency_key_param: str | None = None
     provider_idempotency_key_ttl: float | None = None
+    # When True, derive a missing provider key from effect_id and inject it
+    # into the tool call before body execution (after ATTEMPTING decision CAS).
+    # KEYED_MUTATE tools with a declared provider_idempotency_key_param do this
+    # by default even when this flag is False.
+    propagate_effect_id_as_provider_key: bool = False
     request_id_from: str | None = None
 
     @classmethod
@@ -767,8 +772,14 @@ class ToolTransitionBinding:
         capability: ToolCapability | None = None,
         provider_idempotency_key_param: str | None = None,
         provider_idempotency_key_ttl: float | None = None,
+        propagate_effect_id_as_provider_key: bool = False,
         request_id_from: str | None = None,
     ) -> ToolTransitionBinding:
+        if propagate_effect_id_as_provider_key and provider_idempotency_key_param is None:
+            raise ValueError(
+                "propagate_effect_id_as_provider_key=True requires "
+                "provider_idempotency_key_param"
+            )
         # Binding-level capability sees only the statically declared provider
         # idempotency key. Reconciler presence lives on the ledger and can only
         # *tighten to a promise* at recovery time via
@@ -818,6 +829,7 @@ class ToolTransitionBinding:
             explicit_capability=capability,
             provider_idempotency_key_param=provider_idempotency_key_param,
             provider_idempotency_key_ttl=provider_idempotency_key_ttl,
+            propagate_effect_id_as_provider_key=propagate_effect_id_as_provider_key,
             request_id_from=request_id_from,
         )
 
@@ -1142,6 +1154,20 @@ def extract_provider_idempotency_key(
         return None
     value = kwargs.get(param)
     return str(value) if value is not None else None
+
+
+def should_propagate_effect_id_as_provider_key(binding: ToolTransitionBinding) -> bool:
+    """Whether a missing provider key should be injected from ``effect_id``.
+
+    KEYED_MUTATE tools with a declared provider-key param propagate by default.
+    Other side-effect classes require explicit opt-in via
+    ``propagate_effect_id_as_provider_key=True``.
+    """
+    if binding.provider_idempotency_key_param is None:
+        return False
+    if binding.side_effect_class == SideEffectClass.KEYED_MUTATE:
+        return True
+    return binding.propagate_effect_id_as_provider_key
 
 
 def derive_transition_key_for_call(

--- a/sdk/mycelium/verify/invariants.py
+++ b/sdk/mycelium/verify/invariants.py
@@ -22,6 +22,7 @@ __all__ = [
     "check_at_most_one_committed",
     "check_at_most_one_committed_effect_state",
     "check_effect_state_consistency",
+    "check_unique_effect_id_index",
     "check_provider_mapping",
     "committed_effect_ids",
     "committed_effect_ids_by_state",
@@ -39,20 +40,10 @@ class InvariantViolation:
 def _effect_ref(entry: Any) -> str | None:
     """The dedup identity to bucket a committed row under.
 
-    Uses the same keying as :func:`check_provider_mapping` (which maps provider
-    effects onto rows by ``request_id``): ``transition_key``, then
-    ``idempotency_key`` (the historical dedup ref, and what legacy rows with an
-    explicit idempotency key rely on), then ``request_id``. ``effect_id`` is
-    not consulted directly because for SDK-created rows it is either equal to
-    ``request_id`` (derived default) or, for rows with an explicit
-    ``request_id``, the derived transition hash — bucketing by it would diverge
-    from the provider-mapping key and break the at-most-once check.
+    ``effect_id`` is the authoritative cross-request dedup identity. Legacy
+    rows missing ``effect_id`` fall back to ``request_id``.
     """
-    return (
-        getattr(entry, "transition_key", None)
-        or getattr(entry, "idempotency_key", None)
-        or getattr(entry, "request_id", None)
-    )
+    return getattr(entry, "effect_id", None) or getattr(entry, "request_id", None)
 
 
 def committed_effect_ids(entries: Iterable[Any]) -> dict[str, list[str]]:
@@ -174,6 +165,28 @@ def check_effect_state_consistency(entries: Iterable[Any]) -> list[InvariantViol
     return violations
 
 
+def check_unique_effect_id_index(entries: Iterable[Any]) -> list[InvariantViolation]:
+    """Assert every ``effect_id`` resolves to exactly one canonical request row."""
+    mapping: dict[str, set[str]] = defaultdict(set)
+    for entry in entries:
+        effect_id = str(getattr(entry, "effect_id", None) or getattr(entry, "request_id", ""))
+        request_id = str(getattr(entry, "request_id", ""))
+        if not effect_id or not request_id:
+            continue
+        mapping[effect_id].add(request_id)
+    violations: list[InvariantViolation] = []
+    for effect_id, request_ids in mapping.items():
+        if len(request_ids) > 1:
+            violations.append(
+                InvariantViolation(
+                    effect_id,
+                    f"effect_id {effect_id!r} points to multiple request_ids: "
+                    f"{sorted(request_ids)}",
+                )
+            )
+    return violations
+
+
 def check_provider_mapping(
     entries: Iterable[Any],
     provider_effect_ids: Sequence[str | tuple[str, str]],
@@ -189,20 +202,24 @@ def check_provider_mapping(
     entry_list = list(entries)
     committed = committed_effect_ids(entry_list)
     ref_to_effect = {
-        str(entry.external_operation_ref): str(
-            getattr(entry, "transition_key", None)
-            or getattr(entry, "idempotency_key", None)
-            or entry.request_id
-        )
+        str(entry.external_operation_ref): str(_effect_ref(entry) or entry.request_id)
         for entry in entry_list
         if getattr(entry, "external_operation_ref", None)
     }
+    ledger_key_to_effect: dict[str, str] = {}
+    for entry in entry_list:
+        effect = str(_effect_ref(entry) or entry.request_id)
+        ledger_key_to_effect[entry.request_id] = effect
+        for alias in getattr(entry, "request_id_aliases", ()) or ():
+            if alias:
+                ledger_key_to_effect[str(alias)] = effect
     violations: list[InvariantViolation] = []
     warnings: list[str] = []
     executions: list[tuple[str, str]] = []
     for raw in provider_effect_ids:
         if isinstance(raw, tuple):
-            effect_id, provider_id = map(str, raw)
+            ledger_key, provider_id = map(str, raw)
+            effect_id = ledger_key_to_effect.get(ledger_key, ledger_key)
         else:
             provider_id = str(raw)
             effect_id = ref_to_effect.get(provider_id, provider_id)

--- a/sdk/mycelium/verify/isolation.py
+++ b/sdk/mycelium/verify/isolation.py
@@ -106,6 +106,19 @@ class IsolationGateStorage:
             owned.append(row)
         return owned
 
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        canonical = self._inner.resolve_request_id(effect_id)
+        if canonical is None:
+            return None
+        return self._guard(canonical)
+
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        entry = self._inner.get_by_effect_id(effect_id)
+        if entry is None:
+            return None
+        self._guard(entry.request_id)
+        return entry
+
 
 class FaultInjectingStorage:
     """Deterministic outage wrapper. Does not swap the inner backend type."""
@@ -181,6 +194,12 @@ class FaultInjectingStorage:
     def list_all(self) -> list[LedgerEntry]:
         self._maybe_fail(self.fail_list_all, "list_all")
         return self._inner.list_all()
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        return self._inner.resolve_request_id(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        return self._inner.get_by_effect_id(effect_id)
 
 
 class VerificationAdapter(Protocol):
@@ -494,6 +513,12 @@ class _PostgresPrefixedStorage:
             if entry is not None:
                 entries.append(entry)
         return entries
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        return self._inner.resolve_request_id(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        return self._inner.get_by_effect_id(effect_id)
 
 
 def _redis_session(

--- a/sdk/mycelium/verify/registry.py
+++ b/sdk/mycelium/verify/registry.py
@@ -23,6 +23,7 @@ SCENARIO_ORDER = (
     "authority-window",
     "use-time-currency",
     "simulation",
+    "state-machine-exhaustive",
 )
 
 ScenarioFn = Callable[["ScenarioContext"], "VerificationEvidence"]
@@ -88,6 +89,7 @@ def ensure_builtin_scenarios_registered() -> None:
         redispatch,
         secret_in_args,
         simulation,
+        state_machine_exhaustive,
         storage_outage,
         use_time_currency,
         worker_crash,

--- a/sdk/mycelium/verify/scenarios/reconcile.py
+++ b/sdk/mycelium/verify/scenarios/reconcile.py
@@ -164,17 +164,19 @@ def run_reconcile(ctx: ScenarioContext) -> VerificationEvidence:
             failures.append("provider key drift did not fail closed")
         else:
             decisions.append("keyed:drift HARD_BLOCK")
-        missing_blocked = False
+        before_keys = list(provider.keys_seen)
         try:
             tool(1, request_id=rid, op_id="keyed")
-        except LedgerHardBlockError:
-            missing_blocked = True
         except Exception as exc:  # noqa: BLE001
-            missing_blocked = "block" in str(exc).lower() or "key" in str(exc).lower()
-        if not missing_blocked:
-            failures.append("missing provider key did not fail closed")
+            failures.append(f"keyed missing-key retry: {type(exc).__name__}: {exc}")
         else:
-            decisions.append("keyed:missing HARD_BLOCK")
+            reused = provider.keys_seen[len(before_keys) :]
+            if reused and reused[-1] == "ikey-stable":
+                decisions.append("keyed:missing reuses stored provider key")
+            else:
+                failures.append(
+                    "missing provider key retry did not reuse stored provider key"
+                )
         before_keys = list(provider.keys_seen)
         try:
             tool(1, request_id=rid, op_id="keyed", idempotency_key="ikey-stable")

--- a/sdk/mycelium/verify/scenarios/simulation.py
+++ b/sdk/mycelium/verify/scenarios/simulation.py
@@ -37,14 +37,17 @@ from mycelium.verify.invariants import (
     check_at_most_one_committed_effect_state,
     check_effect_state_consistency,
     check_provider_mapping,
+    check_unique_effect_id_index,
 )
 from mycelium.verify.registry import ScenarioContext, verify_scenario
 from mycelium.verify.types import VerificationEvidence, VerificationStatus
 from mycelium.verify.workers import (
     SYNTHETIC_TOOL,
+    count_executions,
     crash_worker,
     join_workers,
     make_ledger,
+    make_tool,
     read_lines,
     reconcile_worker,
     spawn_workers,
@@ -160,6 +163,8 @@ def _run_crash_sweep(
         for item in check_at_most_one_committed_effect_state(entries):
             failures.append(f"{phase}: {item.message}")
         for item in check_effect_state_consistency(entries):
+            failures.append(f"{phase}: {item.message}")
+        for item in check_unique_effect_id_index(entries):
             failures.append(f"{phase}: {item.message}")
         provider_effects = read_lines(effect_file)
         if provider_effects:
@@ -285,6 +290,8 @@ def _run_fence_takeover(
         failures.append(f"fence takeover: {violation.message}")
     for violation in check_effect_state_consistency([final]):
         failures.append(f"fence takeover: {violation.message}")
+    for violation in check_unique_effect_id_index([final]):
+        failures.append(f"fence takeover: {violation.message}")
     mapped, warnings = check_provider_mapping([final], provider_effects)
     for violation in mapped:
         failures.append(f"fence takeover: {violation.message}")
@@ -295,6 +302,68 @@ def _run_fence_takeover(
             "fence takeover: B sole COMMITTED row and provider attempt; A stale write refused"
         )
     return failures, decisions
+
+
+def _run_explicit_request_alias_dedupe(
+    iso: Any,
+    work: Path,
+) -> tuple[list[str], list[str], int]:
+    failures: list[str] = []
+    decisions: list[str] = []
+    artifact = str(work / "effect-id-alias-exec.txt")
+    storage = iso.open_storage()
+    first_request = iso.track(iso.namespace.request_id("sim", "effect-alias-a"))
+    second_request = iso.track(iso.namespace.request_id("sim", "effect-alias-b"))
+    alias_call_id = "effect-alias-call"
+    with execution_scope(TransitionScope(thread_id="verify", run_id="verify")):
+        tool = make_tool(storage, artifact, lease_ttl=10.0, poll_timeout=5.0)
+        first = tool(
+            1,
+            op_id="effect-alias-op",
+            tool_call_id=alias_call_id,
+            request_id=first_request,
+        )
+        second = tool(
+            1,
+            op_id="effect-alias-op",
+            tool_call_id=alias_call_id,
+            request_id=second_request,
+        )
+    if first != second:
+        failures.append(
+            "effect-id alias dedupe: mismatched results for equivalent explicit request_ids"
+        )
+    exec_count = count_executions(artifact)
+    if exec_count != 1:
+        failures.append(
+            f"effect-id alias dedupe: body executed {exec_count} times (expected 1)"
+        )
+    entries = [
+        entry
+        for entry in iso.open_fresh_client().list_all()
+        if entry.request_id in {first_request, second_request}
+    ]
+    if len(entries) != 1:
+        failures.append(
+            "effect-id alias dedupe: expected one canonical ledger row for colliding effect_id"
+        )
+    elif second_request not in entries[0].request_id_aliases:
+        failures.append(
+            "effect-id alias dedupe: canonical row did not retain supplied request_id alias"
+        )
+    for violation in check_at_most_one_committed(entries):
+        failures.append(f"effect-id alias dedupe: {violation.message}")
+    for violation in check_at_most_one_committed_effect_state(entries):
+        failures.append(f"effect-id alias dedupe: {violation.message}")
+    for violation in check_effect_state_consistency(entries):
+        failures.append(f"effect-id alias dedupe: {violation.message}")
+    for violation in check_unique_effect_id_index(entries):
+        failures.append(f"effect-id alias dedupe: {violation.message}")
+    if not failures:
+        decisions.append(
+            "effect-id alias dedupe: explicit request_id mismatch resolved to one canonical row"
+        )
+    return failures, decisions, exec_count
 
 
 @verify_scenario("simulation")
@@ -343,6 +412,11 @@ def run_simulation(ctx: ScenarioContext) -> VerificationEvidence:
         fence_failures, fence_decisions = _run_fence_takeover(iso, work)
         failures.extend(fence_failures)
         decisions.extend(fence_decisions)
+
+        alias_failures, alias_decisions, alias_exec = _run_explicit_request_alias_dedupe(iso, work)
+        failures.extend(alias_failures)
+        decisions.extend(alias_decisions)
+        total_exec += alias_exec
     finally:
         terminate_owned(ctx.owned_procs)
 
@@ -353,7 +427,7 @@ def run_simulation(ctx: ScenarioContext) -> VerificationEvidence:
         scenario="simulation",
         backend=iso.backend,
         namespace=iso.namespace.prefix,
-        attempts=len(_PHASES) + 1,
+        attempts=len(_PHASES) + 2,
         body_executions=total_exec,
         ledger_decisions=decisions,
         terminal_outcome="COMMITTED",
@@ -361,7 +435,8 @@ def run_simulation(ctx: ScenarioContext) -> VerificationEvidence:
         expected_behavior=(
             "for every effect_id at most one COMPLETED ledger entry, and every "
             "provider effect maps to at most one COMMITTED row; a superseded "
-            "worker's stale-fence write is rejected"
+            "worker's stale-fence write is rejected; mismatched explicit request_ids "
+            "for the same effect_id collapse to one canonical row"
         ),
         observed_behavior="; ".join(failures or decisions),
         artifacts=[str(work)],

--- a/sdk/mycelium/verify/scenarios/state_machine_exhaustive.py
+++ b/sdk/mycelium/verify/scenarios/state_machine_exhaustive.py
@@ -1,0 +1,489 @@
+"""Deterministic exhaustive interleavings for the EffectState protocol."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import replace
+from typing import Any
+
+from mycelium.action_ledger import (
+    ActionLedger,
+    InMemoryLedgerStorage,
+    LedgerEntry,
+    LedgerHardBlockError,
+    LedgerOutcomeAlreadySetError,
+)
+from mycelium.reconcile import ReconcileResult
+from mycelium.transition import (
+    EffectState,
+    SideEffectBoundary,
+    SideEffectClass,
+    TerminalOutcome,
+    ToolTransitionBinding,
+    TransitionScope,
+    derive_effect_id_for_call,
+    execution_scope,
+)
+from mycelium.verify.invariants import (
+    check_at_most_one_committed_effect_state,
+    check_effect_state_consistency,
+    check_unique_effect_id_index,
+)
+from mycelium.verify.registry import ScenarioContext, verify_scenario
+from mycelium.verify.types import VerificationEvidence, VerificationStatus
+
+_TOOL = "verify_state_machine"
+_SCOPE = TransitionScope(thread_id="verify", run_id="verify")
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="mycelium-verify",
+        policy_version="verify",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def _decision(allowed: bool) -> dict[str, Any]:
+    return {"allowed": allowed, "verdicts": [], "denied_reasons": []}
+
+
+def _new_ledger(
+    storage: InMemoryLedgerStorage,
+    *,
+    reconciler: Any | None = None,
+) -> ActionLedger:
+    return ActionLedger(
+        storage=storage,
+        reconciler=reconciler,
+        lease_ttl=0.1,
+        lease_renew_interval=0,
+        poll_interval=0.001,
+        poll_timeout=0.05,
+        reclaim_requires_death_signal=False,
+    )
+
+
+def _resume_storage(storage: InMemoryLedgerStorage) -> InMemoryLedgerStorage:
+    resumed = InMemoryLedgerStorage()
+    for entry in storage.list_all():
+        resumed.set(LedgerEntry.from_dict(entry.to_dict()))
+    return resumed
+
+
+def _assert_invariants(
+    *,
+    label: str,
+    storage: InMemoryLedgerStorage,
+    failures: list[str],
+) -> None:
+    entries = storage.list_all()
+    for violation in check_at_most_one_committed_effect_state(entries):
+        failures.append(f"{label}: {violation.message}")
+    for violation in check_effect_state_consistency(entries):
+        failures.append(f"{label}: {violation.message}")
+    for violation in check_unique_effect_id_index(entries):
+        failures.append(f"{label}: {violation.message}")
+
+
+def _expect_stale_refusal(
+    fn: Any,
+    *,
+    label: str,
+    failures: list[str],
+) -> None:
+    try:
+        fn()
+    except LedgerOutcomeAlreadySetError:
+        return
+    failures.append(f"{label}: stale write unexpectedly succeeded")
+
+
+def _run_stale_fence_interleaving(failures: list[str], decisions: list[str]) -> None:
+    storage = InMemoryLedgerStorage()
+    # IDEMPOTENT_MUTATE + SAFE_RETRY allows EXPIRED/not_crossed reclaim so this
+    # interleaving can focus on fence CAS refusal, not ambiguous-replay policy.
+    binding = ToolTransitionBinding.for_tool(
+        agent_id="mycelium-verify",
+        policy_version="verify",
+        side_effect_class=SideEffectClass.IDEMPOTENT_MUTATE,
+    )
+    request_id = "sm-stale-fence"
+    kwargs = {"amount": 1, "tool_call_id": "sm-stale", "request_id": request_id}
+
+    ledger_a = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        claim_a = ledger_a.claim_side_effecting(request_id, _TOOL, (), dict(kwargs), binding)
+    stale_owner = claim_a.owner
+    stale_fence = claim_a.fence
+
+    storage = _resume_storage(storage)
+    expired = storage.get(request_id)
+    if expired is None:
+        failures.append("stale-fence: initial claim missing")
+        return
+    storage.set(replace(expired, lease_until=time.time() - 1.0, last_heartbeat_at=None))
+
+    storage = _resume_storage(storage)
+    ledger_b = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        claim_b = ledger_b.claim_side_effecting(request_id, _TOOL, (), dict(kwargs), binding)
+    if claim_b.fence <= stale_fence:
+        failures.append(
+            f"stale-fence: reclaim fence did not advance ({stale_fence} -> {claim_b.fence})"
+        )
+        return
+
+    storage = _resume_storage(storage)
+    ledger_b = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        ledger_b.record_decision(
+            request_id,
+            _decision(True),
+            expected_owner=claim_b.owner,
+            expected_fence=claim_b.fence,
+        )
+
+    storage = _resume_storage(storage)
+    stale = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        _expect_stale_refusal(
+            lambda: stale.record_decision(
+                request_id,
+                _decision(True),
+                expected_owner=stale_owner,
+                expected_fence=stale_fence,
+            ),
+            label="stale-fence/record_decision",
+            failures=failures,
+        )
+        _expect_stale_refusal(
+            lambda: stale.advance_boundary(
+                request_id,
+                SideEffectBoundary.MAYBE_CROSSED,
+                expected_owner=stale_owner,
+                expected_fence=stale_fence,
+            ),
+            label="stale-fence/advance_boundary",
+            failures=failures,
+        )
+        _expect_stale_refusal(
+            lambda: stale.fail(
+                request_id,
+                RuntimeError("stale failure"),
+                _expected_owner=stale_owner,
+                _expected_fence=stale_fence,
+            ),
+            label="stale-fence/fail",
+            failures=failures,
+        )
+        _expect_stale_refusal(
+            lambda: stale.complete(
+                request_id,
+                {"stale": True},
+                _expected_owner=stale_owner,
+                _expected_fence=stale_fence,
+            ),
+            label="stale-fence/complete",
+            failures=failures,
+        )
+
+    storage = _resume_storage(storage)
+    winner = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        winner.complete(
+            request_id,
+            {"winner": "B"},
+            _expected_owner=claim_b.owner,
+            _expected_fence=claim_b.fence,
+        )
+    _assert_invariants(label="stale-fence", storage=storage, failures=failures)
+    if not any(item.startswith("stale-fence") for item in failures):
+        decisions.append("stale-fence: stale complete/fail/decision/boundary writes were refused")
+
+
+def _run_transition_matrix_cases(failures: list[str], decisions: list[str]) -> None:
+    """Enumerate the legal EffectState transitions from the transition-matrix tests."""
+    binding = _binding()
+    storage = InMemoryLedgerStorage()
+
+    # INTENDED -> ATTEMPTING -> COMMITTED
+    request_id = "sm-matrix-committed"
+    kwargs = {"amount": 1, "tool_call_id": "sm-matrix-committed", "request_id": request_id}
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        claim = ledger.claim_side_effecting(request_id, _TOOL, (), dict(kwargs), binding)
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        ledger.record_decision(
+            request_id,
+            _decision(True),
+            expected_owner=claim.owner,
+            expected_fence=claim.fence,
+        )
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        committed = ledger.complete(
+            request_id,
+            {"ok": True},
+            _expected_owner=claim.owner,
+            _expected_fence=claim.fence,
+        )
+    if committed.resolved_effect_state() != EffectState.COMMITTED:
+        failures.append("matrix/committed: expected COMMITTED terminal state")
+
+    # INTENDED -> ABORTED
+    request_id = "sm-matrix-aborted-denied"
+    kwargs = {"amount": 1, "tool_call_id": "sm-matrix-denied", "request_id": request_id}
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        denied_claim = ledger.claim_side_effecting(request_id, _TOOL, (), dict(kwargs), binding)
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        denied = ledger.record_decision(
+            request_id,
+            _decision(False),
+            expected_owner=denied_claim.owner,
+            expected_fence=denied_claim.fence,
+        )
+    if denied.resolved_effect_state() != EffectState.ABORTED:
+        failures.append("matrix/aborted-denied: expected ABORTED state")
+
+    # ATTEMPTING -> UNKNOWN
+    request_id = "sm-matrix-unknown"
+    kwargs = {"amount": 1, "tool_call_id": "sm-matrix-unknown", "request_id": request_id}
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        unknown_claim = ledger.claim_side_effecting(request_id, _TOOL, (), dict(kwargs), binding)
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        ledger.record_decision(
+            request_id,
+            _decision(True),
+            expected_owner=unknown_claim.owner,
+            expected_fence=unknown_claim.fence,
+        )
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        unknown = ledger.mark_unknown(
+            request_id,
+            _expected_owner=unknown_claim.owner,
+            expected_fence=unknown_claim.fence,
+            error="ambiguous",
+        )
+    if unknown.resolved_effect_state() != EffectState.UNKNOWN:
+        failures.append("matrix/unknown: expected UNKNOWN state")
+
+    # ATTEMPTING -> ABORTED
+    request_id = "sm-matrix-aborted-fail"
+    kwargs = {"amount": 1, "tool_call_id": "sm-matrix-fail", "request_id": request_id}
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        failed_claim = ledger.claim_side_effecting(request_id, _TOOL, (), dict(kwargs), binding)
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        ledger.record_decision(
+            request_id,
+            _decision(True),
+            expected_owner=failed_claim.owner,
+            expected_fence=failed_claim.fence,
+        )
+    storage = _resume_storage(storage)
+    ledger = _new_ledger(storage)
+    with execution_scope(_SCOPE):
+        failed = ledger.fail(
+            request_id,
+            RuntimeError("failed before effect"),
+            failed_after_effect=False,
+            _expected_owner=failed_claim.owner,
+            _expected_fence=failed_claim.fence,
+        )
+    if failed.resolved_effect_state() != EffectState.ABORTED:
+        failures.append("matrix/aborted-fail: expected ABORTED state")
+
+    _assert_invariants(label="matrix", storage=storage, failures=failures)
+    if not any(item.startswith("matrix") for item in failures):
+        decisions.append(
+            "matrix: legal transitions INTENDED->ATTEMPTING/ABORTED and "
+            "ATTEMPTING->COMMITTED/UNKNOWN/ABORTED hold across crash-resume"
+        )
+
+
+class _StaticReconciler:
+    def __init__(self, verdict: ReconcileResult) -> None:
+        self._verdict = verdict
+
+    def reconcile(self, entry: LedgerEntry) -> ReconcileResult:
+        return self._verdict
+
+
+def _run_reconcile_interleavings(failures: list[str], decisions: list[str]) -> None:
+    binding = _binding()
+    cases = [
+        ("COMPLETED", ReconcileResult.completed({"reconciled": True})),
+        ("NOT_EXECUTED", ReconcileResult.not_executed()),
+        ("UNKNOWN", ReconcileResult.unknown()),
+    ]
+    for label, verdict in cases:
+        request_id = f"sm-reconcile-{label.lower()}"
+        kwargs = {"amount": 1, "tool_call_id": f"sm-{label.lower()}", "request_id": request_id}
+        storage = InMemoryLedgerStorage()
+        ledger_a = _new_ledger(storage)
+        with execution_scope(_SCOPE):
+            claim = ledger_a.claim_side_effecting(request_id, _TOOL, (), dict(kwargs), binding)
+            ledger_a.record_decision(
+                request_id,
+                _decision(True),
+                expected_owner=claim.owner,
+                expected_fence=claim.fence,
+            )
+            ledger_a.attach_external_operation_ref(
+                request_id,
+                f"op-{label.lower()}",
+                expected_owner=claim.owner,
+                expected_fence=claim.fence,
+            )
+
+        storage = _resume_storage(storage)
+        crashed = storage.get(request_id)
+        if crashed is None:
+            failures.append(f"reconcile-{label}: pre-crash row missing")
+            continue
+        storage.set(replace(crashed, lease_until=time.time() - 1.0, last_heartbeat_at=None))
+
+        storage = _resume_storage(storage)
+        ledger_b = _new_ledger(storage, reconciler=_StaticReconciler(verdict))
+        with execution_scope(_SCOPE):
+            if label == "UNKNOWN":
+                try:
+                    ledger_b.claim_side_effecting(request_id, _TOOL, (), dict(kwargs), binding)
+                except LedgerHardBlockError:
+                    decisions.append("reconcile-unknown: redispatch hard-blocked")
+                else:
+                    failures.append("reconcile-unknown: expected hard-block, claim returned")
+            else:
+                recovered = ledger_b.claim_side_effecting(
+                    request_id,
+                    _TOOL,
+                    (),
+                    dict(kwargs),
+                    binding,
+                )
+                if label == "COMPLETED":
+                    if recovered.resolved_terminal_outcome() != TerminalOutcome.COMPLETED:
+                        failures.append(
+                            "reconcile-completed: expected COMPLETED outcome after reconcile"
+                        )
+                    else:
+                        decisions.append(
+                            "reconcile-completed: provider verdict returned stored result"
+                        )
+                else:
+                    if recovered.resolved_effect_state() != EffectState.INTENDED:
+                        failures.append(
+                            "reconcile-not-executed: expected fresh INTENDED claim after reset"
+                        )
+                    else:
+                        decisions.append(
+                            "reconcile-not-executed: reconcile reset ATTEMPTING to fresh claim"
+                        )
+        _assert_invariants(label=f"reconcile-{label.lower()}", storage=storage, failures=failures)
+
+
+def _run_concurrent_intended_claim(failures: list[str], decisions: list[str]) -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = _new_ledger(storage)
+    binding = _binding()
+    request_id = "sm-concurrent-intended"
+    kwargs = {"amount": 1, "tool_call_id": "sm-concurrent", "request_id": request_id}
+    effect_id = derive_effect_id_for_call(_TOOL, (), kwargs, binding)
+    with execution_scope(_SCOPE):
+        template = ledger._new_inflight_entry(
+            request_id,
+            _TOOL,
+            (),
+            dict(kwargs),
+            binding=binding,
+            _effect_id=effect_id,
+        )
+
+    barrier = threading.Barrier(2)
+    outcomes: list[str] = []
+
+    def _worker() -> None:
+        barrier.wait()
+        outcome, _existing = storage.try_claim_inflight(template, lease_ttl=1.0)
+        outcomes.append(outcome)
+
+    first = threading.Thread(target=_worker, daemon=True)
+    second = threading.Thread(target=_worker, daemon=True)
+    first.start()
+    second.start()
+    first.join(timeout=5.0)
+    second.join(timeout=5.0)
+
+    if len(outcomes) != 2:
+        failures.append(f"concurrent-claim: expected 2 outcomes, got {len(outcomes)}")
+    elif outcomes.count("claimed") != 1 or outcomes.count("in_flight") != 1:
+        failures.append(
+            "concurrent-claim: "
+            f"outcomes={outcomes!r}, expected one claimed + one in_flight"
+        )
+    else:
+        decisions.append("concurrent-claim: exactly one INTENDED claim won")
+    _assert_invariants(label="concurrent-claim", storage=storage, failures=failures)
+
+
+@verify_scenario("state-machine-exhaustive")
+def run_state_machine_exhaustive(ctx: ScenarioContext) -> VerificationEvidence:
+    started = time.time()
+    failures: list[str] = []
+    decisions: list[str] = []
+
+    _run_transition_matrix_cases(failures, decisions)
+    _run_stale_fence_interleaving(failures, decisions)
+    _run_reconcile_interleavings(failures, decisions)
+    _run_concurrent_intended_claim(failures, decisions)
+
+    status = VerificationStatus.PASS if not failures else VerificationStatus.FAIL
+    return VerificationEvidence(
+        scenario="state-machine-exhaustive",
+        backend=ctx.isolation.backend,
+        namespace=ctx.isolation.namespace.prefix,
+        attempts=9,
+        body_executions=0,
+        ledger_decisions=decisions,
+        terminal_outcome="COMMITTED" if status == VerificationStatus.PASS else None,
+        duration=time.time() - started,
+        expected_behavior=(
+            "deterministic interleavings preserve EffectState invariants: stale-fence writes are "
+            "rejected, reconcile outcomes map ATTEMPTING to COMPLETED/INTENDED/UNKNOWN gate "
+            "behavior, and concurrent INTENDED claims produce exactly one winner"
+        ),
+        observed_behavior="; ".join(failures or decisions),
+        status=status,
+        summary=(
+            "state-machine exhaustive interleavings held"
+            if status == VerificationStatus.PASS
+            else "; ".join(failures)[:220]
+        ),
+        remediation=(
+            ""
+            if status == VerificationStatus.PASS
+            else (
+                "Inspect stale-fence CAS handling, reconcile transitions, "
+                "and effect_id index invariants."
+            )
+        ),
+    )

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.34.0"
+version = "1.35.0"
 description = "The reliability layer for AI agents — prove run-or-not and enforce at-most-once at the tool boundary"
 authors = [
   { name = "Nandana Dileep" },

--- a/sdk/tests/test_effect_id_index.py
+++ b/sdk/tests/test_effect_id_index.py
@@ -1,0 +1,259 @@
+"""Authoritative effect_id index and cross-request dedupe checks."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from mycelium import (
+    ActionLedger,
+    FileLedgerStorage,
+    InMemoryLedgerStorage,
+    LedgerEntry,
+    SideEffectClass,
+    SqliteLedgerStorage,
+    ToolTransitionBinding,
+    TransitionScope,
+    execution_scope,
+)
+from mycelium.verify.invariants import check_unique_effect_id_index
+
+
+def _binding() -> ToolTransitionBinding:
+    return ToolTransitionBinding.for_tool(
+        agent_id="effect-id-tests",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+    )
+
+
+def _decision(allowed: bool) -> dict[str, object]:
+    return {"allowed": allowed, "verdicts": [], "denied_reasons": []}
+
+
+def _exercise_explicit_alias(
+    ledger: ActionLedger,
+    *,
+    first_request_id: str,
+    second_request_id: str,
+) -> tuple[LedgerEntry, str]:
+    binding = _binding()
+    kwargs_a = {"amount": 10.0, "tool_call_id": "call-1", "request_id": first_request_id}
+    kwargs_b = {"amount": 10.0, "tool_call_id": "call-1", "request_id": second_request_id}
+    with execution_scope(TransitionScope(thread_id="t1", run_id="r1")):
+        first = ledger.claim_side_effecting(first_request_id, "charge", (), dict(kwargs_a), binding)
+        ledger.record_decision(
+            first_request_id,
+            _decision(True),
+            expected_owner=first.owner,
+            expected_fence=first.fence,
+        )
+        ledger.complete(
+            first_request_id,
+            {"charged": True},
+            _expected_owner=first.owner,
+            _expected_fence=first.fence,
+        )
+        replay = ledger.claim_side_effecting(
+            second_request_id,
+            "charge",
+            (),
+            dict(kwargs_b),
+            binding,
+        )
+    return replay, str(first.effect_id)
+
+
+def test_inmemory_effect_id_resolves_to_canonical_request() -> None:
+    storage = InMemoryLedgerStorage()
+    ledger = ActionLedger(storage=storage)
+    replay, effect_id = _exercise_explicit_alias(
+        ledger,
+        first_request_id="req-a",
+        second_request_id="req-b",
+    )
+
+    assert replay.request_id == "req-a"
+    assert replay.is_terminal_completed()
+    assert "req-b" in replay.request_id_aliases
+    assert storage.resolve_request_id(effect_id) == "req-a"
+    by_effect = storage.get_by_effect_id(effect_id)
+    assert by_effect is not None
+    assert by_effect.request_id == "req-a"
+    assert len(storage.list_all()) == 1
+
+
+def test_file_storage_repairs_missing_sidecar_index(tmp_path: Path) -> None:
+    path = tmp_path / "ledger.json"
+    storage = FileLedgerStorage(path)
+    ledger = ActionLedger(storage=storage)
+    replay, effect_id = _exercise_explicit_alias(
+        ledger,
+        first_request_id="file-a",
+        second_request_id="file-b",
+    )
+    assert replay.request_id == "file-a"
+
+    index_path = path.with_suffix(path.suffix + ".effect-index.json")
+    assert index_path.exists()
+    index_path.unlink()
+    assert storage.resolve_request_id(effect_id) == "file-a"
+    assert index_path.exists()
+
+
+def test_file_storage_legacy_schema_row_without_effect_id_repairs_index(tmp_path: Path) -> None:
+    path = tmp_path / "legacy-ledger.json"
+    raw = {
+        "legacy-row-1": {
+            "request_id": "legacy-row-1",
+            "tool": "charge",
+            "args": [],
+            "kwargs": {"request_id": "legacy-row-1"},
+            "status": "completed",
+            "terminal_outcome": "completed",
+            "started_at": 1.0,
+            "schema_version": 1,
+        }
+    }
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    storage = FileLedgerStorage(path)
+    index_path = path.with_suffix(path.suffix + ".effect-index.json")
+    assert not index_path.exists()
+    assert storage.resolve_request_id("legacy-row-1") == "legacy-row-1"
+    by_effect = storage.get_by_effect_id("legacy-row-1")
+    assert by_effect is not None
+    assert by_effect.request_id == "legacy-row-1"
+    assert index_path.exists()
+
+
+def test_sqlite_storage_effect_id_lookup(tmp_path: Path) -> None:
+    storage = SqliteLedgerStorage(tmp_path / "ledger.db")
+    ledger = ActionLedger(storage=storage)
+    replay, effect_id = _exercise_explicit_alias(
+        ledger,
+        first_request_id="sqlite-a",
+        second_request_id="sqlite-b",
+    )
+    assert replay.request_id == "sqlite-a"
+    assert storage.resolve_request_id(effect_id) == "sqlite-a"
+    row = storage.get_by_effect_id(effect_id)
+    assert row is not None
+    assert row.request_id == "sqlite-a"
+
+
+def test_redis_storage_effect_id_lookup(monkeypatch) -> None:
+    fakeredis = pytest.importorskip("fakeredis")
+    fake = fakeredis.FakeRedis(decode_responses=True)
+
+    def from_url(*args: object, **kwargs: object):
+        return fake
+
+    redis = pytest.importorskip("redis")
+
+    monkeypatch.setattr(redis.Redis, "from_url", from_url)
+
+    from mycelium import RedisLedgerStorage
+
+    storage = RedisLedgerStorage("redis://test")
+    ledger = ActionLedger(storage=storage)
+    replay, effect_id = _exercise_explicit_alias(
+        ledger,
+        first_request_id="redis-a",
+        second_request_id="redis-b",
+    )
+    assert replay.request_id == "redis-a"
+    assert storage.resolve_request_id(effect_id) == "redis-a"
+    row = storage.get_by_effect_id(effect_id)
+    assert row is not None
+    assert row.request_id == "redis-a"
+
+
+def test_redis_two_worker_mismatched_request_ids_single_effect(monkeypatch) -> None:
+    fakeredis = pytest.importorskip("fakeredis")
+    fake = fakeredis.FakeRedis(decode_responses=True)
+
+    def from_url(*args: object, **kwargs: object):
+        return fake
+
+    redis = pytest.importorskip("redis")
+    monkeypatch.setattr(redis.Redis, "from_url", from_url)
+
+    from mycelium import RedisLedgerStorage, ledger_sync
+
+    storage = RedisLedgerStorage("redis://test")
+    binding = _binding()
+    started = threading.Event()
+    executions: list[str] = []
+    results: dict[str, dict[str, bool]] = {}
+    errors: list[BaseException] = []
+
+    @ledger_sync(
+        storage=storage,
+        transition_binding=binding,
+        poll_interval=0.001,
+        poll_timeout=2.0,
+    )
+    def charge(amount: float) -> dict[str, bool]:
+        executions.append("run")
+        started.set()
+        time.sleep(0.05)
+        return {"charged": True}
+
+    def _worker(name: str, request_id: str) -> None:
+        try:
+            with execution_scope(TransitionScope(thread_id="redis-two-worker", run_id="r1")):
+                results[name] = charge(
+                    amount=10.0,
+                    request_id=request_id,
+                    tool_call_id="redis-two-worker-call",
+                )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    first = threading.Thread(target=_worker, args=("a", "order-1"), daemon=True)
+    second = threading.Thread(target=_worker, args=("b", "order-2"), daemon=True)
+
+    first.start()
+    assert started.wait(timeout=2.0)
+    second.start()
+    first.join(timeout=5.0)
+    second.join(timeout=5.0)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert not errors
+    assert results["a"] == {"charged": True}
+    assert results["b"] == {"charged": True}
+    assert len(executions) == 1
+    entries = storage.list_all()
+    assert len(entries) == 1
+    assert entries[0].request_id == "order-1"
+    assert "order-2" in entries[0].request_id_aliases
+
+
+def test_unique_effect_id_invariant_reports_duplicate_rows() -> None:
+    entries = [
+        LedgerEntry(
+            request_id="dup-a",
+            tool="charge",
+            args=[],
+            kwargs={},
+            status="completed",
+            effect_id="same-effect",
+        ),
+        LedgerEntry(
+            request_id="dup-b",
+            tool="charge",
+            args=[],
+            kwargs={},
+            status="completed",
+            effect_id="same-effect",
+        ),
+    ]
+    violations = check_unique_effect_id_index(entries)
+    assert len(violations) == 1
+    assert "multiple request_ids" in violations[0].message

--- a/sdk/tests/test_effect_state_machine.py
+++ b/sdk/tests/test_effect_state_machine.py
@@ -56,13 +56,19 @@ def _scope() -> TransitionScope:
     return TransitionScope(thread_id="thread-1", run_id="run-1")
 
 
+def _case_kwargs(case: str) -> dict[str, str]:
+    return {"case": case}
+
+
 def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     storage = InMemoryLedgerStorage()
     ledger = ActionLedger(storage=storage)
     binding = _binding()
 
     # INTENDED -> ATTEMPTING -> COMMITTED
-    allowed = ledger.claim_side_effecting("req-allowed", "tool", (), {}, binding)
+    allowed = ledger.claim_side_effecting(
+        "req-allowed", "tool", (), _case_kwargs("allowed"), binding
+    )
     ledger.record_decision(
         "req-allowed",
         _decision(True),
@@ -72,7 +78,9 @@ def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     assert committed.resolved_effect_state() == EffectState.COMMITTED
 
     # INTENDED -> ABORTED
-    denied = ledger.claim_side_effecting("req-denied", "tool", (), {}, binding)
+    denied = ledger.claim_side_effecting(
+        "req-denied", "tool", (), _case_kwargs("denied"), binding
+    )
     denied_row = ledger.record_decision(
         "req-denied",
         _decision(False),
@@ -81,7 +89,9 @@ def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     assert denied_row.resolved_effect_state() == EffectState.ABORTED
 
     # ATTEMPTING -> UNKNOWN (BLIND-like after-effect failure)
-    unknown = ledger.claim_side_effecting("req-unknown", "tool", (), {}, binding)
+    unknown = ledger.claim_side_effecting(
+        "req-unknown", "tool", (), _case_kwargs("unknown"), binding
+    )
     ledger.record_decision(
         "req-unknown",
         _decision(True),
@@ -95,7 +105,9 @@ def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     assert unknown_row.resolved_effect_state() == EffectState.UNKNOWN
 
     # ATTEMPTING -> ABORTED (failure before effect after allow)
-    failed = ledger.claim_side_effecting("req-fail-before", "tool", (), {}, binding)
+    failed = ledger.claim_side_effecting(
+        "req-fail-before", "tool", (), _case_kwargs("fail-before"), binding
+    )
     ledger.record_decision(
         "req-fail-before",
         _decision(True),
@@ -110,7 +122,9 @@ def test_effect_state_transition_matrix_and_illegal_cas_rejections() -> None:
     assert failed_row.resolved_effect_state() == EffectState.ABORTED
 
     # ILLEGAL: complete before decision (still INTENDED)
-    no_decision = ledger.claim_side_effecting("req-no-decision", "tool", (), {}, binding)
+    no_decision = ledger.claim_side_effecting(
+        "req-no-decision", "tool", (), _case_kwargs("no-decision"), binding
+    )
     with pytest.raises(LedgerOutcomeAlreadySetError):
         ledger.complete(
             "req-no-decision",

--- a/sdk/tests/test_outage_redis_postgres.py
+++ b/sdk/tests/test_outage_redis_postgres.py
@@ -323,6 +323,17 @@ class FailingPostgresStorage:
         self.fail_claim = False
         self.fail_transition = False
         self.fail_list_all = False
+        self.fail_resolve_request_id = False
+
+    def resolve_request_id(self, effect_id: str) -> str | None:
+        if self.fail_resolve_request_id:
+            raise ConnectionError("storage backend unreachable")
+        return self._mem.resolve_request_id(effect_id)
+
+    def get_by_effect_id(self, effect_id: str) -> LedgerEntry | None:
+        if self.fail_resolve_request_id:
+            raise ConnectionError("storage backend unreachable")
+        return self._mem.get_by_effect_id(effect_id)
 
     def get(self, request_id: str) -> LedgerEntry | None:
         if self.fail_get:
@@ -386,7 +397,10 @@ class TestPostgresOutage:
 
         storage = PostgresLedgerStorage("postgresql://outage:5432/mycelium")
         ledger_inst = ActionLedger(storage=storage)
-        with pytest.raises(LedgerStorageUnavailableError, match=r"during (get|try_claim_inflight)"):
+        with pytest.raises(
+            LedgerStorageUnavailableError,
+            match=r"during (get|try_claim_inflight|resolve_request_id)",
+        ):
             ledger_inst.claim_side_effecting(
                 "req-pg-claim", "send_payment", (), {"amount": 10}, _binding()
             )

--- a/sdk/tests/test_provider_idempotency_key.py
+++ b/sdk/tests/test_provider_idempotency_key.py
@@ -18,13 +18,16 @@ from mycelium import (
     SideEffectBoundary,
     SideEffectClass,
     TerminalOutcome,
+    ToolCapability,
     ToolTransitionBinding,
     TransitionScope,
     derive_transition_key_for_call,
     execution_scope,
+    get_ledger,
     ledger_sync,
     load_config_from_string,
 )
+from mycelium.transition import should_propagate_effect_id_as_provider_key
 from mycelium.transition_resolution import TransitionGate, resolve_side_effect_gate
 
 
@@ -212,6 +215,126 @@ def test_claim_stores_provider_idempotency_key() -> None:
     assert entry.provider_idempotency_key == "k1"
 
 
+def test_keyed_mutate_auto_injects_effect_id_key_when_missing() -> None:
+    binding = _keyed_binding(enforce=True)
+    observed: list[str] = []
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str) -> dict[str, str]:
+        observed.append(idempotency_key)
+        return {"status": "sent"}
+
+    with execution_scope(_scope()):
+        result = send_payment(amount=10.0, tool_call_id="auto-key")
+    assert result == {"status": "sent"}
+    assert len(observed) == 1
+    assert observed[0]
+
+    ledger_inst = get_ledger(send_payment)
+    assert ledger_inst is not None
+    with execution_scope(_scope()):
+        request_id = ledger_inst.derive_request_id(
+            "send_payment",
+            (),
+            {"amount": 10.0, "tool_call_id": "auto-key"},
+            transition_binding=binding,
+        )
+    stored = ledger_inst.get(request_id)
+    assert stored is not None
+    assert stored.provider_idempotency_key == observed[0]
+    assert stored.provider_idempotency_key == stored.effect_id
+
+
+def test_keyed_mutate_missing_key_retry_reuses_stored_effect_id() -> None:
+    binding = _keyed_binding(enforce=True)
+    attempts = {"n": 0}
+    seen_keys: list[str] = []
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str) -> dict[str, str]:
+        attempts["n"] += 1
+        seen_keys.append(idempotency_key)
+        if attempts["n"] == 1:
+            raise RuntimeError("network drop before effect")
+        return {"status": "sent"}
+
+    with execution_scope(_scope()):
+        with pytest.raises(RuntimeError):
+            send_payment(amount=10.0, tool_call_id="auto-retry")
+        result = send_payment(amount=10.0, tool_call_id="auto-retry")
+
+    assert result == {"status": "sent"}
+    assert attempts["n"] == 2
+    assert len(set(seen_keys)) == 1
+
+
+def test_missing_retry_reuses_stored_explicit_provider_key() -> None:
+    binding = _keyed_binding(enforce=True)
+    attempts = {"n": 0}
+    seen_keys: list[str] = []
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str) -> dict[str, str]:
+        attempts["n"] += 1
+        seen_keys.append(idempotency_key)
+        if attempts["n"] == 1:
+            raise RuntimeError("network drop before effect")
+        return {"status": "sent"}
+
+    with execution_scope(_scope()):
+        with pytest.raises(RuntimeError):
+            send_payment(amount=10.0, idempotency_key="explicit-key", tool_call_id="explicit-retry")
+        result = send_payment(amount=10.0, tool_call_id="explicit-retry")
+
+    assert result == {"status": "sent"}
+    assert attempts["n"] == 2
+    assert seen_keys == ["explicit-key", "explicit-key"]
+
+
+def test_explicit_provider_key_overrides_effect_id_injection() -> None:
+    binding = _keyed_binding(enforce=True)
+    seen: list[str] = []
+
+    @ledger_sync(storage=InMemoryLedgerStorage(), transition_binding=binding)
+    def send_payment(amount: float, idempotency_key: str) -> dict[str, str]:
+        seen.append(idempotency_key)
+        return {"status": "sent"}
+
+    with execution_scope(_scope()):
+        send_payment(amount=10.0, idempotency_key="explicit-key", tool_call_id="explicit")
+
+    assert seen == ["explicit-key"]
+
+
+def test_for_tool_rejects_propagation_without_provider_param() -> None:
+    with pytest.raises(ValueError, match="provider_idempotency_key_param"):
+        ToolTransitionBinding.for_tool(
+            agent_id="demo",
+            policy_version="1",
+            side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+            propagate_effect_id_as_provider_key=True,
+        )
+
+
+def test_keyed_mutate_with_declared_param_propagates_by_default() -> None:
+    binding = _keyed_binding(enforce=True)
+    assert should_propagate_effect_id_as_provider_key(binding) is True
+
+
+def test_propagation_flag_does_not_loosen_explicit_blind_capability() -> None:
+    binding = ToolTransitionBinding.for_tool(
+        agent_id="demo",
+        policy_version="1",
+        side_effect_class=SideEffectClass.NON_IDEMPOTENT_MUTATE,
+        provider_idempotency_key_param="idempotency_key",
+        capability=ToolCapability.BLIND,
+        propagate_effect_id_as_provider_key=True,
+    )
+    assert should_propagate_effect_id_as_provider_key(binding) is True
+    assert binding.capability == ToolCapability.BLIND
+    assert binding.effective_capability(has_reconciler=False) == ToolCapability.BLIND
+
+
 # --- config wiring ---------------------------------------------------------
 
 
@@ -248,6 +371,22 @@ tools:
   send_payment:
     side_effect_class: keyed_mutate
     provider_idempotency_key_param: 123
+"""
+    with pytest.raises(ConfigError, match="provider_idempotency_key_param"):
+        load_config_from_string(yaml_text)
+
+
+def test_config_rejects_propagation_without_provider_param() -> None:
+    from mycelium import ConfigError
+
+    yaml_text = """
+transition:
+  agent_id: demo
+  policy_version: "1"
+tools:
+  send_payment:
+    side_effect_class: non_idempotent_mutate
+    propagate_effect_id_as_provider_key: true
 """
     with pytest.raises(ConfigError, match="provider_idempotency_key_param"):
         load_config_from_string(yaml_text)

--- a/sdk/tests/test_simulation.py
+++ b/sdk/tests/test_simulation.py
@@ -24,6 +24,7 @@ def _entry(
     ref: str | None = None,
     effect_id: str | None = None,
 ) -> LedgerEntry:
+    resolved_effect_id = effect_id or request_id
     return LedgerEntry(
         request_id=request_id,
         tool="charge",
@@ -32,7 +33,8 @@ def _entry(
         status="completed" if terminal == "COMPLETED" else "failed",
         terminal_outcome=terminal,
         external_operation_ref=ref,
-        idempotency_key=effect_id or request_id,
+        idempotency_key=resolved_effect_id,
+        effect_id=resolved_effect_id,
     )
 
 
@@ -157,3 +159,25 @@ def test_simulation_scenario_known() -> None:
     from mycelium.verify.registry import known_scenarios
 
     assert "simulation" in known_scenarios()
+    assert "state-machine-exhaustive" in known_scenarios()
+
+
+def test_state_machine_exhaustive_scenario_passes(tmp_path: Path) -> None:
+    mod = types.ModuleType("verify_probe_tools")
+    mod.charge = lambda order_id: {"charged": True}  # type: ignore[attr-defined]
+    sys.modules["verify_probe_tools"] = mod
+    try:
+        report = run_verify(
+            _sqlite_dev(tmp_path),
+            scenarios=["state-machine-exhaustive"],
+            connectivity=False,
+            timeout_seconds=25,
+        )
+        evidence = report.scenarios[0]
+        assert evidence.status == VerificationStatus.PASS, evidence.observed_behavior
+        decisions = " ".join(evidence.ledger_decisions)
+        assert "stale-fence" in decisions
+        assert "reconcile" in decisions
+        assert "concurrent-claim" in decisions
+    finally:
+        del sys.modules["verify_probe_tools"]

--- a/sdk/tests/test_verify.py
+++ b/sdk/tests/test_verify.py
@@ -675,6 +675,7 @@ def test_all_order_sqlite(tmp_path: Path, scenario: str) -> None:
         "authority-window",
         "use-time-currency",
         "simulation",
+        "state-machine-exhaustive",
     ]
     assert all(item.status == VerificationStatus.PASS for item in report.scenarios)
     assert report.empirically_verified is True


### PR DESCRIPTION
## Summary
- Make derived `effect_id` the authoritative dedupe key: secondary indexes on all storage backends, `request_id_aliases` on ledger rows, and cross-request alias resolution in `claim_side_effecting`.
- Default keyed-mutate provider-key propagation from `effect_id` when the kwarg is omitted; reuse stored keys on retry.
- Add `state-machine-exhaustive` verify scenario, `check_unique_effect_id_index`, and `sdk/docs/spec/effect_state.tla` formal sketch.

## Test plan
- [x] `ruff check mycelium tests`
- [x] `pytest` — 1311 passed (excluding CLI import and live Redis/Postgres outage tests)
- [x] Focused: `test_effect_id_index`, `test_simulation`, `test_state_machine_exhaustive`, `test_provider_idempotency_key`, reconcile verify scenario
- [ ] Manual `publish.yml` dispatch for v1.35.0 after merge (tag auto-trigger still broken)