### PR TITLE
release: v1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ## Unreleased
 
+## 1.36.0 (2026-08-27)
+
+MINOR: adds an opt-in deployment verification layer for teams that want to
+exercise Mycelium across real shared infrastructure before approving a change.
+Ordinary `mycelium verify --scenario ...` remains synthetic and unchanged.
+
+### Added
+
+- Optional `mycelium verify --cluster` mode for Redis/PostgreSQL deployments.
+  It requires explicit `verify.cluster.enabled: true` and
+  `deployment.topology: multi_node`, launches exactly two subprocess workers,
+  interrupts their real backend connection through a verifier-owned TCP proxy,
+  hard-kills worker A after a sandbox provider operation, and requires worker B
+  to reconcile the recorded operation without executing the provider body a
+  second time.
+- Fail-closed `http_json` sandbox-provider adapter using idempotent
+  `PUT /operations/{operation_id}` and read-only
+  `GET /operations/{operation_id}` calls. Provider URLs, tokens, and attestation
+  keys are read from named environment variables and excluded from reports.
+- Versioned HMAC-SHA256 deployment attestations binding the configuration
+  digest, backend, topology, namespace, provider adapter, worker count, cleanup,
+  and the complete required check set. CI and change-approval systems can
+  validate a report with `mycelium verify --verify-attestation FILE
+  --attestation-key-env ENV`.
+- Cluster configuration examples, safety limitations, dedicated unit tests, and
+  a live Redis integration test covering interruption, hard worker death,
+  reconciliation, duplicate prevention, cleanup, and signature verification.
+
 ## 1.35.0 (2026-08-25)
 
 MINOR: one coherent trust-boundary batch: closes the remaining effect-commit

--- a/sdk/docs/FAILURE_AND_THREAT_MODEL.md
+++ b/sdk/docs/FAILURE_AND_THREAT_MODEL.md
@@ -410,6 +410,7 @@ are cited once. "Where documented" links the README section.
 | Use-time currency (when enabled) | README § [Use-time currency (AF-012)](../README.md#use-time-currency-af-012) | `test_use_time_currency.py` · `test_verify.py::test_cli_smoke_each_scenario` (`use-time-currency`) |
 | Single-key state machine invariants (executions ≤ 1 + not-executed verdicts; COMPLETED terminal; CAS out of IN_FLIGHT) | this doc, § C / [NOT_EXECUTED reset CAS](../README.md#not_executed-reset-cas-v118) | `test_property_transitions.py::test_transition_key_invariants` (Hypothesis, file + Redis) · `test_payment_provider_mock.py::test_redispatch_storm_never_double_charges` |
 | Deterministic simulation invariants (legacy + exhaustive interleavings) | README § [`mycelium verify`](../README.md#mycelium-verify-exercise-the-guarantees) | `test_simulation.py::test_simulation_scenario_passes_on_shared_backend` · `test_simulation.py::test_state_machine_exhaustive_scenario_passes` · `test_verify.py::test_all_order_sqlite` |
+| Optional two-worker cluster interruption, hard-kill recovery, sandbox reconciliation, cleanup, and signed deployment attestation | README § [Optional cluster verification](../README.md#optional-cluster-verification) | `test_cluster_verify.py::test_live_redis_cluster_flow_when_configured` · `test_cluster_verify.py::test_backend_fault_proxy_interrupts_and_restores_connections` · `test_cluster_verify.py::test_cli_verifies_signed_attestation` |
 
 <sup>1</sup> `test_postgres_storage_atomic_claim` runs when `psycopg` is
 installed and `MYCELIUM_TEST_POSTGRES_DSN` is set; it skips otherwise.
@@ -503,6 +504,19 @@ Still can go wrong — even with everything above configured correctly:
   business provider. Some infrastructure properties (Redis persistence,
   host call-site identity) remain operator assertions or not verifiable
   and are not converted into “proven” by a passing Verify report.
+- **Cluster verification is opt-in deployment evidence, not a production
+  proof.** `mycelium verify --cluster` requires an explicit multi-node
+  Redis/PostgreSQL test deployment, provider sandbox, and attestation key. It
+  launches two workers, severs their backend connection, kills one after the
+  sandbox effect, and requires the survivor to reconcile without re-executing
+  the provider body. The signed attestation binds the tested configuration and
+  complete check set, but cannot prove that production behaves like the
+  sandbox, that Redis persistence is enabled, that a signing key is
+  uncompromised, or that failures outside the injected sequence are safe. The
+  built-in TCP proxy rejects `rediss://` and hostname-verifying PostgreSQL TLS;
+  the sandbox operation is retained and should expire under provider test-data
+  policy. Ordinary `--scenario` verification remains synthetic and never
+  contacts a provider.
 
 
 ---

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mycelium-runtime"
-version = "1.35.0"
+version = "1.36.0"
 description = "The reliability layer for AI agents — prove run-or-not and enforce at-most-once at the tool boundary"
 authors = [
   { name = "Nandana Dileep" },

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "mycelium-runtime"
-version = "1.35.0"
+version = "1.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Release summary

Publishes the optional two-worker cluster verification mode merged in #108.
Normal `mycelium verify --scenario ...` behavior remains synthetic and unchanged.

## Release checklist

### Intent

- [x] Intentional backward-compatible MINOR release with real user-facing behavior
- [x] No other `mycelium-runtime` version published today
- [x] CHANGELOG presents one coherent deployment-verification story
- [x] Reliability-layer positioning retained; no velocity claims

### Correctness

- [x] `pytest tests/`: 1373 passed, 15 skipped
- [x] `ruff check mycelium tests`: clean
- [x] Main CI for merged feature: green
- [x] New guarantees mapped to unit tests and live Redis integration test
- [ ] Release PR CI green on Python 3.10–3.13

### Surface area

- [x] New public symbols exported from `mycelium.__init__`
- [x] YAML template updated
- [x] SDK README updated
- [x] Failure/threat model updated with evidence and residual risks
- [x] Handbook/site: N/A; existing documentation is not version-pinned or misleading

### Versioning

- [x] `sdk/pyproject.toml` bumped once to `1.36.0`
- [x] `sdk/uv.lock` matches `1.36.0`
- [x] `CHANGELOG.md` includes `## 1.36.0 (2026-08-27)`
- [x] Root and SDK README do not hardcode a current version
- [x] Wheel and sdist build successfully and contain the cluster modules

After merge, `release.yml` should tag `v1.36.0`, create the GitHub Release, and trigger the trusted PyPI publish workflow.
