### PR TITLE
Require boolean audit receipt flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ### Fixed
 
+- Require audit receipt flags in tool, task, and global configuration to be
+  YAML booleans instead of accepting truthy values such as quoted `false`.
 - Compare contention and concurrent-reconciliation worker results as structured
   JSON so PostgreSQL JSONB key reordering cannot cause false verification failures.
 - Include the official `mycelium-setup` coding-agent skill in built wheels and

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -2229,6 +2229,21 @@ def _merge_storage_settings(
     return merged
 
 
+def _parse_bool_option(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    field: str,
+    default: bool,
+) -> bool:
+    if key not in raw:
+        return default
+    value = raw[key]
+    if not isinstance(value, bool):
+        raise ConfigError(f"{field} must be a boolean")
+    return value
+
+
 def _parse_tool_config(
     name: str,
     raw: dict[str, Any] | None,
@@ -2244,7 +2259,12 @@ def _parse_tool_config(
     protect = raw.get("protect")
     bounded = raw.get("bounded")
     ledger_raw = raw.get("ledger")
-    audit_receipt = bool(raw.get("audit_receipt", False))
+    audit_receipt = _parse_bool_option(
+        raw,
+        "audit_receipt",
+        field=f"tool '{name}'.audit_receipt",
+        default=False,
+    )
 
     if protect is not None and not isinstance(protect, dict):
         raise ConfigError(f"tool '{name}'.protect must be a mapping")
@@ -2503,7 +2523,12 @@ def _parse_task_config(
             ledger_raw = {"id_from": id_from}
         elif isinstance(ledger_raw, dict):
             ledger_raw = {**ledger_raw, "id_from": id_from}
-    audit_receipt = bool(raw.get("audit_receipt", False))
+    audit_receipt = _parse_bool_option(
+        raw,
+        "audit_receipt",
+        field=f"task '{name}'.audit_receipt",
+        default=False,
+    )
     ledger = _normalize_ledger_config(name, ledger_raw, task_ledger_global)
     if audit_auto and ledger is not None and raw.get("audit_receipt") is not False:
         audit_receipt = True
@@ -4008,7 +4033,14 @@ def _parse_config(
         if storage_type == "shared" and state_backend_raw is None:
             raise ConfigError("audit_receipt storage 'shared' requires state_backend")
 
-    audit_auto = bool(audit_receipt_raw and audit_receipt_raw.get("auto", True))
+    audit_auto = False
+    if audit_receipt_raw is not None:
+        audit_auto = _parse_bool_option(
+            audit_receipt_raw,
+            "auto",
+            field="'audit_receipt.auto'",
+            default=bool(audit_receipt_raw),
+        )
 
     outcome_emit_raw = data.get("outcome_emit")
     if outcome_emit_raw is not None and not isinstance(outcome_emit_raw, dict):

--- a/sdk/tests/test_config.py
+++ b/sdk/tests/test_config.py
@@ -482,6 +482,72 @@ tools:
     assert len(audit.storage.list_all()) == 1
 
 
+@pytest.mark.parametrize("value", ['"false"', '"true"', "0", "1", "null", "[]", "{}"])
+def test_tool_audit_receipt_requires_boolean(value: str) -> None:
+    with pytest.raises(ConfigError, match=r"tool 'send_payment'\.audit_receipt must be a boolean"):
+        load_config_from_string(f"""
+tools:
+  send_payment:
+    audit_receipt: {value}
+""")
+
+
+@pytest.mark.parametrize("value", ['"false"', '"true"', "0", "1", "null", "[]", "{}"])
+def test_task_audit_receipt_requires_boolean(value: str) -> None:
+    with pytest.raises(ConfigError, match=r"task 'summarize'\.audit_receipt must be a boolean"):
+        load_config_from_string(f"""
+tasks:
+  summarize:
+    audit_receipt: {value}
+""")
+
+
+@pytest.mark.parametrize("value", ['"false"', '"true"', "0", "1", "null", "[]", "{}"])
+def test_global_audit_receipt_auto_requires_boolean(value: str) -> None:
+    with pytest.raises(ConfigError, match=r"'audit_receipt\.auto' must be a boolean"):
+        load_config_from_string(f"""
+audit_receipt:
+  auto: {value}
+""")
+
+
+def test_audit_receipt_boolean_values_and_omitted_defaults() -> None:
+    config = load_config_from_string("""
+audit_receipt:
+  signing_key: test-key
+  storage: memory
+  auto: false
+action_ledger:
+  storage: memory
+  tools: [send_payment]
+task_ledger:
+  storage: memory
+  tasks: [summarize]
+tools:
+  send_payment:
+    audit_receipt: true
+tasks:
+  summarize:
+    audit_receipt: false
+""")
+    assert config.tools["send_payment"].audit_receipt is True
+    assert config.tasks["summarize"].audit_receipt is False
+
+    defaulted = load_config_from_string("""
+audit_receipt:
+  signing_key: test-key
+  storage: memory
+action_ledger:
+  storage: memory
+  tools: [send_payment]
+task_ledger:
+  storage: memory
+  tasks: [summarize]
+""")
+    assert defaulted.tools["send_payment"].audit_receipt is True
+    assert defaulted.tasks["summarize"].audit_receipt is True
+
+
 def test_global_action_ledger_and_ledger_true() -> None:
     yaml_text = """
 action_ledger:


### PR DESCRIPTION
## What changed

Audit receipt flags now require YAML booleans in tool, task, and global configuration. Quoted values such as `"false"`, numbers, nulls, lists, and mappings are rejected with field-specific `ConfigError` messages instead of being coerced by truthiness.

Omitted flags retain their existing defaults, and valid `true`/`false` values preserve the existing audit-receipt auto-enable precedence. The changelog records the validation fix.

## Validation

- `tests/test_config.py`: 64 passed
- `ruff check mycelium tests`: passed
- Full `pytest tests/ -q`: 1419 passed, 12 skipped, 22 failures on Windows; the failures are pre-existing in unrelated CLI/verify and multiprocess paths. The same 22 failures were reproduced from a clean base worktree, including `os.fork` availability, SQLite `WinError 32` teardown, and subprocess behavior.

AI assistance: I used Codex to inspect and draft this change, then reviewed the submitted lines and validation results.
