### PR TITLE
fix: validate state_flush.flush_on_complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ small PyPI versions. Pre-release checklist: [sdk/docs/RELEASE.md](sdk/docs/RELEA
 
 ### Fixed
 
+- Require `state_flush.flush_on_complete` to be a YAML boolean instead of
+  accepting truthy values such as quoted `false`.
 - Reject non-finite and boolean authority-window clock-skew tolerances during
   policy construction and YAML configuration loading.
 - Require audit receipt flags in tool, task, and global configuration to be

--- a/sdk/mycelium/config.py
+++ b/sdk/mycelium/config.py
@@ -1672,7 +1672,12 @@ class MyceliumConfig:
         flush_on = self.state_flush.get("flush_on")
         if flush_on is not None and not isinstance(flush_on, list):
             raise ConfigError("'state_flush.flush_on' must be a list")
-        flush_on_complete = bool(self.state_flush.get("flush_on_complete", True))
+        flush_on_complete = _parse_bool_option(
+            self.state_flush,
+            "flush_on_complete",
+            field="'state_flush.flush_on_complete'",
+            default=True,
+        )
         self._state_flush = StateFlush(
             storage=storage,
             flush_on=list(flush_on) if flush_on is not None else None,

--- a/sdk/tests/test_config.py
+++ b/sdk/tests/test_config.py
@@ -424,6 +424,41 @@ audit_receipt:
     assert audit.agent_id == "payment-agent"
 
 
+@pytest.mark.parametrize(
+    "value", ['"false"', '"true"', "0", "1", "null", "[]", "{}"]
+)
+def test_state_flush_on_complete_requires_boolean(value: str) -> None:
+    config = load_config_from_string(f"""
+state_flush:
+  storage: memory
+  flush_on_complete: {value}
+""")
+
+    with pytest.raises(
+        ConfigError,
+        match=r"'state_flush\.flush_on_complete' must be a boolean",
+    ):
+        config.build_state_flush()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("true", True), ("false", False), ("", True)],
+)
+def test_state_flush_on_complete_boolean_values_and_omitted_default(
+    value: str, expected: bool
+) -> None:
+    option = f"  flush_on_complete: {value}\n" if value else ""
+    config = load_config_from_string(f"""
+state_flush:
+  storage: memory
+{option}""")
+    state_flush = config.build_state_flush()
+
+    assert state_flush is not None
+    assert state_flush._flush_on_complete is expected
+
+
 def test_transition_lease_renew_interval_parsed() -> None:
     yaml_text = """
 transition:


### PR DESCRIPTION
## What changed

`state_flush.flush_on_complete` was parsed with `bool(...)`, so a quoted YAML value such as `"false"` enabled completion flushing instead of rejecting invalid configuration. This replaces coercion with the existing strict boolean parser.

## Evidence

On current `main` (`e67e8da`), this configuration built a state flush with completion flushing enabled:

```yaml
state_flush:
  storage: memory
  flush_on_complete: "false"
```

The patch preserves the default and valid YAML `true` / `false` behavior, while rejecting strings, numbers, null, lists, and mappings with a field-specific `ConfigError`.

## Validation

- `python -m pytest tests/test_config.py -k state_flush_on_complete -q` — 10 passed
- `python -m pytest tests/test_config.py -q` — 74 passed
- `python -m pytest tests/test_state_flush.py tests/test_atomic_state_backend.py -q` — 16 passed, 3 skipped
- `git diff --check` — passed
- Full `pytest tests -q` could not collect locally because `langchain_core`, `langgraph`, `hypothesis`, and `fakeredis` are absent; the same six collection errors reproduce on a clean `main` worktree.
- Ruff was unavailable in this environment.

## Compatibility

Valid configurations and the omitted default remain unchanged. This is configuration parsing only; it does not alter storage or durable-state behavior.

AI assistance: I used Codex to help inspect and draft this change, then reviewed every submitted line, reproduced the bug, and ran the validation listed above.