### PR TITLE
Reject invalid authority window skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ### Fixed
 
+- Reject non-finite and boolean authority-window clock-skew tolerances during
+  policy construction and YAML configuration loading.
 - Require audit receipt flags in tool, task, and global configuration to be
   YAML booleans instead of accepting truthy values such as quoted `false`.
 - Validate webhook exporter timeouts as finite, positive numbers and reject

--- a/sdk/mycelium/authority_window.py
+++ b/sdk/mycelium/authority_window.py
@@ -12,6 +12,7 @@ currency by itself — policy/state freshness beyond expiry lands in item 5.
 from __future__ import annotations
 
 import hashlib
+import math
 from collections.abc import Callable, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
@@ -167,9 +168,14 @@ class AuthorityWindowPolicy:
                 "authority_window.use_time_check must be one of "
                 f"{sorted(USE_TIME_CHECKS)}, got {self.use_time_check!r}"
             )
-        if self.clock_skew_tolerance_seconds < 0:
+        if (
+            not isinstance(self.clock_skew_tolerance_seconds, (int, float))
+            or isinstance(self.clock_skew_tolerance_seconds, bool)
+            or not math.isfinite(self.clock_skew_tolerance_seconds)
+            or self.clock_skew_tolerance_seconds < 0
+        ):
             raise ValueError(
-                "authority_window.clock_skew_tolerance_seconds must be >= 0"
+                "authority_window.clock_skew_tolerance_seconds must be a finite number >= 0"
             )
 
 

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import importlib
 import inspect
+import math
 import os
 import re
 import warnings
@@ -3433,8 +3434,15 @@ def _parse_authority_window(
             f"'authority_window.use_time_check' must be one of {sorted(USE_TIME_CHECKS)}"
         )
     skew = raw.get("clock_skew_tolerance_seconds", 0)
-    if not isinstance(skew, (int, float)) or isinstance(skew, bool) or skew < 0:
-        raise ConfigError("'authority_window.clock_skew_tolerance_seconds' must be a number >= 0")
+    if (
+        not isinstance(skew, (int, float))
+        or isinstance(skew, bool)
+        or not math.isfinite(skew)
+        or skew < 0
+    ):
+        raise ConfigError(
+            "'authority_window.clock_skew_tolerance_seconds' must be a finite number >= 0"
+        )
     if profile == PROFILE_PRODUCTION and destructive_confirm is not None:
         if not enabled or use_time != USE_TIME_CHECK_REQUIRED:
             raise ConfigError(

--- a/sdk/tests/test_authority_window.py
+++ b/sdk/tests/test_authority_window.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -493,6 +494,30 @@ authority_window:
   clock_skew_tolerance_seconds: -1
 """
         )
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf, True, False])
+def test_authority_window_policy_rejects_invalid_clock_skew(value: float) -> None:
+    with pytest.raises(ValueError, match="clock_skew"):
+        AuthorityWindowPolicy(clock_skew_tolerance_seconds=value)
+
+
+@pytest.mark.parametrize("value", [".nan", ".inf", "-.inf", "true", "false"])
+def test_config_authority_window_rejects_invalid_clock_skew(value: str) -> None:
+    with pytest.raises(ConfigError, match="clock_skew"):
+        load_config_from_string(f"""
+authority_window:
+  clock_skew_tolerance_seconds: {value}
+""")
+
+
+def test_authority_window_accepts_zero_and_finite_clock_skew() -> None:
+    assert (
+        AuthorityWindowPolicy(clock_skew_tolerance_seconds=0).clock_skew_tolerance_seconds == 0
+    )
+    assert (
+        AuthorityWindowPolicy(clock_skew_tolerance_seconds=2.5).clock_skew_tolerance_seconds == 2.5
+    )
 
 
 def test_omitted_config_preserves_behavior_without_destructive() -> None:


### PR DESCRIPTION
## What changed

Authority-window clock-skew tolerances now accept only finite numbers greater than or equal to zero. Boolean and non-finite values are rejected during direct policy construction and YAML configuration loading with a field-specific error.

Zero and ordinary finite tolerances remain valid. The changelog records the validation fix.

## Validation

- `tests/test_authority_window.py`: 29 passed
- `ruff check mycelium tests`: passed
- Full `pytest tests/ -q`: 1408 passed, 12 skipped, 22 failures on Windows; the failures are pre-existing in unrelated CLI/verify and multiprocess paths and were reproduced from a clean base worktree.

AI assistance: I used Codex to inspect and draft this change, then reviewed the submitted lines and validation results.
