### PR TITLE
feat(ci): add incremental Python test coverage gate (#144)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,9 +166,28 @@ jobs:
         run: pip install -e "./sdk[dev,redis,postgres]"
 
       - name: SDK unit tests
+        if: matrix.python-version != '3.12'
         working-directory: sdk
         # Full suite already exercises Redis/Postgres under REQUIRE_*=1.
         run: pytest tests/ -v
+
+      - name: SDK unit tests with coverage gate
+        if: matrix.python-version == '3.12'
+        working-directory: sdk
+        # Full suite already exercises Redis/Postgres under REQUIRE_*=1.
+        # Run coverage measurement and enforce fail-under gate on primary Python 3.12.
+        run: pytest tests/ -v --cov=mycelium --cov-report=term-missing
+
+      - name: Output coverage report to job summary
+        if: always() && matrix.python-version == '3.12'
+        working-directory: sdk
+        run: |
+          if [ -f .coverage ]; then
+            echo "### Python 3.12 Test Coverage Report" >> $GITHUB_STEP_SUMMARY
+            echo '```text' >> $GITHUB_STEP_SUMMARY
+            coverage report >> $GITHUB_STEP_SUMMARY 2>&1 || true
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Concurrency proofs must not skip
         working-directory: sdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
           if [ -f .coverage ]; then
             echo "### Python 3.12 Test Coverage Report" >> $GITHUB_STEP_SUMMARY
             echo '```text' >> $GITHUB_STEP_SUMMARY
-            coverage report >> $GITHUB_STEP_SUMMARY 2>&1 || true
+            python -m coverage report >> $GITHUB_STEP_SUMMARY 2>&1 || true
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .coverage
+.coverage.*
+coverage.xml
+coverage.json
+coverage.lcov
+htmlcov/
 .context/
 *.egg-info/
 dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ git clone https://github.com/mycelium-labs/mycelium.git
 cd mycelium/sdk
 uv sync --extra dev --extra redis --extra postgres
 uv run pytest tests/ -v
+uv run pytest --cov=mycelium --cov-report=term-missing
 uv run ruff check mycelium tests
 ```
 
@@ -67,6 +68,7 @@ python -m venv .venv
 source .venv/bin/activate
 python -m pip install -e ".[dev,redis,postgres]"
 pytest tests/ -v
+pytest --cov=mycelium --cov-report=term-missing
 ruff check mycelium tests
 ```
 
@@ -81,6 +83,7 @@ checks:
 ```bash
 cd sdk
 uv run pytest tests/ -v
+uv run pytest --cov=mycelium --cov-report=term-missing
 uv run ruff check mycelium tests
 ```
 
@@ -193,6 +196,7 @@ Copy the applicable items into the pull request description:
 
 - [ ] Focused regression tests pass
 - [ ] Full `pytest tests/ -v` passes
+- [ ] Coverage gate passes (`pytest --cov=mycelium --cov-report=term-missing`)
 - [ ] `ruff check mycelium tests` passes
 - [ ] Redis/Postgres tests ran, or the PR explains why they do not apply
 - [ ] No relevant tests were silently skipped

--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -3,6 +3,12 @@ __pycache__/
 *.py[cod]
 .pytest_cache/
 .ruff_cache/
+.coverage
+.coverage.*
+coverage.xml
+coverage.json
+coverage.lcov
+htmlcov/
 *.egg-info/
 dist/
 build/

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -2781,4 +2781,5 @@ Clone the GitHub repo to run proofs and tests. PyPI installs only the `mycelium`
 git clone https://github.com/mycelium-labs/mycelium.git
 cd mycelium/sdk && pip install -e ".[dev]"
 pytest tests/ -v
+pytest --cov=mycelium --cov-report=term-missing
 ```

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -102,6 +102,9 @@ select = ["E", "F", "I", "UP"]
 exclude = [
   ".coverage",
   ".coverage.*",
+  "coverage.xml",
+  "coverage.json",
+  "coverage.lcov",
   "htmlcov/",
   ".hypothesis/",
   ".pytest_cache/",

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -57,6 +57,7 @@ observability = ["opentelemetry-api>=1.20", "prometheus-client>=0.17"]
 dev = [
     "pytest",
     "pytest-asyncio",
+    "pytest-cov>=5.0.0",
     "ruff",
     "fakeredis",
     "hypothesis",
@@ -78,6 +79,15 @@ packages = ["mycelium"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["mycelium"]
+branch = true
+
+[tool.coverage.report]
+fail_under = 65
+show_missing = true
+
 
 [tool.ruff]
 target-version = "py310"

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -100,6 +100,9 @@ select = ["E", "F", "I", "UP"]
 # contains the README, build metadata, and the complete runtime package.
 [tool.hatch.build.targets.sdist]
 exclude = [
+  ".coverage",
+  ".coverage.*",
+  "htmlcov/",
   ".hypothesis/",
   ".pytest_cache/",
   ".ruff_cache/",


### PR DESCRIPTION
﻿### Summary

Closes #144.

This PR establishes an incremental Python test coverage gate in CI, following core maintainer @nandanadileep's requirements in Issue #144.

1. **Coverage Tooling & Single-Source Configuration (`sdk/pyproject.toml`)**:
   - Added `pytest-cov>=5.0.0` to `[project.optional-dependencies] dev`.
   - Configured `[tool.coverage.run]` with source set to `mycelium` and `branch = true` enabled.
   - Configured `[tool.coverage.report]` with `fail_under = 65` and `show_missing = true`.
   - The fail-under threshold of 65% is comfortably satisfied by the current repository suite baseline (~69–74%) without requiring artificial test additions or test rewrites.

2. **CI Workflow Gate (`.github/workflows/ci.yml`)**:
   - Conditioned coverage measurement to run on the primary Python 3.12 matrix runner (`pytest tests/ -v --cov=mycelium --cov-report=term-missing`), preventing redundant overhead across all 4 Python matrix versions.
   - Preserved full Python 3.10–3.13 matrix execution intact.
   - Added a job step summary output publishing the clean terminal coverage report directly to `$GITHUB_STEP_SUMMARY`.
   - Ensures any package coverage drop below 65% triggers a non-zero exit code and fails the CI gate.

3. **Contributor Documentation (`sdk/README.md` & `CONTRIBUTING.md`)**:
   - Documented the local test coverage command (`pytest --cov=mycelium --cov-report=term-missing` and `uv run pytest --cov=mycelium --cov-report=term-missing`) in `CONTRIBUTING.md` under both `uv` and `pip` workflows as well as "Run the right tests" and the PR validation checklist.
   - Documented the local coverage command in `sdk/README.md` under "For contributors (repo layout)".

### Acceptance Criteria Verification
- [x] `pytest-cov>=5.0.0` is installed via `dev` extra.
- [x] Single source of truth configuration in `sdk/pyproject.toml` (`[tool.coverage.run]` and `[tool.coverage.report]`).
- [x] Total package coverage threshold fails CI if unmet (verified: setting threshold above baseline triggers exit code 1 / `Coverage failure: total of 69 is less than fail-under=70`), while existing tests pass cleanly (threshold 65%).
- [x] Matrix tests (Python 3.10, 3.11, 3.12, 3.13), package-install, and version-hygiene checks remain intact and green.
- [x] Clear terminal coverage report output to CI job summary (`$GITHUB_STEP_SUMMARY`).
- [x] Documentation updated in `CONTRIBUTING.md` and `sdk/README.md`.

### Verification Evidence
- `python -m ruff check mycelium tests` -> **All checks passed!**
- `git diff --check` -> **Clean (0 errors)**
- Version hygiene checks -> **Clean (0 violations)**
- Package build (`python -m build sdk`) and distribution contents check (`check-distribution-contents.py`) -> **Passed**
- Pytest baseline coverage run -> **Measured ~69% branch coverage on Python 3.12, comfortably passing 65% threshold**
