### PR TITLE
fix(storage): fail closed on corrupt JSON state

### DIFF
--- a/sdk/mycelium/storage/__init__.py
+++ b/sdk/mycelium/storage/__init__.py
@@ -12,7 +12,7 @@ from mycelium.storage.atomic_state import (
     RedisAtomicStateBackend,
 )
 from mycelium.storage.file_lock import PathFileLock
-from mycelium.storage.json_file import LockedJsonDictFile
+from mycelium.storage.json_file import LockedJsonDictFile, StorageCorruptionError
 from mycelium.storage.postgres_ledger import (
     PostgresLedgerStorage,
     PostgresTaskLedgerStorage,
@@ -48,4 +48,5 @@ __all__ = [
     "RedisTaskLedgerStorage",
     "SqliteLedgerStorage",
     "SqliteTaskLedgerStorage",
+    "StorageCorruptionError",
 ]

--- a/sdk/mycelium/storage/json_file.py
+++ b/sdk/mycelium/storage/json_file.py
@@ -13,6 +13,10 @@ from mycelium.storage.file_lock import PathFileLock
 T = TypeVar("T")
 
 
+class StorageCorruptionError(RuntimeError):
+    """Raised when a JSON-backed storage file is not a valid object."""
+
+
 class LockedJsonDictFile:
     """JSON object file with exclusive ``fcntl`` locking on read-modify-write."""
 
@@ -27,10 +31,12 @@ class LockedJsonDictFile:
         try:
             with self._path.open("r", encoding="utf-8") as handle:
                 data = json.load(handle)
-        except json.JSONDecodeError:
-            return {}
+        except json.JSONDecodeError as exc:
+            raise StorageCorruptionError(f"invalid JSON in storage file {self._path}") from exc
         if not isinstance(data, dict):
-            return {}
+            raise StorageCorruptionError(
+                f"storage file {self._path} must contain a JSON object"
+            )
         return data
 
     def save(self, data: dict[str, dict[str, Any]]) -> None:

--- a/sdk/tests/test_json_file.py
+++ b/sdk/tests/test_json_file.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-from mycelium.storage.json_file import LockedJsonDictFile
+import pytest
+
+from mycelium.storage.json_file import LockedJsonDictFile, StorageCorruptionError
 
 
 def test_save_fsyncs_tmp_before_replace(tmp_path: Path) -> None:
@@ -26,3 +28,35 @@ def test_save_fsyncs_tmp_before_replace(tmp_path: Path) -> None:
     assert store.load() == {"k1": {"v": 1}}
     # tmp file fsync + best-effort directory fsync
     assert len(fsync_fds) >= 1
+
+
+@pytest.mark.parametrize("payload", ['{"old-run":', "[]"])
+def test_load_rejects_corrupt_json_without_rewriting(
+    tmp_path: Path,
+    payload: str,
+) -> None:
+    path = tmp_path / "state.json"
+    path.write_text(payload, encoding="utf-8")
+    original = path.read_bytes()
+
+    with pytest.raises(StorageCorruptionError):
+        LockedJsonDictFile(path).load()
+
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("payload", ['{"old-run":', "[]"])
+def test_read_modify_write_rejects_corrupt_json_without_overwriting(
+    tmp_path: Path,
+    payload: str,
+) -> None:
+    path = tmp_path / "state.json"
+    path.write_text(payload, encoding="utf-8")
+    original = path.read_bytes()
+
+    with pytest.raises(StorageCorruptionError):
+        LockedJsonDictFile(path).read_modify_write(
+            lambda data: data.update({"new-run": {"steps": 1}})
+        )
+
+    assert path.read_bytes() == original


### PR DESCRIPTION
Fixes #122

Malformed or non-object JSON now raises `StorageCorruptionError` instead of silently resetting the file to `{}`. `load()` and `read_modify_write()` preserve the original file bytes on corruption.

Tests: 8 focused storage tests passed (`test_json_file.py` plus file-backed storage coverage). No migration or unrelated behavior change.