### PR TITLE
feat(ci): add automated dependency vulnerability audit with pip-audit (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,24 @@ jobs:
         working-directory: sdk
         run: ruff check mycelium tests
 
+      - name: Dependency vulnerability audit
+        if: matrix.python-version == '3.12'
+        working-directory: sdk
+        # Dependency vulnerability gate (#146). pip-audit exits non-zero on
+        # findings or service errors. Exceptions must be recorded in
+        # sdk/.pip-audit-ignore with a reason and review date.
+        run: |
+          IGNORE_ARGS=()
+          if [ -f .pip-audit-ignore ]; then
+            while IFS= read -r line || [ -n "$line" ]; do
+              line="${line#"${line%%[![:space:]]*}"}"
+              [[ -z "$line" || "$line" =~ ^# ]] && continue
+              vuln_id=$(echo "$line" | awk '{print $1}')
+              [ -n "$vuln_id" ] && IGNORE_ARGS+=("--ignore-vuln" "$vuln_id")
+            done < .pip-audit-ignore
+          fi
+          pip-audit --desc on "${IGNORE_ARGS[@]}"
+
   markdown-links:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ uv sync --extra dev --extra redis --extra postgres
 uv run pytest tests/ -v
 uv run pytest --cov=mycelium --cov-report=term-missing
 uv run ruff check mycelium tests
+uv run pip-audit --desc on
 ```
 
 ### Alternative: pip
@@ -70,6 +71,7 @@ python -m pip install -e ".[dev,redis,postgres]"
 pytest tests/ -v
 pytest --cov=mycelium --cov-report=term-missing
 ruff check mycelium tests
+pip-audit --desc on
 ```
 
 On Windows PowerShell, activate the environment with
@@ -85,6 +87,7 @@ cd sdk
 uv run pytest tests/ -v
 uv run pytest --cov=mycelium --cov-report=term-missing
 uv run ruff check mycelium tests
+uv run pip-audit --desc on
 ```
 
 Use the equivalent commands inside an activated pip environment if you are not
@@ -198,6 +201,7 @@ Copy the applicable items into the pull request description:
 - [ ] Full `pytest tests/ -v` passes
 - [ ] Coverage gate passes (`pytest --cov=mycelium --cov-report=term-missing`)
 - [ ] `ruff check mycelium tests` passes
+- [ ] `pip-audit --desc on` passes (from `sdk/`)
 - [ ] Redis/Postgres tests ran, or the PR explains why they do not apply
 - [ ] No relevant tests were silently skipped
 - [ ] Compatibility and durable-state impact were reviewed
@@ -313,3 +317,21 @@ lychee --verbose --no-progress --offline \
   --exclude-path graphify-out \
   --exclude-path .cache \
   "**/*.md"
+```
+
+### Dependency vulnerability audit
+
+CI audits the SDK runtime and release extras for known vulnerabilities (#146).
+Run the same local check from `sdk/` before opening a pull request that
+touches dependencies:
+
+```bash
+pip install -e ".[dev,redis,postgres,observability]"
+pip-audit --desc on
+```
+
+`pip-audit` exits non-zero on findings and on advisory-service errors, so an
+unavailable service fails closed. Temporary exceptions must stay specific,
+justified, and time-bounded adhering to `sdk/.pip-audit-ignore` policy:
+`# Format: <VULN_ID> # reason: <rationale> (review: YYYY-MM-DD)`.
+Do not add broad skips, and do not auto-upgrade dependencies in the audit step.

--- a/sdk/.pip-audit-ignore
+++ b/sdk/.pip-audit-ignore
@@ -1,0 +1,12 @@
+# Format: <VULN_ID> # reason: <rationale> (review: YYYY-MM-DD)
+#
+# Pip-Audit Vulnerability Ignore Policy (Issue #146)
+# =================================================
+# Any ignored advisory must include a specific justification (reason)
+# and a time-bounded review date (review: YYYY-MM-DD).
+#
+# Broad skips or silencing of vulnerabilities without justification are strictly forbidden.
+# Lines starting with '#' and empty lines are ignored by the parser.
+#
+# Example:
+# GHSA-xxxx-xxxx-xxxx # reason: Upstream patch pending; vulnerability not reachable via public API (review: 2026-10-01)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1367,8 +1367,8 @@ ledger.release(request_id, verified="not_executed",
 
 The action ledger deduplicates **retries of the same dispatch**. If the LLM emits a *new* `tool_call_id` each turn with the same tool + args, that is a new transition — the ledger allows it. Optional `loop_guard:` detects that thrash:
 
-1. Soft — `ToolBoundaryError` (`violation=loop_detected`) with an `llm_message`; body does not run  
-2. Hard — `LedgerHardBlockError`; **entire run** frozen until an operator releases it  
+1. Soft — `ToolBoundaryError` (`violation=loop_detected`) with an `llm_message`; body does not run
+2. Hard — `LedgerHardBlockError`; **entire run** frozen until an operator releases it
 
 ```yaml
 loop_guard:
@@ -2782,4 +2782,8 @@ git clone https://github.com/mycelium-labs/mycelium.git
 cd mycelium/sdk && pip install -e ".[dev]"
 pytest tests/ -v
 pytest --cov=mycelium --cov-report=term-missing
+ruff check mycelium tests
+pip-audit --desc on
 ```
+
+Audit dependencies for known vulnerabilities before opening a pull request. Temporary exceptions must be documented in `.pip-audit-ignore` with a reason and review date, and passed via `--ignore-vuln <ID>`.

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     "fakeredis",
     "hypothesis",
     "langgraph>=1.2.9",
+    "pip-audit>=2.7.3",
 ]
 langgraph = [
     "langgraph>=1.2.9",
@@ -117,6 +118,7 @@ exclude = [
   "scripts/",
   "api-snapshot.json",
   "uv.lock",
+  ".pip-audit-ignore",
   "**/__pycache__/",
   "**/*.pyc",
 ]


### PR DESCRIPTION
## What changed

Adds automated dependency vulnerability scanning via `pip-audit` to CI, defines the exception policy adhering to Issue #146, and documents local developer commands in `CONTRIBUTING.md` and `sdk/README.md`.

Closes #146

### Implementation details

1. **CI Integration (`.github/workflows/ci.yml`)**:
   - Added `Dependency vulnerability audit` step under the `test:` matrix job on Python 3.12, running after SDK install (`pip install -e "./sdk[dev,redis,postgres]"`) and Ruff linting.
   - Executes `pip-audit --desc on`, failing closed on identified vulnerabilities or advisory service errors.
   - Parses `sdk/.pip-audit-ignore` line-by-line if present, passing each ignored advisory via `--ignore-vuln <ID>`.

2. **Configuration & Packaging (`sdk/pyproject.toml`, `sdk/.pip-audit-ignore`)**:
   - Added `pip-audit>=2.7.3` to `[project.optional-dependencies] dev`.
   - Created `sdk/.pip-audit-ignore` documenting the mandatory exception policy format:
     `# Format: <VULN_ID> # reason: <rationale> (review: YYYY-MM-DD)`
   - Excluded `.pip-audit-ignore` from source distribution archives (`[tool.hatch.build.targets.sdist] exclude`).

3. **Documentation (`CONTRIBUTING.md`, `sdk/README.md`)**:
   - Documented local contributor commands with `pip` and `uv` (`pip-audit --desc on` and `uv run pip-audit --desc on`).
   - Added `pip-audit` check item to the PR validation checklist.
   - Detailed the fail-closed policy, prohibition against broad skips or silent ignores, and the time-bounded exception format.

## Evidence

- Issue: #146
- Clean baseline audit: Running `pip-audit` against the SDK dependency tree reported 0 known vulnerabilities.
- Adversarial test: Verified `pip-audit` fails closed on known CVEs/advisories (e.g. vulnerable `urllib3`) with exit code 1, and honors specific `--ignore-vuln` exemptions only when explicitly provided.

## Validation

- [x] Full `ruff check mycelium tests` passes cleanly
- [x] Unit test suite passes
- [x] Local dependency audit passes (`pip-audit --desc on`)
- [x] `git diff --check` passes with zero whitespace or formatting errors
- [x] Sdist build excludes `.pip-audit-ignore`
- [x] No secrets or credentials included

> AI assistance: I used Antigravity / Gemini to inspect the dependency graph, draft the CI integration and policy template, and run local validation. I reviewed every submitted line, verified adversarial behavior, and tested against local linters.
