### PR TITLE
Validate webhook exporter timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ### Fixed
 
+- Validate webhook exporter timeouts as finite, positive numbers and reject
+  booleans in both direct construction and YAML configuration.
 - Compare contention and concurrent-reconciliation worker results as structured
   JSON so PostgreSQL JSONB key reordering cannot cause false verification failures.
 - Include the official `mycelium-setup` coding-agent skill in built wheels and

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -2038,7 +2038,7 @@ class MyceliumConfig:
                             url,
                             headers={str(k): str(v) for k, v in (headers or {}).items()},
                             secret=str(secret) if secret is not None else None,
-                            timeout=float(item.get("timeout", 5.0)),
+                            timeout=item.get("timeout", 5.0),
                         )
                     )
                 else:

--- a/sdk/mycelium/outcome_export.py
+++ b/sdk/mycelium/outcome_export.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import math
 import threading
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -288,8 +289,14 @@ class WebhookOutcomeStorage(OutcomeStorage):
     ) -> None:
         if not url:
             raise ValueError("webhook url must be non-empty")
-        if timeout <= 0:
-            raise ValueError("webhook timeout must be positive")
+        try:
+            valid_timeout = (
+                not isinstance(timeout, bool) and math.isfinite(timeout) and timeout > 0
+            )
+        except TypeError:
+            valid_timeout = False
+        if not valid_timeout:
+            raise ValueError("webhook timeout must be a finite positive number")
         self._url = url
         self._headers = dict(headers or {})
         self._secret = secret.encode() if isinstance(secret, str) else secret

--- a/sdk/tests/test_outcome_emit.py
+++ b/sdk/tests/test_outcome_emit.py
@@ -515,6 +515,50 @@ outcome_emit:
     )
 
 
+@pytest.mark.parametrize("timeout", [".nan", ".inf", "-.inf", "true", "false", "0", "-1"])
+def test_config_rejects_invalid_webhook_timeout(tmp_path: Path, timeout: str) -> None:
+    config = load_config_from_string(
+        f"""
+transition:
+  agent_id: acme
+  policy_version: "1"
+outcome_emit:
+  storage: file
+  path: {tmp_path / "outcomes.jsonl"}
+  exporters:
+    - type: webhook
+      url: https://events.example.test/mycelium
+      timeout: {timeout}
+"""
+    )
+    with pytest.raises(ConfigError, match=r"outcome exporter 'webhook' is invalid"):
+        config.build_outcome_emitter()
+
+
+@pytest.mark.parametrize("timeout", [1, 2.5])
+def test_config_accepts_positive_finite_webhook_timeout(tmp_path: Path, timeout: float) -> None:
+    config = load_config_from_string(
+        f"""
+transition:
+  agent_id: acme
+  policy_version: "1"
+outcome_emit:
+  storage: file
+  path: {tmp_path / "outcomes.jsonl"}
+  exporters:
+    - type: webhook
+      url: https://events.example.test/mycelium
+      timeout: {timeout}
+"""
+    )
+    emitter = config.build_outcome_emitter()
+    assert emitter is not None
+    webhook = next(
+        sink for sink in emitter.storage._sinks if isinstance(sink, WebhookOutcomeStorage)
+    )
+    assert webhook._timeout == timeout
+
+
 def test_config_apply_tool_wires_outcome_emitter(tmp_path: Path) -> None:
     path = tmp_path / "mycelium.yaml"
     path.write_text(

--- a/sdk/tests/test_outcome_export.py
+++ b/sdk/tests/test_outcome_export.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import math
 import sys
 from types import SimpleNamespace
 from typing import Any
+
+import pytest
 
 from mycelium.outcome_emit import (
     EVENT_DECISION_DENIAL,
@@ -192,6 +195,20 @@ def test_webhook_posts_versioned_signed_envelope(monkeypatch: Any) -> None:
     expected = hmac.new(b"signing-key", body, hashlib.sha256).hexdigest()
     assert request.headers["X-mycelium-signature"] == f"sha256={expected}"
     assert captured["timeout"] == 2.5
+
+
+@pytest.mark.parametrize(
+    "timeout", [None, "5", 0, -1, math.nan, math.inf, -math.inf, True, False]
+)
+def test_webhook_rejects_non_finite_non_positive_and_boolean_timeouts(timeout: Any) -> None:
+    with pytest.raises(ValueError, match="finite positive"):
+        WebhookOutcomeStorage("https://events.example.test/outcomes", timeout=timeout)
+
+
+@pytest.mark.parametrize("timeout", [0.001, 2, 2.5])
+def test_webhook_accepts_positive_finite_timeouts(timeout: float) -> None:
+    storage = WebhookOutcomeStorage("https://events.example.test/outcomes", timeout=timeout)
+    assert storage._timeout == timeout
 
 
 def test_fanout_writes_all_sinks_and_reads_primary() -> None:


### PR DESCRIPTION
## What changed

`WebhookOutcomeStorage` now accepts only finite, positive numeric timeouts and rejects boolean values. YAML webhook exporters pass the original timeout value through the same validation so invalid values raise a contextual `ConfigError` during configuration setup.

The change covers direct construction and `outcome_emit.exporters` configuration while preserving positive integer and floating-point timeouts. The changelog records the user-visible validation fix.

## Validation

- `tests/test_outcome_export.py` and `tests/test_outcome_emit.py`: 60 passed
- `ruff check mycelium tests`: passed
- Full `pytest tests/ -q`: 1415 passed, 12 skipped, 23 failures on Windows; the failures are pre-existing in unrelated CLI/verify paths. The same failure set was reproduced from the clean base worktree, including `os.fork` on Windows, SQLite `WinError 32` teardown, and subprocess exit `3221225477`.

AI assistance: I used Codex to inspect and draft this change, then reviewed the submitted lines and validation results.
