### PR TITLE
chore(ops): add Dependabot for Python and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 
 updates:
-  # ── Python dependencies under sdk/ ────────────────────────────────────────
-  - package-ecosystem: "pip"
+  # ── Python dependencies under sdk/ (managed with uv) ───────────────────────
+  - package-ecosystem: "uv"
     directory: "/sdk"
     schedule:
       interval: "weekly"
@@ -20,12 +20,9 @@ updates:
           - "pytest*"
           - "coverage*"
           - "mypy*"
-    labels:
-      - "dependencies"
-      - "python"
     commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
+      prefix: "chore"
+      prefix-development: "chore"
       include: "scope"
     # Security updates are not grouped and are always shown individually.
 
@@ -38,9 +35,6 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "github-actions"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
     # Runtime dependency updates remain separate so behaviour changes are visible.
     groups:
       dev-dependencies:
-        dependency-type: "development"
         patterns:
           - "ruff"
           - "pytest*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+updates:
+  # ── Python dependencies under sdk/ ────────────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/sdk"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    # Group compatible dev/test dependency updates to reduce noise.
+    # Runtime dependency updates remain separate so behaviour changes are visible.
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "ruff"
+          - "pytest*"
+          - "coverage*"
+          - "mypy*"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    # Security updates are not grouped and are always shown individually.
+
+  # ── GitHub Actions ─────────────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
## What changed

Adds .github/dependabot.yml to enable automated dependency-update pull requests.

Closes #148

## Ecosystems configured

### uv — sdk/
- Weekly schedule (Monday 09:00 UTC)
- open-pull-requests-limit: 5 to avoid flooding the queue
- Dev dependencies grouped together (ruff, pytest*, coverage*, mypy*) to reduce noise
- Runtime dependency updates are **not** grouped — behaviour changes stay individually visible
- Security updates bypass grouping by GitHub's default behaviour

### github-actions — repo root
- Same weekly Monday schedule
- Separate open-pull-requests-limit: 5
- Conventional commit prefix chore consistent with existing commit style

## Acceptance criteria verification

- [x] Dependabot configuration file is valid YAML at .github/dependabot.yml
- [x] Python package ecosystem (uv) enabled for sdk/
- [x] GitHub Actions ecosystem enabled at repository root
- [x] Weekly schedule avoids excessive update noise
- [x] Compatible dev dependencies grouped to reduce PR count
- [x] Runtime (user-visible) dependency updates remain ungrouped
- [x] Security updates not hidden inside broad groups (no security: false override)
- [x] Auto-merge is **not** configured — existing CI requirements are preserved

## Non-goals (per issue)
- Automatic merging of dependency updates
- Bypassing CI requirements
- Changing Mycelium runtime behaviour

> AI assistance: I used an AI agent to draft this configuration. I reviewed every field against the [GitHub Dependabot documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuration-options-for-the-dependabot.yml-file), the project's CONTRIBUTING.md, and the existing CI workflow.