### PR TITLE
Add Markdown link and anchor validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,3 +186,20 @@ jobs:
       - name: Ruff
         working-directory: sdk
         run: ruff check mycelium tests
+
+  markdown-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Markdown links and heading anchors
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --offline
+            --exclude-path graphify-out
+            --exclude-path .cache
+            "**/*.md"
+          fail: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,3 +298,14 @@ If you find Mycelium useful, please consider giving the
 [repository a GitHub star](https://github.com/mycelium-labs/mycelium). It helps
 others discover the project—no pressure, and it is never a condition of issue
 triage, review, or merge.
+
+### Markdown link checks
+
+Before opening a documentation-related pull request, run the same local Markdown
+link and heading-anchor check used by CI:
+
+```bash
+lychee --verbose --no-progress --offline \
+  --exclude-path graphify-out \
+  --exclude-path .cache \
+  "**/*.md"


### PR DESCRIPTION
Closes #152

## What changed

- Added Lychee Markdown link checking to CI.
- Validated local file links and Markdown heading anchors.
- Used `--offline` so external websites do not affect CI reliability.
- Excluded generated `graphify-out` and cache `.cache` directories.
- Documented the equivalent local command in `CONTRIBUTING.md`.

## Validation

- Verified the workflow configuration manually.
- `git diff --check` passes.
- No runtime code or tests were changed.