### PR TITLE
Add focused GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Runtime bug
+description: Report a bug, crash, or unexpected behavior.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please provide a minimal reproduction and fill out the details below.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug or unexpected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest possible code snippet or steps to reproduce the issue.
+    validations:
+      required: true
+  - type: input
+    id: mycelium_version
+    attributes:
+      label: Mycelium version
+      description: Which version of Mycelium are you using? (e.g., 1.34.0)
+    validations:
+      required: true
+  - type: input
+    id: backend
+    attributes:
+      label: Storage backend
+      description: Which storage backend are you using? (e.g., SQLite, Postgres, Redis, Memory)
+    validations:
+      required: true
+  - type: input
+    id: framework
+    attributes:
+      label: Framework
+      description: Which LLM framework are you using? (e.g., LangChain, LlamaIndex, Custom)
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and Traceback
+      description: Paste any relevant logs, stack traces, or errors.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerabilities
+    url: https://github.com/mycelium-labs/mycelium/blob/main/SECURITY.md
+    about: Please report security vulnerabilities privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,22 @@
+name: Documentation request
+description: Request improvements or additions to the documentation.
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping us improve our documentation! Please provide details on what is missing, unclear, or incorrect.
+  - type: textarea
+    id: request
+    attributes:
+      label: Documentation Request
+      description: Describe the documentation you need or the issue you found with existing documentation.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this documentation needed? (e.g., what task were you trying to accomplish?)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/reliability.yml
+++ b/.github/ISSUE_TEMPLATE/reliability.yml
@@ -1,0 +1,37 @@
+name: Reliability guarantee or threat-model change
+description: Propose a change to atomicity, isolation, durability, or security threat models.
+labels: ["enhancement", "design decision needed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Mycelium sits on the execution boundary for payments and external mutations. A small behavioral change can alter whether an operation runs, retries, or fails closed. 
+        Before proposing a change, ensure you have read the [CONTRIBUTING.md](https://github.com/mycelium-labs/mycelium/blob/main/CONTRIBUTING.md) guide on reliability guarantees.
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe the proposed change
+      description: What specific change are you proposing to the reliability guarantee or threat model?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this change necessary? What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What guarantees are weakened, strengthened, or altered? Are there any backward compatibility concerns?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Were there other ways to solve this problem? Why were they rejected?
+    validations:
+      required: false


### PR DESCRIPTION
Fixes #87. Added YAML issue templates for bug reports, documentation requests, and reliability changes, as well as a config to point security issues to SECURITY.md.