### PR TITLE
Fix Webhook and Config validations

### DIFF
--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -2244,7 +2244,12 @@ def _parse_tool_config(
     protect = raw.get("protect")
     bounded = raw.get("bounded")
     ledger_raw = raw.get("ledger")
-    audit_receipt = bool(raw.get("audit_receipt", False))
+    raw_audit = raw.get("audit_receipt")
+    if isinstance(raw_audit, str) and raw_audit.lower() == "false":
+        raw_audit = False
+    elif isinstance(raw_audit, str) and raw_audit.lower() == "true":
+        raw_audit = True
+    audit_receipt = bool(raw_audit if raw_audit is not None else False)
 
     if protect is not None and not isinstance(protect, dict):
         raise ConfigError(f"tool '{name}'.protect must be a mapping")
@@ -2278,7 +2283,7 @@ def _parse_tool_config(
             raise ConfigError(str(exc)) from exc
 
     ledger = _normalize_ledger_config(name, ledger_raw, action_ledger_global)
-    if audit_auto and ledger is not None and raw.get("audit_receipt") is not False:
+    if audit_auto and ledger is not None and raw_audit is not False:
         audit_receipt = True
 
     side_effect_class: SideEffectClass | None = None
@@ -2503,9 +2508,14 @@ def _parse_task_config(
             ledger_raw = {"id_from": id_from}
         elif isinstance(ledger_raw, dict):
             ledger_raw = {**ledger_raw, "id_from": id_from}
-    audit_receipt = bool(raw.get("audit_receipt", False))
+    raw_audit = raw.get("audit_receipt")
+    if isinstance(raw_audit, str) and raw_audit.lower() == "false":
+        raw_audit = False
+    elif isinstance(raw_audit, str) and raw_audit.lower() == "true":
+        raw_audit = True
+    audit_receipt = bool(raw_audit if raw_audit is not None else False)
     ledger = _normalize_ledger_config(name, ledger_raw, task_ledger_global)
-    if audit_auto and ledger is not None and raw.get("audit_receipt") is not False:
+    if audit_auto and ledger is not None and raw_audit is not False:
         audit_receipt = True
 
     callable_path = _parse_callable_path(

--- a/sdk/mycelium/outcome_export.py
+++ b/sdk/mycelium/outcome_export.py
@@ -286,10 +286,15 @@ class WebhookOutcomeStorage(OutcomeStorage):
         secret: str | bytes | None = None,
         timeout: float = 5.0,
     ) -> None:
+        import math
         if not url:
             raise ValueError("webhook url must be non-empty")
-        if timeout <= 0:
-            raise ValueError("webhook timeout must be positive")
+        if isinstance(timeout, bool):
+            raise TypeError("webhook timeout must not be a boolean")
+        if not isinstance(timeout, (int, float)):
+            raise TypeError("webhook timeout must be a number")
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("webhook timeout must be a positive finite number")
         self._url = url
         self._headers = dict(headers or {})
         self._secret = secret.encode() if isinstance(secret, str) else secret


### PR DESCRIPTION
Fixes two issues: 1) The webhook outcome timeout parameter erroneously accepted dangerous floats (like NaN or Infinity) and booleans. Enhanced WebhookOutcomeStorage.__init__ with tight validation using math.isfinite() and explicit bool checks. 2) The audit_receipt configuration flag loosely coerced quoted false to True. Updated _parse_tool_config and _parse_task_config to explicitly check for the string false and map it properly to False.