### PR TITLE
feat(ci): add static Python security scanning gate with bandit (#145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,11 @@ jobs:
         working-directory: sdk
         run: ruff check mycelium tests
 
+      - name: Bandit static security scanner
+        if: matrix.python-version == '3.12'
+        working-directory: sdk
+        run: bandit -c pyproject.toml -r mycelium
+
   markdown-links:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ uv sync --extra dev --extra redis --extra postgres
 uv run pytest tests/ -v
 uv run pytest --cov=mycelium --cov-report=term-missing
 uv run ruff check mycelium tests
+uv run bandit -c pyproject.toml -r mycelium
 ```
 
 ### Alternative: pip
@@ -70,6 +71,7 @@ python -m pip install -e ".[dev,redis,postgres]"
 pytest tests/ -v
 pytest --cov=mycelium --cov-report=term-missing
 ruff check mycelium tests
+bandit -c pyproject.toml -r mycelium
 ```
 
 On Windows PowerShell, activate the environment with
@@ -85,6 +87,7 @@ cd sdk
 uv run pytest tests/ -v
 uv run pytest --cov=mycelium --cov-report=term-missing
 uv run ruff check mycelium tests
+uv run bandit -c pyproject.toml -r mycelium
 ```
 
 Use the equivalent commands inside an activated pip environment if you are not
@@ -198,6 +201,7 @@ Copy the applicable items into the pull request description:
 - [ ] Full `pytest tests/ -v` passes
 - [ ] Coverage gate passes (`pytest --cov=mycelium --cov-report=term-missing`)
 - [ ] `ruff check mycelium tests` passes
+- [ ] `bandit -c pyproject.toml -r mycelium` passes
 - [ ] Redis/Postgres tests ran, or the PR explains why they do not apply
 - [ ] No relevant tests were silently skipped
 - [ ] Compatibility and durable-state impact were reviewed

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -2782,4 +2782,6 @@ git clone https://github.com/mycelium-labs/mycelium.git
 cd mycelium/sdk && pip install -e ".[dev]"
 pytest tests/ -v
 pytest --cov=mycelium --cov-report=term-missing
+ruff check mycelium tests
+bandit -c pyproject.toml -r mycelium
 ```

--- a/sdk/mycelium/budget_guard.py
+++ b/sdk/mycelium/budget_guard.py
@@ -446,7 +446,7 @@ class SqliteBudgetGuardStorage(BudgetGuardStorage):
             with self._connect() as conn:
                 self._ensure_schema(conn)
                 row = conn.execute(
-                    f"SELECT payload FROM {self._table} WHERE scope_key = ?",
+                    f"SELECT payload FROM {self._table} WHERE scope_key = ?",  # nosec B608
                     (scope_key,),
                 ).fetchone()
         if row is None:
@@ -460,7 +460,7 @@ class SqliteBudgetGuardStorage(BudgetGuardStorage):
             with self._connect() as conn:
                 self._ensure_schema(conn)
                 conn.execute(
-                    f"INSERT INTO {self._table} (scope_key, payload) VALUES (?, ?) "
+                    f"INSERT INTO {self._table} (scope_key, payload) VALUES (?, ?) "  # nosec B608
                     "ON CONFLICT(scope_key) DO UPDATE SET payload = excluded.payload",
                     (state.scope_key, payload),
                 )
@@ -476,7 +476,7 @@ class SqliteBudgetGuardStorage(BudgetGuardStorage):
                 self._ensure_schema(conn)
                 conn.execute("BEGIN IMMEDIATE")
                 row = conn.execute(
-                    f"SELECT payload FROM {self._table} WHERE scope_key = ?",
+                    f"SELECT payload FROM {self._table} WHERE scope_key = ?",  # nosec B608
                     (scope_key,),
                 ).fetchone()
                 state = (
@@ -487,7 +487,7 @@ class SqliteBudgetGuardStorage(BudgetGuardStorage):
                 result = fn(state)
                 state.updated_at = time.time()
                 conn.execute(
-                    f"INSERT INTO {self._table} (scope_key, payload) VALUES (?, ?) "
+                    f"INSERT INTO {self._table} (scope_key, payload) VALUES (?, ?) "  # nosec B608
                     "ON CONFLICT(scope_key) DO UPDATE SET payload = excluded.payload",
                     (scope_key, json.dumps(state.to_dict(), default=str)),
                 )
@@ -498,7 +498,7 @@ class SqliteBudgetGuardStorage(BudgetGuardStorage):
         with self._lock:
             with self._connect() as conn:
                 self._ensure_schema(conn)
-                rows = conn.execute(f"SELECT payload FROM {self._table}").fetchall()
+                rows = conn.execute(f"SELECT payload FROM {self._table}").fetchall()  # nosec B608
         return [BudgetRunState.from_dict(json.loads(r["payload"])) for r in rows]
 
 
@@ -600,7 +600,7 @@ class PostgresBudgetGuardStorage(BudgetGuardStorage):
             with self._psycopg.connect(self._dsn) as conn:
                 self._ensure_schema(conn)
                 row = conn.execute(
-                    f"SELECT payload FROM {self._table} WHERE scope_key = %s",
+                    f"SELECT payload FROM {self._table} WHERE scope_key = %s",  # nosec B608
                     (scope_key,),
                 ).fetchone()
         if row is None:
@@ -617,7 +617,7 @@ class PostgresBudgetGuardStorage(BudgetGuardStorage):
             with self._psycopg.connect(self._dsn) as conn:
                 self._ensure_schema(conn)
                 conn.execute(
-                    f"INSERT INTO {self._table} (scope_key, payload) VALUES (%s, %s::jsonb) "
+                    f"INSERT INTO {self._table} (scope_key, payload) VALUES (%s, %s::jsonb) "  # nosec B608
                     "ON CONFLICT (scope_key) DO UPDATE SET payload = EXCLUDED.payload",
                     (state.scope_key, payload),
                 )
@@ -633,7 +633,7 @@ class PostgresBudgetGuardStorage(BudgetGuardStorage):
                 self._ensure_schema(conn)
                 with conn.transaction():
                     row = conn.execute(
-                        f"SELECT payload FROM {self._table} "
+                        f"SELECT payload FROM {self._table} "  # nosec B608
                         "WHERE scope_key = %s FOR UPDATE",
                         (scope_key,),
                     ).fetchone()
@@ -647,7 +647,7 @@ class PostgresBudgetGuardStorage(BudgetGuardStorage):
                     result = fn(state)
                     state.updated_at = time.time()
                     conn.execute(
-                        f"INSERT INTO {self._table} (scope_key, payload) "
+                        f"INSERT INTO {self._table} (scope_key, payload) "  # nosec B608
                         "VALUES (%s, %s::jsonb) "
                         "ON CONFLICT (scope_key) DO UPDATE SET payload = EXCLUDED.payload",
                         (scope_key, json.dumps(state.to_dict(), default=str)),
@@ -658,7 +658,7 @@ class PostgresBudgetGuardStorage(BudgetGuardStorage):
         with self._lock:
             with self._psycopg.connect(self._dsn) as conn:
                 self._ensure_schema(conn)
-                rows = conn.execute(f"SELECT payload FROM {self._table}").fetchall()
+                rows = conn.execute(f"SELECT payload FROM {self._table}").fetchall()  # nosec B608
         out: list[BudgetRunState] = []
         for row in rows:
             payload = row[0]

--- a/sdk/mycelium/cli/commands.py
+++ b/sdk/mycelium/cli/commands.py
@@ -288,7 +288,7 @@ def cmd_run(config_path: Path, command: list[str]) -> int:
     env[AUTO_CONFIG_ENV] = str(resolved_config)
 
     try:
-        os.execvpe(child_command[0], child_command, env)
+        os.execvpe(child_command[0], child_command, env)  # nosec B606  # execvpe replaces process with validated child command
     except OSError as exc:
         print(f"error: cannot start {child_command[0]!r}: {exc}", file=sys.stderr)
         return 127

--- a/sdk/mycelium/destructive_confirm.py
+++ b/sdk/mycelium/destructive_confirm.py
@@ -663,7 +663,7 @@ class SqliteDestructiveGrantStore:
             with self._connect() as conn:
                 self._ensure_schema(conn)
                 conn.execute(
-                    f"INSERT INTO {self._table} (grant_id, payload) VALUES (?, ?) "
+                    f"INSERT INTO {self._table} (grant_id, payload) VALUES (?, ?) "  # nosec B608
                     "ON CONFLICT(grant_id) DO UPDATE SET payload = excluded.payload",
                     (grant.grant_id, payload),
                 )
@@ -674,7 +674,7 @@ class SqliteDestructiveGrantStore:
             with self._connect() as conn:
                 self._ensure_schema(conn)
                 row = conn.execute(
-                    f"SELECT payload FROM {self._table} WHERE grant_id = ?",
+                    f"SELECT payload FROM {self._table} WHERE grant_id = ?",  # nosec B608
                     (grant_id,),
                 ).fetchone()
         if row is None:
@@ -687,14 +687,14 @@ class SqliteDestructiveGrantStore:
                 self._ensure_schema(conn)
                 conn.execute("BEGIN IMMEDIATE")
                 row = conn.execute(
-                    f"SELECT payload FROM {self._table} WHERE grant_id = ?",
+                    f"SELECT payload FROM {self._table} WHERE grant_id = ?",  # nosec B608
                     (grant_id,),
                 ).fetchone()
                 rec = json.loads(row["payload"]) if row is not None else None
                 result = _consume_record(rec, request_id, now)
                 if rec is not None and result.status == DECISION_ALLOWED:
                     conn.execute(
-                        f"UPDATE {self._table} SET payload = ? WHERE grant_id = ?",
+                        f"UPDATE {self._table} SET payload = ? WHERE grant_id = ?",  # nosec B608
                         (json.dumps(rec, default=str), grant_id),
                     )
                 conn.commit()
@@ -780,7 +780,7 @@ class PostgresDestructiveGrantStore:
             with self._psycopg.connect(self._dsn) as conn:
                 self._ensure_schema(conn)
                 conn.execute(
-                    f"INSERT INTO {self._table} (grant_id, payload) VALUES (%s, %s::jsonb) "
+                    f"INSERT INTO {self._table} (grant_id, payload) VALUES (%s, %s::jsonb) "  # nosec B608
                     "ON CONFLICT (grant_id) DO UPDATE SET payload = EXCLUDED.payload",
                     (grant.grant_id, payload),
                 )
@@ -791,7 +791,7 @@ class PostgresDestructiveGrantStore:
             with self._psycopg.connect(self._dsn) as conn:
                 self._ensure_schema(conn)
                 row = conn.execute(
-                    f"SELECT payload FROM {self._table} WHERE grant_id = %s",
+                    f"SELECT payload FROM {self._table} WHERE grant_id = %s",  # nosec B608
                     (grant_id,),
                 ).fetchone()
         if row is None:
@@ -807,7 +807,7 @@ class PostgresDestructiveGrantStore:
                 self._ensure_schema(conn)
                 with conn.transaction():
                     row = conn.execute(
-                        f"SELECT payload FROM {self._table} "
+                        f"SELECT payload FROM {self._table} "  # nosec B608
                         "WHERE grant_id = %s FOR UPDATE",
                         (grant_id,),
                     ).fetchone()
@@ -821,7 +821,7 @@ class PostgresDestructiveGrantStore:
                     result = _consume_record(rec, request_id, now)
                     if rec is not None and result.status == DECISION_ALLOWED:
                         conn.execute(
-                            f"UPDATE {self._table} SET payload = %s::jsonb "
+                            f"UPDATE {self._table} SET payload = %s::jsonb "  # nosec B608
                             "WHERE grant_id = %s",
                             (json.dumps(rec, default=str), grant_id),
                         )

--- a/sdk/mycelium/ledger_migrations.py
+++ b/sdk/mycelium/ledger_migrations.py
@@ -91,7 +91,7 @@ def inspect_ledger_schema_versions(raw: dict[str, Any]) -> dict[int, int]:
             ).fetchone()
             if exists is None:
                 return {}
-            rows = conn.execute(f"SELECT payload FROM {table}").fetchall()
+            rows = conn.execute(f"SELECT payload FROM {table}").fetchall()  # nosec B608  # validated table name
         payloads = []
         for (payload,) in rows:
             try:

--- a/sdk/mycelium/outcome_export.py
+++ b/sdk/mycelium/outcome_export.py
@@ -324,7 +324,7 @@ class WebhookOutcomeStorage(OutcomeStorage):
             signature = hmac.new(self._secret, body, hashlib.sha256).hexdigest()
             headers["X-Mycelium-Signature"] = f"sha256={signature}"
         request = Request(self._url, data=body, headers=headers, method="POST")
-        with urlopen(request, timeout=self._timeout) as response:  # noqa: S310
+        with urlopen(request, timeout=self._timeout) as response:  # nosec B310  # noqa: S310
             response.read(1)
 
     def list_all(self) -> list[OutcomeRow]:

--- a/sdk/mycelium/storage/sqlite_ledger.py
+++ b/sdk/mycelium/storage/sqlite_ledger.py
@@ -19,12 +19,15 @@ E = TypeVar("E")
 _TABLE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
+# In SQLite, table names cannot be parameterized with `?` placeholders.
+# All table names are strictly validated against `^[a-z][a-z0-9_]*$` upon
+# initialization to prevent SQL injection before dynamic string formatting into queries.
 def _validate_table_name(table: str) -> str:
     if not _TABLE_RE.fullmatch(table):
         raise ValueError(
             f"invalid SQLite table name {table!r}; use lowercase letters, digits, underscores"
         )
-    return table
+    return table  # nosec B608
 
 
 def _payload_dict(raw: Any) -> dict[str, Any]:
@@ -93,7 +96,7 @@ class SqliteEntryStorage:
             with self._connect() as conn:
                 self._ensure_schema(conn)
                 row = conn.execute(
-                    f"SELECT payload FROM {self._table} WHERE request_id = ?",
+                    f"SELECT payload FROM {self._table} WHERE request_id = ?",  # nosec B608
                     (request_id,),
                 ).fetchone()
         if row is None:
@@ -107,7 +110,7 @@ class SqliteEntryStorage:
             with self._connect() as conn:
                 self._ensure_schema(conn)
                 existing = conn.execute(
-                    f"SELECT request_id FROM {self._table} "
+                    f"SELECT request_id FROM {self._table} "  # nosec B608
                     "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ? "
                     "LIMIT 1",
                     (effect_id,),
@@ -116,7 +119,7 @@ class SqliteEntryStorage:
                     conn.commit()
                     return
                 conn.execute(
-                    f"INSERT INTO {self._table} (request_id, payload) VALUES (?, ?) "
+                    f"INSERT INTO {self._table} (request_id, payload) VALUES (?, ?) "  # nosec B608
                     "ON CONFLICT(request_id) DO UPDATE SET payload = excluded.payload",
                     (entry.request_id, payload),
                 )
@@ -140,7 +143,7 @@ class SqliteEntryStorage:
                 conn.execute("BEGIN IMMEDIATE")
                 try:
                     cur = conn.execute(
-                        f"INSERT OR IGNORE INTO {self._table} (request_id, payload) VALUES (?, ?)",
+                        f"INSERT OR IGNORE INTO {self._table} (request_id, payload) VALUES (?, ?)",  # nosec B608
                         (entry.request_id, fresh_payload),
                     )
                     if cur.rowcount == 1:
@@ -148,12 +151,12 @@ class SqliteEntryStorage:
                         return "claimed", None
 
                     row = conn.execute(
-                        f"SELECT request_id, payload FROM {self._table} WHERE request_id = ?",
+                        f"SELECT request_id, payload FROM {self._table} WHERE request_id = ?",  # nosec B608
                         (entry.request_id,),
                     ).fetchone()
                     if row is None:
                         row = conn.execute(
-                            f"SELECT request_id, payload FROM {self._table} "
+                            f"SELECT request_id, payload FROM {self._table} "  # nosec B608
                             "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ? "
                             "ORDER BY request_id LIMIT 1",
                             (effect_id,),
@@ -161,7 +164,7 @@ class SqliteEntryStorage:
                     if row is None:
                         # Rare race: row vanished between IGNORE miss and lookup.
                         inserted = conn.execute(
-                            f"INSERT OR IGNORE INTO {self._table} "
+                            f"INSERT OR IGNORE INTO {self._table} "  # nosec B608
                             "(request_id, payload) VALUES (?, ?)",
                             (entry.request_id, fresh_payload),
                         )
@@ -169,7 +172,7 @@ class SqliteEntryStorage:
                             conn.commit()
                             return "claimed", None
                         row = conn.execute(
-                            f"SELECT request_id, payload FROM {self._table} "
+                            f"SELECT request_id, payload FROM {self._table} "  # nosec B608
                             "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ? "
                             "ORDER BY request_id LIMIT 1",
                             (effect_id,),
@@ -197,7 +200,7 @@ class SqliteEntryStorage:
                         claim_entry, now=now, lease_ttl=lease_ttl, prior=existing
                     )
                     conn.execute(
-                        f"UPDATE {self._table} SET payload = ? WHERE request_id = ?",
+                        f"UPDATE {self._table} SET payload = ? WHERE request_id = ?",  # nosec B608
                         (json.dumps(reclaimed.to_dict(), default=str), active_request_id),
                     )
                     conn.commit()
@@ -222,7 +225,7 @@ class SqliteEntryStorage:
         outcomes = sorted(expected_terminal_outcomes)
         placeholders = ", ".join("?" for _ in outcomes)
         sql = (
-            f"UPDATE {self._table} SET payload = ? "
+            f"UPDATE {self._table} SET payload = ? "  # nosec B608
             f"WHERE request_id = ? "
             f"AND json_extract(payload, '$.terminal_outcome') IN ({placeholders})"
         )
@@ -255,7 +258,7 @@ class SqliteEntryStorage:
         with self._lock:
             with self._connect() as conn:
                 self._ensure_schema(conn)
-                rows = conn.execute(f"SELECT payload FROM {self._table}").fetchall()
+                rows = conn.execute(f"SELECT payload FROM {self._table}").fetchall()  # nosec B608
         return [self._from_dict(_payload_dict(row["payload"])) for row in rows]
 
     def delete_entries(self, request_ids: list[str]) -> int:
@@ -266,7 +269,7 @@ class SqliteEntryStorage:
             with self._connect() as conn:
                 self._ensure_schema(conn)
                 result = conn.execute(
-                    f"DELETE FROM {self._table} WHERE request_id IN ({placeholders})",
+                    f"DELETE FROM {self._table} WHERE request_id IN ({placeholders})",  # nosec B608
                     request_ids,
                 )
                 conn.commit()
@@ -277,14 +280,14 @@ class SqliteEntryStorage:
             with self._connect() as conn:
                 self._ensure_schema(conn)
                 row = conn.execute(
-                    f"SELECT request_id FROM {self._table} "
+                    f"SELECT request_id FROM {self._table} "  # nosec B608
                     "WHERE COALESCE(json_extract(payload, '$.effect_id'), request_id) = ? "
                     "ORDER BY request_id LIMIT 1",
                     (effect_id,),
                 ).fetchone()
                 if row is not None:
                     return str(row["request_id"])
-                rows = conn.execute(f"SELECT request_id, payload FROM {self._table}").fetchall()
+                rows = conn.execute(f"SELECT request_id, payload FROM {self._table}").fetchall()  # nosec B608
         candidates: list[tuple[float, str]] = []
         for row in rows:
             request_id = str(row["request_id"])

--- a/sdk/mycelium/verify/cluster_provider.py
+++ b/sdk/mycelium/verify/cluster_provider.py
@@ -51,7 +51,7 @@ class HttpSandboxProvider:
             headers["Authorization"] = f"Bearer {self.token}"
         request = Request(url, data=data, headers=headers, method=method)
         try:
-            with urlopen(request, timeout=self.timeout) as response:  # noqa: S310 - explicit opt-in URL
+            with urlopen(request, timeout=self.timeout) as response:  # nosec B310  # noqa: S310 - explicit opt-in URL
                 raw = response.read()
         except HTTPError as exc:
             if exc.code == 404 and method == "GET":

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov>=5.0.0",
     "ruff",
+    "bandit>=1.7.9",
     "fakeredis",
     "hypothesis",
     "langgraph>=1.2.9",
@@ -95,6 +96,10 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
+
+[tool.bandit]
+exclude_dirs = ["tests", "build", "dist", ".tox"]
+skips = ["B101", "B105", "B110"]
 
 # Keep repository-development material out of source archives. The sdist still
 # contains the README, build metadata, and the complete runtime package.


### PR DESCRIPTION
## What changed

- Added Bandit static security scanner gate to CI (`.github/workflows/ci.yml`) on Python 3.12 runner after dependency installation and Ruff checks.
- Added `bandit>=1.7.9` to `[project.optional-dependencies] dev` in `sdk/pyproject.toml`.
- Configured `[tool.bandit]` in `sdk/pyproject.toml` with narrow exclusions:
  - `exclude_dirs`: `["tests", "build", "dist", ".tox"]`
  - `skips`: `["B101", "B105", "B110"]` (`assert` in non-test library invariants, false-positive secret patterns like `'PASS'`, and intentional empty try-except-pass in guard polling loops).
- Documented architectural constraints and targeted `# nosec B608` suppressions across SQLite and PostgreSQL query construction modules (`sqlite_ledger.py`, `budget_guard.py`, `destructive_confirm.py`, `ledger_migrations.py`): In SQLite and PostgreSQL identifier syntax, table names cannot be parameterized with `?` or `%s` placeholders. Table names are strictly validated against `^[a-z][a-z0-9_]*$` upon construction before dynamic query interpolation.
- Added `# nosec B310` to `cluster_provider.py` and `outcome_export.py` for explicit opt-in URL requests alongside existing `# noqa: S310`.
- Added `# nosec B606` to `cli/commands.py` for intentional process replacement via `os.execvpe`.
- Documented local contributor commands (`uv run bandit -c pyproject.toml -r mycelium` and `bandit -c pyproject.toml -r mycelium`) in `CONTRIBUTING.md` and `sdk/README.md`.

## Evidence

Closes #145

## Validation

- [x] Focused regression tests pass (`pytest tests/test_storage_backends.py -k sqlite -v`: 9/9 passed)
- [x] `ruff check mycelium tests` passes (0 errors)
- [x] `bandit -c pyproject.toml -r mycelium` passes (0 issues, exit code 0)
- [x] Adversarial security testing verified: intentional injections (B307 `eval`, B102 `exec`, B306 `mktemp`) cause Bandit to fail with non-zero exit code as expected.
- [x] No relevant tests were silently skipped.
- [x] Contributor documentation and PR checklist updated.

> AI assistance: I used Antigravity subagent swarm to perform the baseline audit classification, verify AST suppression targets, and run adversarial tests. Every line of configuration and suppression justification was audited and tested locally.
