### PR TITLE
Fix manual max_steps ceiling enforcement

### DIFF
--- a/sdk/mycelium/budget_guard.py
+++ b/sdk/mycelium/budget_guard.py
@@ -1130,7 +1130,10 @@ class BudgetGuard:
         c = self._ceilings
         if c.max_duration is not None and (now - state.started_at) >= c.max_duration:
             return "max_duration"
-        if c.max_steps is not None and (state.steps + pending_steps) > c.max_steps:
+        if c.max_steps is not None and (
+            state.steps + pending_steps > c.max_steps
+            or (pending_steps == 0 and state.steps >= c.max_steps)
+        ):
             return "max_steps"
         if c.max_tokens is not None and state.tokens >= c.max_tokens:
             return "max_tokens"

--- a/sdk/tests/test_budget_guard.py
+++ b/sdk/tests/test_budget_guard.py
@@ -94,6 +94,21 @@ def test_max_steps_soft_warn_allows_then_hard() -> None:
         assert calls["n"] == 5
 
 
+def test_manual_max_steps_ceiling_blocks_at_n() -> None:
+    guard = BudgetGuard(
+        InMemoryBudgetGuardStorage(), max_steps=3, warn_at=1.0, on_missing_meter="off"
+    )
+
+    with execution_scope(_scope("manual-steps")):
+        for _ in range(3):
+            guard.check(KIND_TOOL, increment_steps=False)
+            with pytest.warns(UserWarning, match="adds host-reported steps"):
+                guard.record_usage(steps=1)
+
+        with pytest.raises(LedgerHardBlockError):
+            guard.check(KIND_TOOL, increment_steps=False)
+
+
 def test_warn_at_does_not_refuse_under_ceiling_usd() -> None:
     """Honey Mail 2: warn_at is permissive — $0.85 of $1.00 must not refuse."""
     guard = BudgetGuard(


### PR DESCRIPTION
## Issue

Closes #103

## Summary

The documented manual `BudgetGuard` integration could execute `max_steps + 1` steps because a check with `increment_steps=False` allowed the already-consumed count to equal the ceiling.

## Changes

- Treat an already-reached `max_steps` ceiling as exhausted for manual checks.
- Add a regression test proving the manual path blocks at the declared ceiling.

## Compatibility

Automatic step reservation behavior is unchanged. This only makes the documented manual accounting path enforce the same ceiling.

## Validation

- `python -m pytest tests/test_budget_guard.py -q` — 16 passed
- `python -m ruff check mycelium tests` — passed
- `git diff --check` — passed

The focused test run used a repository-local temporary directory because the host default pytest temporary directory was not writable.
