### PR TITLE
Reject invalid use-time freshness windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
   YAML booleans instead of accepting truthy values such as quoted `false`.
 - Validate webhook exporter timeouts as finite, positive numbers and reject
   booleans in both direct construction and YAML configuration.
+- Reject non-finite and boolean use-time currency freshness windows during
+  fact construction and YAML configuration loading.
 - Compare contention and concurrent-reconciliation worker results as structured
   JSON so PostgreSQL JSONB key reordering cannot cause false verification failures.
 - Include the official `mycelium-setup` coding-agent skill in built wheels and

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import importlib
 import inspect
+import math
 import os
 import re
 import warnings
@@ -3537,9 +3538,14 @@ def _parse_use_time_fact(raw: Any, *, tool: str) -> dict[str, Any]:
         raise ConfigError(f"use_time_currency.tools.{tool}.facts[].validator is required")
     max_age = raw.get("max_age_seconds")
     if max_age is not None and (
-        not isinstance(max_age, (int, float)) or isinstance(max_age, bool) or max_age < 0
+        not isinstance(max_age, (int, float))
+        or isinstance(max_age, bool)
+        or not math.isfinite(max_age)
+        or max_age < 0
     ):
-        raise ConfigError(f"use_time_currency.tools.{tool}.facts[].max_age_seconds must be >= 0")
+        raise ConfigError(
+            f"use_time_currency.tools.{tool}.facts[].max_age_seconds must be a finite number >= 0"
+        )
     require = raw.get("require")
     if require is not None and not isinstance(require, dict):
         raise ConfigError(f"use_time_currency.tools.{tool}.facts[].require must be a mapping")

--- a/sdk/mycelium/use_time_currency.py
+++ b/sdk/mycelium/use_time_currency.py
@@ -14,6 +14,7 @@ import asyncio
 import functools
 import hashlib
 import inspect
+import math
 from collections.abc import Awaitable, Callable, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
@@ -137,8 +138,13 @@ class UseTimeFact:
             raise ValueError("use-time fact subject_type must be non-empty")
         if not self.subject_id or not str(self.subject_id).strip():
             raise ValueError("use-time fact subject_id must be non-empty")
-        if self.max_age_seconds is not None and self.max_age_seconds < 0:
-            raise ValueError("max_age_seconds must be >= 0")
+        if self.max_age_seconds is not None and (
+            not isinstance(self.max_age_seconds, (int, float))
+            or isinstance(self.max_age_seconds, bool)
+            or not math.isfinite(self.max_age_seconds)
+            or self.max_age_seconds < 0
+        ):
+            raise ValueError("max_age_seconds must be a finite number >= 0")
 
     @property
     def subject_ref(self) -> str:
@@ -239,8 +245,13 @@ class UseTimeFactSpec:
             raise ValueError("subject.id_from must be non-empty")
         if not self.validator or not str(self.validator).strip():
             raise ValueError("validator must be non-empty")
-        if self.max_age_seconds is not None and self.max_age_seconds < 0:
-            raise ValueError("max_age_seconds must be >= 0")
+        if self.max_age_seconds is not None and (
+            not isinstance(self.max_age_seconds, (int, float))
+            or isinstance(self.max_age_seconds, bool)
+            or not math.isfinite(self.max_age_seconds)
+            or self.max_age_seconds < 0
+        ):
+            raise ValueError("max_age_seconds must be a finite number >= 0")
 
 
 @dataclass(frozen=True)

--- a/sdk/tests/test_use_time_currency.py
+++ b/sdk/tests/test_use_time_currency.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from datetime import datetime, timezone
 from typing import Any
 
@@ -1649,6 +1650,42 @@ use_time_currency:
           validator: payment_state
 """
         )
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf, True, False])
+def test_use_time_facts_reject_invalid_max_age(value: float) -> None:
+    common = {
+        "name": "record.current",
+        "subject_type": "record",
+        "subject_id": "record-1",
+        "observed_at": datetime.now(timezone.utc),
+        "max_age_seconds": value,
+    }
+    with pytest.raises(ValueError, match="max_age_seconds"):
+        UseTimeFact(**common)
+    with pytest.raises(ValueError, match="max_age_seconds"):
+        UseTimeFactSpec(
+            name="record.current",
+            subject_type="record",
+            id_from="record_id",
+            validator="record_state",
+            max_age_seconds=value,
+        )
+
+
+@pytest.mark.parametrize("value", [".nan", ".inf", "-.inf", "true", "false"])
+def test_config_rejects_nonfinite_max_age(value: str) -> None:
+    with pytest.raises(ConfigError, match="max_age_seconds"):
+        load_config_from_string(f"""
+use_time_currency:
+  tools:
+    lookup_record:
+      facts:
+        - name: record.current
+          subject: {{type: record, id_from: record_id}}
+          validator: record_state
+          max_age_seconds: {value}
+""")
 
 
 def test_production_requires_missing_policy_error() -> None:


### PR DESCRIPTION
## What changed

Use-time currency freshness windows now accept only finite numeric values greater than or equal to zero. Boolean and non-finite values are rejected during direct `UseTimeFact`/`UseTimeFactSpec` construction and YAML configuration loading with a field-specific `ConfigError`.

Zero and ordinary finite values retain their existing behavior. The changelog records the validation fix.

## Validation

- `tests/test_use_time_currency.py`: 54 passed
- `ruff check mycelium tests`: passed
- Full `pytest tests/ -q`: 1405 passed, 12 skipped, 24 failures on Windows; the failures are pre-existing in unrelated CLI/verify and multiprocess paths. The affected CLI baseline was also reproduced from a clean base worktree, including Windows subprocess exit code `3221225477`.

AI assistance: I used Codex to inspect and draft this change, then reviewed the submitted lines and validation results.
