### PR TITLE
feat(ci): generate and publish CycloneDX SBOM for releases (#147)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -27,8 +27,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install build tools
-        run: pip install build hatchling
+      - name: Install build and SBOM tools
+        run: pip install build hatchling "cyclonedx-bom>=4.0.0"
 
       - name: Build sdist and wheel
         run: python -m build
@@ -37,6 +37,40 @@ jobs:
         run: >-
           python ../.github/scripts/check-distribution-contents.py
           dist/*.whl dist/*.tar.gz
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          set -euo pipefail
+          mkdir -p sbom
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          python -m venv "${RUNNER_TEMP}/sbom-env"
+          "${RUNNER_TEMP}/sbom-env/bin/pip" install dist/*.whl
+          cyclonedx-py environment "${RUNNER_TEMP}/sbom-env/bin/python" \
+            --pyproject pyproject.toml \
+            --output-format JSON \
+            --output-file "sbom/mycelium-runtime-${VERSION}.cdx.json"
+          python -c "import json; data = json.load(open('sbom/mycelium-runtime-${VERSION}.cdx.json')); assert data.get('bomFormat') == 'CycloneDX'; assert data.get('metadata', {}).get('component', {}).get('name') == 'mycelium-runtime'"
+
+      - name: Upload SBOM build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mycelium-runtime-sbom
+          path: sdk/sbom/*
+
+      - name: Upload SBOM to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG="v${VERSION}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Uploading SBOM to GitHub Release ${TAG}..."
+            gh release upload "$TAG" "sbom/mycelium-runtime-${VERSION}.cdx.json" --clobber
+          else
+            echo "GitHub Release ${TAG} does not exist yet; skipping release asset upload."
+          fi
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,8 @@ jobs:
           dist/*.whl dist/*.tar.gz
 
       - name: Generate CycloneDX SBOM
+        env:
+          SOURCE_COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
           mkdir -p sbom
@@ -47,9 +49,52 @@ jobs:
           "${RUNNER_TEMP}/sbom-env/bin/pip" install dist/*.whl
           cyclonedx-py environment "${RUNNER_TEMP}/sbom-env/bin/python" \
             --pyproject pyproject.toml \
+            --mc-type library \
             --output-format JSON \
             --output-file "sbom/mycelium-runtime-${VERSION}.cdx.json"
-          python -c "import json; data = json.load(open('sbom/mycelium-runtime-${VERSION}.cdx.json')); assert data.get('bomFormat') == 'CycloneDX'; assert data.get('metadata', {}).get('component', {}).get('name') == 'mycelium-runtime'"
+          python - <<'PY'
+          import json, os, subprocess
+
+          version = os.environ.get("VERSION")
+          if not version:
+              import tomllib
+              with open("pyproject.toml", "rb") as f:
+                  version = tomllib.load(f)["project"]["version"]
+
+          sbom_path = f"sbom/mycelium-runtime-{version}.cdx.json"
+          with open(sbom_path, "r", encoding="utf-8") as f:
+              data = json.load(f)
+
+          assert data.get("bomFormat") == "CycloneDX"
+          component = data.get("metadata", {}).get("component", {})
+          assert component.get("name") == "mycelium-runtime"
+          assert component.get("version") == version
+
+          # Associate exact source commit SHA with root component (Issue #147)
+          commit_sha = os.environ.get("SOURCE_COMMIT")
+          if not commit_sha:
+              try:
+                  commit_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+              except Exception:
+                  commit_sha = ""
+
+          if commit_sha:
+              repo = os.environ.get("GITHUB_REPOSITORY", "mycelium-labs/mycelium")
+              ext_refs = component.setdefault("externalReferences", [])
+              ext_refs.append({
+                  "type": "vcs",
+                  "url": f"https://github.com/{repo}/tree/{commit_sha}",
+                  "comment": f"Source commit {commit_sha}",
+              })
+              properties = component.setdefault("properties", [])
+              properties.append({
+                  "name": "vcs:commit",
+                  "value": commit_sha,
+              })
+
+          with open(sbom_path, "w", encoding="utf-8") as f:
+              json.dump(data, f, indent=2)
+          PY
 
       - name: Upload SBOM build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -65,11 +110,25 @@ jobs:
           set -euo pipefail
           VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           TAG="v${VERSION}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
+          RELEASE_FOUND=false
+          # Wait up to 60s for release.yml to finish creating the release if triggered by tag push
+          for i in $(seq 1 12); do
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              RELEASE_FOUND=true
+              break
+            fi
+            echo "GitHub Release ${TAG} not found yet; waiting 5s (attempt $i/12)..."
+            sleep 5
+          done
+
+          if [ "$RELEASE_FOUND" = "true" ]; then
             echo "Uploading SBOM to GitHub Release ${TAG}..."
             gh release upload "$TAG" "sbom/mycelium-runtime-${VERSION}.cdx.json" --clobber
+          elif [ "${GITHUB_EVENT_NAME:-}" = "workflow_dispatch" ]; then
+            echo "GitHub Release ${TAG} does not exist for workflow_dispatch; skipping release asset upload."
           else
-            echo "GitHub Release ${TAG} does not exist yet; skipping release asset upload."
+            echo "::error::GitHub Release ${TAG} not found after timeout; failing to prevent incomplete release without SBOM."
+            exit 1
           fi
 
       - name: Publish to PyPI

--- a/sdk/docs/RELEASE.md
+++ b/sdk/docs/RELEASE.md
@@ -168,6 +168,7 @@ To generate and verify the CycloneDX SBOM locally:
    ```bash
    cyclonedx-py environment .sbom-env/bin/python \
      --pyproject sdk/pyproject.toml \
+     --mc-type library \
      --output-format JSON \
      --output-file sdk/dist/mycelium-runtime.cdx.json
    ```

--- a/sdk/docs/RELEASE.md
+++ b/sdk/docs/RELEASE.md
@@ -134,8 +134,48 @@ On merge to `main`, [release.yml](../../.github/workflows/release.yml) tags
 uploads to PyPI. Confirm:
 
 - [ ] GitHub Release notes look right (from CHANGELOG extract).
+- [ ] GitHub Release includes the CycloneDX SBOM artifact (`mycelium-runtime-X.Y.Z.cdx.json`).
 - [ ] PyPI shows the new version: https://pypi.org/project/mycelium-runtime/
 - [ ] Hotfix: notify affected design partners; otherwise no “blast” needed.
+
+---
+
+## Software Bill of Materials (SBOM)
+
+Releases automatically generate and attach a machine-readable Software Bill of Materials (SBOM) in CycloneDX JSON format (`mycelium-runtime-<version>.cdx.json`) as a release asset in GitHub Releases and as a workflow artifact in GitHub Actions.
+
+### Reproducing and verifying locally
+
+To generate and verify the CycloneDX SBOM locally:
+
+1. Install build tools and `cyclonedx-bom`:
+   ```bash
+   pip install build "cyclonedx-bom>=4.0.0"
+   ```
+
+2. Build the package wheel and sdist:
+   ```bash
+   python -m build sdk
+   ```
+
+3. Install the built wheel into a clean virtual environment:
+   ```bash
+   python -m venv .sbom-env
+   .sbom-env/bin/pip install sdk/dist/*.whl
+   ```
+
+4. Generate the CycloneDX SBOM:
+   ```bash
+   cyclonedx-py environment .sbom-env/bin/python \
+     --pyproject sdk/pyproject.toml \
+     --output-format JSON \
+     --output-file sdk/dist/mycelium-runtime.cdx.json
+   ```
+
+5. Verify the generated SBOM with standard tooling:
+   ```bash
+   python -c "import json; data = json.load(open('sdk/dist/mycelium-runtime.cdx.json')); print('Format:', data['bomFormat'], data['specVersion']); print('Root:', data['metadata']['component']['name'], data['metadata']['component']['version'])"
+   ```
 
 ---
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     "fakeredis",
     "hypothesis",
     "langgraph>=1.2.9",
+    "cyclonedx-bom>=4.0.0",
 ]
 langgraph = [
     "langgraph>=1.2.9",


### PR DESCRIPTION
## Problem

Mycelium publishes wheels and source distributions, but releases previously lacked a machine-readable Software Bill of Materials (SBOM) describing packaged components and resolved dependency relationships (#147).

## Solution

1. **Dependency Addition**: Added \cyclonedx-bom>=4.0.0\ to dev dependencies in \sdk/pyproject.toml\.
2. **Release Workflow Automation (\.github/workflows/publish.yml\)**:
   - Installed \cyclonedx-bom\ in the publish job.
   - Automated CycloneDX JSON SBOM generation (\cyclonedx-py environment --mc-type library\) for the built release wheel within an isolated virtual environment to accurately capture resolved package dependencies and root component metadata without build tool contamination.
   - Associated the exact source git commit SHA with the root component via \cs\ external reference and \cs:commit\ property to satisfy metadata traceability requirements.
   - Enforced validation ensuring generation success before PyPI publishing (\ssert data['bomFormat'] == 'CycloneDX'\).
   - Uploaded the generated SBOM (\mycelium-runtime-\.cdx.json\) as a workflow artifact.
   - Added robust polling (up to 60s) to wait for \elease.yml\ to create the GitHub release during tag-triggered runs, and upload the SBOM directly as a release asset with \gh release upload --clobber\. If release asset upload fails on a tag run, the job fails to prevent publishing an incomplete release without an SBOM.
3. **Documentation**: Documented SBOM generation, local reproduction, and verification steps in \sdk/docs/RELEASE.md\ and added an SBOM verification checkbox to the release checklist.

Closes #147