### PR TITLE
Restore incremental Pyright gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,3 +186,7 @@ jobs:
       - name: Ruff
         working-directory: sdk
         run: ruff check mycelium tests
+
+      - name: Pyright
+        working-directory: sdk
+        run: pyright

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "ruff",
+    "pyright",
     "fakeredis",
     "hypothesis",
     "langgraph>=1.2.9",
@@ -82,3 +83,10 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
+
+[tool.pyright]
+typeCheckingMode = "basic"
+include = [
+    "mycelium/api_stability.py",
+    "mycelium/audit_receipt.py",
+]


### PR DESCRIPTION
Fixes #84. Added an explicit Pyright configuration that establishes a baseline on two stable public modules (pi_stability.py and udit_receipt.py). This allows us to incrementally add type checking without breaking CI. pyright has been added to the test dependencies and CI workflow.