### PR TITLE
Fix BudgetGuard warning after manual step opt-out

### DIFF
--- a/sdk/mycelium/budget_guard.py
+++ b/sdk/mycelium/budget_guard.py
@@ -180,10 +180,10 @@ class BudgetRunState:
     usage_unknown: bool = False
     last_model: str | None = None
     last_provider: str | None = None
+    updated_at: float = field(default_factory=time.time)
     # ``None`` means no check has run yet; otherwise this records whether the
     # most recent check reserved a step for automatic accounting.
     last_check_incremented_steps: bool | None = None
-    updated_at: float = field(default_factory=time.time)
 
     @property
     def tokens(self) -> int:
@@ -212,8 +212,8 @@ class BudgetRunState:
             "usage_unknown": self.usage_unknown,
             "last_model": self.last_model,
             "last_provider": self.last_provider,
-            "last_check_incremented_steps": self.last_check_incremented_steps,
             "updated_at": self.updated_at,
+            "last_check_incremented_steps": self.last_check_incremented_steps,
         }
 
     @classmethod

--- a/sdk/mycelium/budget_guard.py
+++ b/sdk/mycelium/budget_guard.py
@@ -180,6 +180,9 @@ class BudgetRunState:
     usage_unknown: bool = False
     last_model: str | None = None
     last_provider: str | None = None
+    # ``None`` means no check has run yet; otherwise this records whether the
+    # most recent check reserved a step for automatic accounting.
+    last_check_incremented_steps: bool | None = None
     updated_at: float = field(default_factory=time.time)
 
     @property
@@ -209,6 +212,7 @@ class BudgetRunState:
             "usage_unknown": self.usage_unknown,
             "last_model": self.last_model,
             "last_provider": self.last_provider,
+            "last_check_incremented_steps": self.last_check_incremented_steps,
             "updated_at": self.updated_at,
         }
 
@@ -241,6 +245,11 @@ class BudgetRunState:
             last_provider=(
                 str(data["last_provider"])
                 if data.get("last_provider") is not None
+                else None
+            ),
+            last_check_incremented_steps=(
+                bool(data["last_check_incremented_steps"])
+                if data.get("last_check_incremented_steps") is not None
                 else None
             ),
             updated_at=float(data.get("updated_at") or time.time()),
@@ -861,6 +870,7 @@ class BudgetGuard:
 
             if increment_steps:
                 state.steps += 1
+            state.last_check_incremented_steps = increment_steps
             outcome["state"] = state
             return state
 
@@ -892,8 +902,9 @@ class BudgetGuard:
         Prefer ``check()`` to reserve steps before work; use ``record_usage``
         after the host observes token/USD spend. ``check()`` and the budget
         decorators auto-meter one step by default. Passing ``steps`` here is
-        supported for fully manual integrations, but warns because combining
-        it with the default check/decorator behavior double-counts steps.
+        supported for fully manual integrations; it warns unless the current
+        run's latest ``check()`` used ``increment_steps=False``, because
+        combining it with automatic accounting double-counts steps.
         """
         global _SCOPE_MISSING_WARNED
 
@@ -918,19 +929,17 @@ class BudgetGuard:
         add_steps = int(steps)
         if add_in < 0 or add_out < 0 or add_usd < 0 or add_steps < 0:
             raise ValueError("usage deltas must be non-negative")
-        if add_steps:
-            warnings.warn(
-                "BudgetGuard.record_usage(steps=...) adds host-reported steps, "
-                "but check() and @budget_guard auto-meter one step by default. "
-                "Use steps=0, or use check(increment_steps=False) in a fully "
-                "manual integration, to avoid double metering.",
-                UserWarning,
-                stacklevel=2,
-            )
 
-        outcome: dict[str, Any] = {"exc": None, "state": None}
+        outcome: dict[str, Any] = {"exc": None, "state": None, "warning": None}
 
         def apply(state: BudgetRunState) -> BudgetRunState:
+            if add_steps and state.last_check_incremented_steps is not False:
+                outcome["warning"] = (
+                    "BudgetGuard.record_usage(steps=...) adds host-reported steps, "
+                    "but check() and @budget_guard auto-meter one step by default. "
+                    "Use steps=0, or use check(increment_steps=False) in a fully "
+                    "manual integration, to avoid double metering."
+                )
             if state.hard_blocked and not state.allow_once:
                 outcome["exc"] = LedgerHardBlockError(
                     f"BudgetGuard: run {key!r} is hard-blocked"
@@ -970,6 +979,9 @@ class BudgetGuard:
             return state
 
         self._storage.update(key, apply)
+        warning = outcome["warning"]
+        if warning is not None:
+            warnings.warn(warning, UserWarning, stacklevel=2)
         exc = outcome["exc"]
         if exc is not None:
             raise exc
@@ -1023,6 +1035,7 @@ class BudgetGuard:
                 state.tokens_in = 0
                 state.tokens_out = 0
                 state.usd = 0.0
+                state.last_check_incremented_steps = None
                 state.started_at = now
             elif verified == VERIFIED_ALLOW_ONCE:
                 state.hard_blocked = False

--- a/sdk/tests/test_budget_guard.py
+++ b/sdk/tests/test_budget_guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
+import warnings
 
 import pytest
 
@@ -100,10 +101,12 @@ def test_manual_max_steps_ceiling_blocks_at_n() -> None:
     )
 
     with execution_scope(_scope("manual-steps")):
-        for _ in range(3):
-            guard.check(KIND_TOOL, increment_steps=False)
-            with pytest.warns(UserWarning, match="adds host-reported steps"):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            for _ in range(3):
+                guard.check(KIND_TOOL, increment_steps=False)
                 guard.record_usage(steps=1)
+        assert not caught
 
         with pytest.raises(LedgerHardBlockError):
             guard.check(KIND_TOOL, increment_steps=False)

--- a/sdk/tests/test_budget_guard.py
+++ b/sdk/tests/test_budget_guard.py
@@ -18,6 +18,7 @@ from mycelium.budget_guard import (
     KIND_TOOL,
     ON_MISSING_HARD,
     BudgetGuard,
+    BudgetRunState,
     FileBudgetGuardStorage,
     InMemoryBudgetGuardStorage,
     SqliteBudgetGuardStorage,
@@ -42,6 +43,32 @@ def test_parse_duration_seconds() -> None:
     assert parse_duration_seconds("1h") == 3600.0
     with pytest.raises(ValueError):
         parse_duration_seconds("nope")
+
+
+def test_budget_run_state_positional_constructor_preserves_updated_at() -> None:
+    state = BudgetRunState(
+        "compat",
+        1.0,
+        2,
+        3,
+        4,
+        5.0,
+        True,
+        {"max_steps": True},
+        True,
+        "max_steps",
+        "clear",
+        "ops@example.com",
+        "reset",
+        6.0,
+        True,
+        "model",
+        "provider",
+        7.0,
+    )
+
+    assert state.updated_at == 7.0
+    assert state.last_check_incremented_steps is None
 
 
 def test_max_steps_ceiling_allows_n() -> None:


### PR DESCRIPTION
Fixes #104

`record_usage(steps=...)` no longer emits the double-metering warning after an explicit `check(increment_steps=False)`. The warning remains for automatic step reservation.

Tests: BudgetGuard and BudgetGuard LLM tests (24 passed).