### PR TITLE
Reject invalid transition configuration values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
   booleans in both direct construction and YAML configuration.
 - Reject non-finite and boolean use-time currency freshness windows during
   fact construction and YAML configuration loading.
+- Reject invalid transition identity, boolean, and non-finite timing values
+  during YAML configuration loading.
 - Compare contention and concurrent-reconciliation worker results as structured
   JSON so PostgreSQL JSONB key reordering cannot cause false verification failures.
 - Include the official `mycelium-setup` coding-agent skill in built wheels and

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -2669,11 +2669,13 @@ def _parse_optional_positive_float(
         if allow_null:
             return None
         raise ConfigError(f"'{section}.{key}' cannot be null")
+    if isinstance(value, bool):
+        raise ConfigError(f"'{section}.{key}' must be a number")
     try:
         parsed = float(value)
     except (TypeError, ValueError) as exc:
         raise ConfigError(f"'{section}.{key}' must be a number") from exc
-    if parsed <= 0:
+    if not math.isfinite(parsed) or parsed <= 0:
         raise ConfigError(f"'{section}.{key}' must be greater than zero")
     return parsed
 
@@ -2693,11 +2695,13 @@ def _parse_optional_non_negative_float(
         if allow_null:
             return None
         raise ConfigError(f"'{section}.{key}' cannot be null")
+    if isinstance(value, bool):
+        raise ConfigError(f"'{section}.{key}' must be a number")
     try:
         parsed = float(value)
     except (TypeError, ValueError) as exc:
         raise ConfigError(f"'{section}.{key}' must be a number") from exc
-    if parsed < 0:
+    if not math.isfinite(parsed) or parsed < 0:
         raise ConfigError(f"'{section}.{key}' must be greater than or equal to zero")
     return parsed
 
@@ -2710,10 +2714,10 @@ def _parse_transition_config(raw: Any) -> TransitionConfig | None:
 
     agent_id = raw.get("agent_id")
     policy_version = raw.get("policy_version")
-    if not agent_id:
-        raise ConfigError("'transition.agent_id' is required")
-    if not policy_version:
-        raise ConfigError("'transition.policy_version' is required")
+    if not isinstance(agent_id, str) or not agent_id.strip():
+        raise ConfigError("'transition.agent_id' must be a non-empty string")
+    if not isinstance(policy_version, str) or not policy_version.strip():
+        raise ConfigError("'transition.policy_version' must be a non-empty string")
 
     scope_from_raw = raw.get("scope_from", {})
     if not isinstance(scope_from_raw, dict):
@@ -2727,14 +2731,16 @@ def _parse_transition_config(raw: Any) -> TransitionConfig | None:
     poll_interval = _parse_optional_positive_float(raw, "poll_interval", section="transition")
     poll_timeout = _parse_optional_positive_float(raw, "poll_timeout", section="transition")
 
-    reclaim_requires_death_signal = bool(raw.get("reclaim_requires_death_signal", True))
+    reclaim_requires_death_signal = raw.get("reclaim_requires_death_signal", True)
+    if not isinstance(reclaim_requires_death_signal, bool):
+        raise ConfigError("'transition.reclaim_requires_death_signal' must be a boolean")
     presumed_dead_after = _parse_optional_positive_float(
         raw, "presumed_dead_after", section="transition"
     )
 
     return TransitionConfig(
-        agent_id=str(agent_id),
-        policy_version=str(policy_version),
+        agent_id=agent_id.strip(),
+        policy_version=policy_version.strip(),
         scope_from=scope_from,
         lease_ttl=lease_ttl,
         lease_renew_interval=lease_renew_interval,

--- a/sdk/tests/test_config.py
+++ b/sdk/tests/test_config.py
@@ -450,6 +450,42 @@ transition:
         load_config_from_string(yaml_text)
 
 
+@pytest.mark.parametrize(
+    "field",
+    ["lease_ttl", "lease_renew_interval", "poll_interval", "poll_timeout", "presumed_dead_after"],
+)
+@pytest.mark.parametrize("value", [".nan", ".inf", "-.inf", "true", "false"])
+def test_transition_rejects_nonfinite_and_boolean_timing(field: str, value: str) -> None:
+    with pytest.raises(ConfigError, match=field):
+        load_config_from_string(f"""
+transition:
+  agent_id: payment-agent
+  policy_version: test
+  {field}: {value}
+""")
+
+
+@pytest.mark.parametrize("value", ['"false"', "0", "1", "null", "[]", "{}"])
+def test_transition_reclaim_requires_boolean(value: str) -> None:
+    with pytest.raises(ConfigError, match="reclaim_requires_death_signal"):
+        load_config_from_string(f"""
+transition:
+  agent_id: payment-agent
+  policy_version: test
+  reclaim_requires_death_signal: {value}
+""")
+
+
+@pytest.mark.parametrize("field", ["agent_id", "policy_version"])
+def test_transition_identity_requires_nonempty_string(field: str) -> None:
+    with pytest.raises(ConfigError, match=field):
+        load_config_from_string(f"""
+transition:
+  agent_id: {"true" if field == "agent_id" else "payment-agent"}
+  policy_version: {"123" if field == "policy_version" else "test"}
+""")
+
+
 def test_apply_tool_with_audit_receipt_from_yaml() -> None:
     yaml_text = """
 transition:


### PR DESCRIPTION
## What changed

Transition configuration now requires non-empty string identity values and an actual boolean for `reclaim_requires_death_signal`. Shared numeric timing parsing rejects booleans, NaN, and infinities while preserving valid finite values and zero where supported.

## Validation

- `tests/test_config.py`: 75 passed
- `ruff check mycelium tests`: passed
- The full suite has a known Windows baseline failure set in unrelated CLI/verify and multiprocess paths; the same failures were reproduced from a clean base worktree. The changed configuration tests pass.

AI assistance: I used Codex to inspect and draft this change, then reviewed the submitted lines and validation results.
