### PR TITLE
feat(docs): make guarantee-to-test map machine-verifiable (#150)

### DIFF
--- a/.github/scripts/check-guarantee-map.py
+++ b/.github/scripts/check-guarantee-map.py
@@ -1,0 +1,701 @@
+#!/usr/bin/env python3
+"""Validate that the guarantee-to-test map in FAILURE_AND_THREAT_MODEL.md is accurate and non-drifting.
+
+Verifies:
+1. Section E ('## E. Guarantee -> test map') exists and contains a valid markdown table.
+2. Every guarantee identifier is unique, non-empty, and correctly formatted.
+3. Every referenced test file exists in sdk/tests/ or repository test directories.
+4. Every referenced test function or test class actually exists within the target test file (verified via AST parsing).
+5. Any duplicate, missing, or malformed entries fail execution with a descriptive error report and non-zero exit code.
+6. Emits compiler diagnostics and optional GitHub Actions annotations on failure.
+
+Usage:
+    python .github/scripts/check-guarantee-map.py [--root <DIR>] [--doc <DOC>] [--test-dir <TEST_DIR>]
+"""
+
+import argparse
+import ast
+import os
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+# Ensure stdout and stderr handle unicode characters safely across all platforms (e.g. Windows cp1252)
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+DEFAULT_DOC = "sdk/docs/FAILURE_AND_THREAT_MODEL.md"
+DEFAULT_TEST_DIR = "sdk/tests"
+
+# Pattern to locate Section E heading (supporting ->, →, –, —, or "to")
+SECTION_E_PATTERN = re.compile(
+    r"(?m)^##\s+E\.\s+Guarantee\s*(?:[\u2192\u2013\u2014\->]+|to)\s*test\s+map\s*$",
+    re.IGNORECASE,
+)
+
+# Pattern to extract test references ending in .py, optionally followed by ::symbol.
+# Lookbehind includes ':' to avoid matching URL schemes like http://... or https://...
+TEST_REF_PATTERN = re.compile(
+    r"(?<![\w/\\.:-])([a-zA-Z0-9_\/\\.-]+\.py(?:::[a-zA-Z0-9_]+)*)"
+)
+
+
+class SymbolCollection(set[str]):
+    """Set of runnable test symbols with separated qualified and bare lookup sets."""
+
+    def __init__(self, qualified: Iterable[str] = (), bare: Iterable[str] = ()) -> None:
+        super().__init__(set(qualified) | set(bare))
+        self.qualified: set[str] = set(qualified)
+        self.bare: set[str] = set(bare)
+
+
+@dataclass
+class TestReference:
+    raw: str
+    file_path_str: str
+    symbols: list[str]
+    resolved_path: Path | None = None
+    is_malformed: bool = False
+    malformed_reason: str = ""
+
+
+@dataclass
+class GuaranteeRow:
+    identifier: str
+    doc_ref: str
+    tests_raw: str
+    test_refs: list[TestReference]
+    line_number: int
+
+
+def emit_error(message: str, file: str | None = None, line: int | None = None) -> None:
+    """Print an error and optional GitHub Actions annotation."""
+    loc = ""
+    if file:
+        loc = f"{file}:{line or 1}: "
+    print(f"{loc}error: {message}", file=sys.stderr)
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        annotation = f"::error file={file or 'guarantee-map'}"
+        if line:
+            annotation += f",line={line}"
+        annotation += f"::{message}"
+        print(annotation, file=sys.stderr)
+
+
+def split_markdown_table_row(line: str) -> list[str]:
+    """Split a markdown table row into cells, respecting escaped pipes and code spans."""
+    stripped = line.strip()
+    if not stripped:
+        return []
+
+    # Strip optional outer pipes if present and unescaped
+    stripped = stripped.removeprefix("|")
+    if stripped.endswith("|"):
+        # Count preceding backslashes to ensure trailing pipe is not escaped (\|)
+        num_bs = 0
+        pos = len(stripped) - 2
+        while pos >= 0 and stripped[pos] == "\\":
+            num_bs += 1
+            pos -= 1
+        if num_bs % 2 == 0:
+            stripped = stripped[:-1]
+
+    cells: list[str] = []
+    current_cell: list[str] = []
+    idx = 0
+    in_code = False
+    code_delim_len = 0
+    n = len(stripped)
+
+    while idx < n:
+        char = stripped[idx]
+
+        # Handle escaped characters like \| or \`
+        if char == "\\" and idx + 1 < n:
+            next_char = stripped[idx + 1]
+            if next_char == "|":
+                current_cell.append("|")
+                idx += 2
+                continue
+            else:
+                current_cell.append(char)
+                current_cell.append(next_char)
+                idx += 2
+                continue
+
+        # Handle backtick code spans
+        if char == "`":
+            run_len = 1
+            while idx + run_len < n and stripped[idx + run_len] == "`":
+                run_len += 1
+            if not in_code:
+                in_code = True
+                code_delim_len = run_len
+            elif run_len == code_delim_len:
+                in_code = False
+                code_delim_len = 0
+            current_cell.append(stripped[idx : idx + run_len])
+            idx += run_len
+            continue
+
+        # Handle unescaped pipe outside code spans
+        if char == "|" and not in_code:
+            cells.append("".join(current_cell).strip())
+            current_cell = []
+            idx += 1
+            continue
+
+        current_cell.append(char)
+        idx += 1
+
+    cells.append("".join(current_cell).strip())
+    return cells
+
+
+def extract_symbols_from_ast(tree: ast.AST) -> SymbolCollection:
+    """Extract top-level functions, classes, and class methods from an AST.
+
+    Supports test symbols defined conditionally inside compound statements
+    (e.g. if/try blocks). Inner helper functions or local closures defined
+    inside function bodies are excluded because pytest cannot discover or
+    address them directly.
+    """
+    qualified_symbols: set[str] = set()
+    bare_symbols: set[str] = set()
+
+    class SymbolVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.class_stack: list[str] = []
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            qualified = "::".join(self.class_stack + [node.name])
+            qualified_symbols.add(qualified)
+            qualified_symbols.add(node.name)
+            bare_symbols.add(node.name)
+
+            self.class_stack.append(node.name)
+            self.generic_visit(node)
+            self.class_stack.pop()
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            bare_symbols.add(node.name)
+            if self.class_stack:
+                qualified = "::".join(self.class_stack + [node.name])
+                qualified_symbols.add(qualified)
+                if len(self.class_stack) > 1:
+                    qualified_symbols.add(f"{self.class_stack[-1]}::{node.name}")
+            else:
+                qualified_symbols.add(node.name)
+            # Deliberately do NOT recurse into function bodies: inner functions/closures
+            # are not pytest test items.
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            bare_symbols.add(node.name)
+            if self.class_stack:
+                qualified = "::".join(self.class_stack + [node.name])
+                qualified_symbols.add(qualified)
+                if len(self.class_stack) > 1:
+                    qualified_symbols.add(f"{self.class_stack[-1]}::{node.name}")
+            else:
+                qualified_symbols.add(node.name)
+            # Deliberately do NOT recurse into function bodies
+
+    SymbolVisitor().visit(tree)
+
+    return SymbolCollection(qualified_symbols, bare_symbols)
+
+
+def parse_test_references(cell_text: str) -> list[TestReference]:
+    """Extract and validate test references from a markdown table cell."""
+    # Strip HTML comments
+    cleaned = re.sub(r"<!--.*?-->", "", cell_text, flags=re.DOTALL)
+    # Strip HTML tags such as <sup>1</sup>
+    cleaned = re.sub(r"<[^>]+>", "", cleaned)
+
+    # Handle markdown links: [anchor](url)
+    # If anchor contains .py, keep anchor.
+    # Otherwise if url contains .py (and is not an external URL), extract from url.
+    def replace_link(match: re.Match[str]) -> str:
+        anchor = match.group(1)
+        url = match.group(2).strip()
+        # External URLs should never be extracted as local test files
+        if re.match(r"^[a-zA-Z]+://", url) or url.startswith("//"):
+            return anchor
+        if ".py" in anchor:
+            return anchor
+        if ".py" in url:
+            url_clean = url.split("#")[0].split("?")[0]
+            return f" {url_clean} "
+        return anchor
+
+    cleaned = re.sub(r"\[([^\]]*)\]\(([^)]*)\)", replace_link, cleaned)
+
+    candidate_pattern = re.compile(
+        r"(?<![\w/\\.:-])([a-zA-Z0-9_\/\\.:-]*\.py[a-zA-Z0-9_\/\\.:-]*)"
+    )
+    matches = candidate_pattern.findall(cleaned)
+    refs: list[TestReference] = []
+    seen_raw: set[str] = set()
+
+    for m in matches:
+        cand = m.strip()
+        # Skip external URLs or UNC network paths
+        if "://" in cand or cand.startswith(("//", "\\\\")):
+            continue
+
+        # Strip sentence-ending punctuation like period, comma, or semicolon
+        raw_token = cand.rstrip(".,;")
+        if not raw_token or raw_token in seen_raw:
+            continue
+        seen_raw.add(raw_token)
+
+        parts = raw_token.split("::")
+        file_part = parts[0]
+
+        if not file_part.endswith(".py"):
+            refs.append(
+                TestReference(
+                    raw=raw_token,
+                    file_path_str=file_part,
+                    symbols=[],
+                    is_malformed=True,
+                    malformed_reason="test file path must end with '.py'",
+                )
+            )
+            continue
+
+        normalized_file = file_part.replace("\\", "/")
+        if normalized_file == ".py" or normalized_file.endswith(("/.py",)):
+            refs.append(
+                TestReference(
+                    raw=raw_token,
+                    file_path_str=file_part,
+                    symbols=[],
+                    is_malformed=True,
+                    malformed_reason="empty test filename",
+                )
+            )
+            continue
+
+        symbols = parts[1:]
+        if len(parts) > 1 and (
+            not symbols or any(not s.isidentifier() for s in symbols)
+        ):
+            refs.append(
+                TestReference(
+                    raw=raw_token,
+                    file_path_str=file_part,
+                    symbols=symbols,
+                    is_malformed=True,
+                    malformed_reason="invalid test symbol identifier",
+                )
+            )
+            continue
+
+        refs.append(
+            TestReference(
+                raw=raw_token,
+                file_path_str=file_part,
+                symbols=symbols,
+            )
+        )
+    return refs
+
+
+def parse_guarantee_map(
+    doc_content: str, doc_path: Path
+) -> tuple[list[GuaranteeRow], list[str]]:
+    """Parse Section E of FAILURE_AND_THREAT_MODEL.md into structured GuaranteeRow objects."""
+    errors: list[str] = []
+    rows: list[GuaranteeRow] = []
+
+    match = SECTION_E_PATTERN.search(doc_content)
+    if not match:
+        msg = f"Section '## E. Guarantee → test map' not found in {doc_path}"
+        errors.append(msg)
+        emit_error(msg, str(doc_path))
+        return rows, errors
+
+    section_start = match.end()
+    lines = doc_content[section_start:].splitlines()
+    start_line_offset = doc_content[:section_start].count("\n") + 1
+
+    table_lines: list[tuple[int, str]] = []
+    in_table = False
+
+    in_html_comment = False
+    for idx, raw_line in enumerate(lines):
+        line_num = start_line_offset + idx
+        stripped = raw_line.strip()
+
+        # Handle multi-line and standalone HTML comments
+        if in_html_comment:
+            if "-->" in stripped:
+                in_html_comment = False
+            continue
+
+        if stripped.startswith("<!--"):
+            if not stripped.endswith("-->") or stripped == "<!--":
+                in_html_comment = True
+            continue
+
+        # Stop if we hit the next major section or section divider (whether table has started or not)
+        if stripped.startswith(("## ", "# ")) or stripped == "---":
+            break
+
+        if stripped.startswith("|"):
+            in_table = True
+            table_lines.append((line_num, stripped))
+        elif in_table:
+            # First non-table line after table start indicates table has ended
+            break
+
+    if not table_lines:
+        msg = f"No markdown table found in Section E of {doc_path}"
+        errors.append(msg)
+        emit_error(msg, str(doc_path))
+        return rows, errors
+
+    # Parse header
+    header_line_num, header_line = table_lines[0]
+    header_cols = split_markdown_table_row(header_line)
+
+    if len(header_cols) < 2:
+        msg = f"Malformed table header at line {header_line_num}: expected at least 2 columns"
+        errors.append(msg)
+        emit_error(msg, str(doc_path), header_line_num)
+        return rows, errors
+
+    # Determine column indexes flexibly
+    id_col_idx = -1
+    test_col_idx = -1
+    where_col_idx = -1
+
+    for i, col in enumerate(header_cols):
+        col_lower = col.lower()
+        if col_lower in ("id", "guarantee id"):
+            id_col_idx = i
+            break
+    if id_col_idx == -1:
+        for i, col in enumerate(header_cols):
+            if "guarantee" in col.lower():
+                id_col_idx = i
+                break
+    if id_col_idx == -1:
+        id_col_idx = 0
+
+    for i, col in enumerate(header_cols):
+        if "test" in col.lower():
+            test_col_idx = i
+            break
+    if test_col_idx == -1:
+        test_col_idx = len(header_cols) - 1
+
+    for i, col in enumerate(header_cols):
+        if "where" in col.lower() or "doc" in col.lower():
+            where_col_idx = i
+            break
+
+    if id_col_idx == test_col_idx:
+        msg = (
+            f"Malformed table header at line {header_line_num}: "
+            f"could not distinguish guarantee identifier and test columns"
+        )
+        errors.append(msg)
+        emit_error(msg, str(doc_path), header_line_num)
+        return rows, errors
+
+    seen_ids: dict[str, tuple[int, str]] = {}
+
+    # Skip header and separator rows
+    for line_num, line in table_lines[1:]:
+        cols = split_markdown_table_row(line)
+        # Skip separator row e.g. |---|---|---|
+        non_empty_cols = [c for c in cols if c]
+        if non_empty_cols and all(re.match(r"^:?-+:?$", c) for c in non_empty_cols):
+            continue
+
+        if len(cols) <= max(id_col_idx, test_col_idx):
+            msg = (
+                f"Malformed table row at line {line_num}: "
+                f"expected at least {max(id_col_idx, test_col_idx) + 1} columns, found {len(cols)}"
+            )
+            errors.append(msg)
+            emit_error(msg, str(doc_path), line_num)
+            continue
+
+        raw_id = cols[id_col_idx]
+        # Clean markdown formatting and normalize whitespace
+        clean_id = re.sub(r"[*_`]", "", raw_id).strip()
+        clean_id = " ".join(clean_id.split())
+
+        # Validate non-empty and correctly formatted
+        if not clean_id:
+            msg = f"Empty guarantee identifier at line {line_num}"
+            errors.append(msg)
+            emit_error(msg, str(doc_path), line_num)
+            continue
+
+        if not re.search(r"\w", clean_id):
+            msg = (
+                f"Malformed guarantee identifier '{raw_id}' at line {line_num}: "
+                f"must contain alphanumeric characters"
+            )
+            errors.append(msg)
+            emit_error(msg, str(doc_path), line_num)
+            continue
+
+        # Check uniqueness case-insensitively with normalized whitespace
+        normalized_id = clean_id.lower()
+        if normalized_id in seen_ids:
+            first_line, original_name = seen_ids[normalized_id]
+            if clean_id == original_name:
+                msg = (
+                    f"Duplicate guarantee identifier '{clean_id}' at line {line_num} "
+                    f"(first defined at line {first_line})"
+                )
+            else:
+                msg = (
+                    f"Duplicate guarantee identifier '{clean_id}' at line {line_num} "
+                    f"(first defined as '{original_name}' at line {first_line})"
+                )
+            errors.append(msg)
+            emit_error(msg, str(doc_path), line_num)
+            continue
+        seen_ids[normalized_id] = (line_num, clean_id)
+
+        doc_ref = (
+            cols[where_col_idx]
+            if where_col_idx >= 0 and where_col_idx < len(cols)
+            else ""
+        )
+        tests_raw = cols[test_col_idx]
+        test_refs = parse_test_references(tests_raw)
+
+        has_malformed = False
+        for ref in test_refs:
+            if ref.is_malformed:
+                has_malformed = True
+                msg = (
+                    f"Guarantee '{clean_id}' at line {line_num} has malformed test reference "
+                    f"'{ref.raw}': {ref.malformed_reason}"
+                )
+                errors.append(msg)
+                emit_error(msg, str(doc_path), line_num)
+
+        valid_refs = [r for r in test_refs if not r.is_malformed]
+        if not valid_refs and not has_malformed:
+            msg = f"Guarantee '{clean_id}' at line {line_num} has no valid test references"
+            errors.append(msg)
+            emit_error(msg, str(doc_path), line_num)
+            continue
+
+        rows.append(
+            GuaranteeRow(
+                identifier=clean_id,
+                doc_ref=doc_ref,
+                tests_raw=tests_raw,
+                test_refs=test_refs,
+                line_number=line_num,
+            )
+        )
+
+    return rows, errors
+
+
+def resolve_test_file(
+    root: Path, file_path_str: str, custom_test_dir: Path | None = None
+) -> Path | None:
+    """Resolve a test file path against candidate test roots, enforcing exact casing across all components."""
+    # Reject external URLs, UNC network paths, and absolute paths
+    if file_path_str.startswith(("//", "\\\\", "/", "\\")) or "://" in file_path_str:
+        return None
+
+    # Normalize path separators across platforms
+    normalized_path_str = file_path_str.replace("\\", "/")
+    path_obj = Path(*(normalized_path_str.split("/")))
+    if path_obj.is_absolute():
+        return None
+
+    candidates: list[tuple[Path, Path]] = []
+    seen_candidates: set[Path] = set()
+
+    def add_candidate(base: Path, candidate_path: Path) -> None:
+        if candidate_path not in seen_candidates:
+            seen_candidates.add(candidate_path)
+            candidates.append((base, candidate_path))
+
+    if len(path_obj.parts) == 1:
+        # Bare filename e.g. "test_version.py"
+        if custom_test_dir:
+            add_candidate(custom_test_dir, custom_test_dir / path_obj)
+        add_candidate(root, root / "sdk" / "tests" / path_obj)
+        add_candidate(root, root / "tests" / path_obj)
+        add_candidate(root, root / path_obj)
+    elif len(path_obj.parts) > 1:
+        # Relative path with directory structure e.g. "tests/test_version.py"
+        if custom_test_dir:
+            add_candidate(custom_test_dir, custom_test_dir / path_obj)
+        add_candidate(root, root / path_obj)
+        add_candidate(root, root / "sdk" / path_obj)
+
+    for base, c in candidates:
+        try:
+            if c.is_file():
+                res = c.resolve()
+                base_res = base.resolve()
+                # Enforce path confinement within base directory
+                if not res.is_relative_to(base_res):
+                    continue
+                # Enforce exact case sensitivity for all path components
+                if c.relative_to(base).parts == res.relative_to(base_res).parts:
+                    return res
+        except (OSError, ValueError):
+            continue
+
+    return None
+
+
+def validate_guarantee_map(
+    root: Path,
+    doc_path: Path | str | None = None,
+    test_dir: Path | str | None = None,
+) -> tuple[bool, list[str]]:
+    """Validate all guarantee identifiers, referenced test files, and test symbols."""
+    errors: list[str] = []
+    doc = (root / (Path(doc_path) if doc_path else Path(DEFAULT_DOC))).resolve()
+    test_directory = (
+        (root / Path(test_dir)).resolve()
+        if test_dir
+        else (root / DEFAULT_TEST_DIR).resolve()
+    )
+
+    if not doc.exists():
+        msg = f"Documentation file not found: {doc}"
+        emit_error(msg, str(doc))
+        return False, [msg]
+
+    try:
+        content = doc.read_text(encoding="utf-8")
+    except OSError as e:
+        msg = f"Failed to read documentation file {doc}: {e}"
+        emit_error(msg, str(doc))
+        return False, [msg]
+
+    rows, parse_errors = parse_guarantee_map(content, doc)
+    errors.extend(parse_errors)
+
+    # Cache AST symbols per resolved test file
+    ast_symbol_cache: dict[Path, SymbolCollection] = {}
+    ast_error_cache: dict[Path, str] = {}
+
+    for row in rows:
+        for ref in row.test_refs:
+            if ref.is_malformed:
+                continue
+            resolved = resolve_test_file(root, ref.file_path_str, test_directory)
+            if not resolved:
+                msg = (
+                    f"Guarantee '{row.identifier}' references non-existent test file: "
+                    f"'{ref.file_path_str}'"
+                )
+                errors.append(msg)
+                emit_error(msg, str(doc), row.line_number)
+                continue
+
+            ref.resolved_path = resolved
+
+            # Parse AST if not already cached
+            if resolved not in ast_symbol_cache and resolved not in ast_error_cache:
+                try:
+                    tree = ast.parse(
+                        resolved.read_text(encoding="utf-8"), filename=str(resolved)
+                    )
+                    ast_symbol_cache[resolved] = extract_symbols_from_ast(tree)
+                except SyntaxError as se:
+                    ast_error_cache[resolved] = (
+                        f"SyntaxError parsing test file {resolved}: {se}"
+                    )
+                except (OSError, UnicodeDecodeError) as oe:
+                    ast_error_cache[resolved] = (
+                        f"Error reading test file {resolved}: {oe}"
+                    )
+
+            if resolved in ast_error_cache:
+                msg = f"Guarantee '{row.identifier}': {ast_error_cache[resolved]}"
+                errors.append(msg)
+                emit_error(msg, str(doc), row.line_number)
+                continue
+
+            available_symbols = ast_symbol_cache[resolved]
+
+            # Validate referenced symbol(s)
+            if ref.symbols:
+                if len(ref.symbols) == 1:
+                    # Single symbol matches top-level function, class, or cited class method
+                    target = ref.symbols[0]
+                    if target not in available_symbols:
+                        msg = (
+                            f"Guarantee '{row.identifier}' references non-existent test symbol "
+                            f"'{target}' in '{ref.file_path_str}'"
+                        )
+                        errors.append(msg)
+                        emit_error(msg, str(doc), row.line_number)
+                else:
+                    # Multi-part symbol e.g. Class::method must match qualified hierarchy
+                    qualified_target = "::".join(ref.symbols)
+                    if qualified_target not in available_symbols.qualified:
+                        msg = (
+                            f"Guarantee '{row.identifier}' references non-existent test symbol "
+                            f"'{qualified_target}' in '{ref.file_path_str}'"
+                        )
+                        errors.append(msg)
+                        emit_error(msg, str(doc), row.line_number)
+
+    return len(errors) == 0, errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate guarantee-to-test map in FAILURE_AND_THREAT_MODEL.md"
+    )
+    parser.add_argument("--root", default=".", help="Repository root directory")
+    parser.add_argument(
+        "--doc",
+        default=DEFAULT_DOC,
+        help="Path to failure and threat model markdown",
+    )
+    parser.add_argument(
+        "--test-dir",
+        default=DEFAULT_TEST_DIR,
+        help="Path to tests directory",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    doc_path = Path(args.doc)
+    test_dir = Path(args.test_dir)
+
+    valid, errors = validate_guarantee_map(
+        root=root,
+        doc_path=doc_path,
+        test_dir=test_dir,
+    )
+
+    if not valid:
+        print(
+            f"\nGuarantee map validation failed with {len(errors)} error(s).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Guarantee map verified successfully: all test references and symbols exist.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Verify architecture map source provenance
         run: python .github/scripts/check-architecture-provenance.py --strict
 
+      - name: Verify guarantee-to-test map
+        run: python .github/scripts/check-guarantee-map.py
+
   package:
     runs-on: ubuntu-latest
     steps:

--- a/sdk/tests/test_guarantee_map_validator.py
+++ b/sdk/tests/test_guarantee_map_validator.py
@@ -1,0 +1,972 @@
+"""Tests for guarantee-to-test map machine verification and drift detection."""
+
+import ast
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS_DIR = ROOT / ".github" / "scripts"
+SCRIPT_PATH = SCRIPTS_DIR / "check-guarantee-map.py"
+
+
+@pytest.fixture
+def tmp_path():
+    """Isolated temporary directory fixture safe from Windows permission locks on pytest-of-user."""
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+def _load_script_module(name: str, filename: str):
+    """Dynamically import helper script from .github/scripts/ without sys.path pollution."""
+    script_path = SCRIPTS_DIR / filename
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+validator_mod = _load_script_module("check_guarantee_map", "check-guarantee-map.py")
+
+
+class TestGuaranteeMapValidator:
+    """Comprehensive test suite for the guarantee-to-test map validator."""
+
+    def test_live_guarantee_map_passes(self):
+        """The checked-in FAILURE_AND_THREAT_MODEL.md must validate cleanly with 0 errors."""
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=Path("sdk/docs/FAILURE_AND_THREAT_MODEL.md"),
+        )
+        assert valid, f"Guarantee map validation failed: {errors}"
+        assert len(errors) == 0
+
+    def test_live_guarantee_map_covers_all_shipped_guarantees(self):
+        """Section E must parse all 27 shipped guarantee rows with non-empty test links."""
+        doc_path = ROOT / "sdk/docs/FAILURE_AND_THREAT_MODEL.md"
+        content = doc_path.read_text(encoding="utf-8")
+        rows, errors = validator_mod.parse_guarantee_map(content, doc_path)
+
+        assert len(errors) == 0
+        assert len(rows) >= 27
+        for row in rows:
+            assert len(row.identifier) > 0
+            assert len(row.test_refs) >= 1
+            for ref in row.test_refs:
+                assert ref.file_path_str.endswith(".py")
+
+    def test_cli_live_guarantee_map_exit_code_zero(self):
+        """Executing check-guarantee-map.py directly via CLI must exit with returncode 0."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--root", str(ROOT)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"CLI exited with {result.returncode}.\n"
+            f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+        )
+        assert "Guarantee map verified successfully" in result.stdout
+
+    def test_detects_nonexistent_test_file(self, tmp_path):
+        """Validator must detect and fail on non-existent test files."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Valid Claim | README | `test_version.py::test_version_matches_pyproject` |
+| Phantom Claim | README | `test_nonexistent_file_xyz_123.py::test_phantom` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any(
+            "references non-existent test file: 'test_nonexistent_file_xyz_123.py'" in e
+            for e in errors
+        )
+
+    def test_cli_detects_nonexistent_test_file_exit_code_one(self, tmp_path):
+        """CLI invocation on doc with missing test file must exit with returncode 1."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Broken File | README | `test_completely_missing_xyz.py::test_missing` |
+""",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--root",
+                str(ROOT),
+                "--doc",
+                str(synthetic_doc),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "non-existent test file" in result.stderr
+
+    def test_detects_nonexistent_test_symbol(self, tmp_path):
+        """Validator must detect and fail on non-existent test functions within existing files."""
+        synthetic_test_dir = tmp_path / "tests"
+        synthetic_test_dir.mkdir()
+        test_file = synthetic_test_dir / "test_sample.py"
+        test_file.write_text(
+            """
+def test_real_one():
+    assert True
+""",
+            encoding="utf-8",
+        )
+
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Real Test | README | `test_sample.py::test_real_one` |
+| Fake Test | README | `test_sample.py::test_does_not_exist` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=tmp_path,
+            doc_path=synthetic_doc,
+            test_dir=synthetic_test_dir,
+        )
+        assert not valid
+        assert any(
+            "references non-existent test symbol 'test_does_not_exist' in 'test_sample.py'" in e
+            for e in errors
+        )
+
+    def test_cli_detects_nonexistent_test_symbol_exit_code_one(self, tmp_path):
+        """CLI invocation on doc with missing test symbol must exit with returncode 1."""
+        synthetic_test_dir = tmp_path / "tests"
+        synthetic_test_dir.mkdir()
+        test_file = synthetic_test_dir / "test_sample.py"
+        test_file.write_text("def test_real(): pass\n", encoding="utf-8")
+
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Bad Symbol | README | `test_sample.py::test_missing_func` |
+""",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--root",
+                str(tmp_path),
+                "--doc",
+                str(synthetic_doc),
+                "--test-dir",
+                str(synthetic_test_dir),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "non-existent test symbol 'test_missing_func'" in result.stderr
+
+    def test_detects_duplicate_guarantee_identifier(self, tmp_path):
+        """Validator must detect and reject duplicate guarantee identifiers."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Atomic Claim | § 1 | `test_version.py::test_version_matches_pyproject` |
+| Other Guarantee | § 2 | `test_version.py::test_version_matches_pyproject` |
+| Atomic Claim | § 3 | `test_version.py::test_version_matches_pyproject` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any(
+            "Duplicate guarantee identifier 'Atomic Claim' at line 8 (first defined at line 6)" in e
+            for e in errors
+        )
+
+    def test_cli_detects_duplicate_guarantee_exit_code_one(self, tmp_path):
+        """CLI invocation on doc with duplicate guarantee identifier must exit with code 1."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Duplicated ID | § 1 | `test_version.py::test_version_matches_pyproject` |
+| Duplicated ID | § 2 | `test_version.py::test_version_matches_pyproject` |
+""",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--root",
+                str(ROOT),
+                "--doc",
+                str(synthetic_doc),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "Duplicate guarantee identifier 'Duplicated ID'" in result.stderr
+
+    def test_detects_empty_or_malformed_identifier(self, tmp_path):
+        """Empty or punctuation-only guarantee identifiers must be rejected."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+|   | README | `test_storage_backends.py::test_file_storage_serializes_concurrent_claims` |
+| !!! | README | `test_storage_backends.py::test_file_storage_serializes_concurrent_claims` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any("Empty guarantee identifier" in e for e in errors)
+        assert any("must contain alphanumeric characters" in e for e in errors)
+
+    def test_detects_missing_section_e(self, tmp_path):
+        """Missing Section E in documentation must fail with clean error."""
+        synthetic_doc = tmp_path / "NO_SECTION_E.md"
+        synthetic_doc.write_text("# Model\nSome text without section E.\n", encoding="utf-8")
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any("Section '## E. Guarantee → test map' not found" in e for e in errors)
+
+    def test_detects_missing_table_in_section_e(self, tmp_path):
+        """Section E without markdown table rows must fail with clean error."""
+        synthetic_doc = tmp_path / "NO_TABLE.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+This section contains text but no markdown table.
+
+## F. Residual risks
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any("No markdown table found in Section E" in e for e in errors)
+
+    def test_detects_guarantee_row_without_test_references(self, tmp_path):
+        """Row lacking valid test references must fail validation."""
+        synthetic_doc = tmp_path / "EMPTY_TESTS.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Empty Test Row | README | TBD / None |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any("has no valid test references" in e for e in errors)
+
+    def test_ast_symbol_extraction_hierarchy(self):
+        """AST extractor must collect functions, classes, and class methods."""
+        code = """
+def top_level_sync():
+    pass
+
+async def top_level_async():
+    pass
+
+class TestSuiteAlpha:
+    def method_one(self):
+        pass
+
+    async def async_method_two(self):
+        pass
+
+    class NestedHelper:
+        def nested_method(self):
+            pass
+"""
+        tree = ast.parse(code)
+        symbols = validator_mod.extract_symbols_from_ast(tree)
+
+        assert "top_level_sync" in symbols
+        assert "top_level_async" in symbols
+        assert "TestSuiteAlpha" in symbols
+        assert "method_one" in symbols
+        assert "TestSuiteAlpha::method_one" in symbols
+        assert "async_method_two" in symbols
+        assert "TestSuiteAlpha::async_method_two" in symbols
+        assert "NestedHelper" in symbols
+        assert "TestSuiteAlpha::NestedHelper" in symbols
+        assert "nested_method" in symbols
+        assert "NestedHelper::nested_method" in symbols
+
+    def test_syntax_error_in_test_file_detected(self, tmp_path):
+        """Syntax error in a referenced test file must fail validation with diagnostic."""
+        bad_test_dir = tmp_path / "tests"
+        bad_test_dir.mkdir()
+        bad_file = bad_test_dir / "test_syntax_err.py"
+        bad_file.write_text("def broken_syntax(:\n", encoding="utf-8")
+
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Syntax Guarantee | README | `test_syntax_err.py::test_broken` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=tmp_path,
+            doc_path=synthetic_doc,
+            test_dir=bad_test_dir,
+        )
+        assert not valid
+        assert any("SyntaxError parsing test file" in e for e in errors)
+
+    def test_missing_doc_file_detected(self, tmp_path):
+        """Non-existent documentation path fails gracefully."""
+        nonexistent = tmp_path / "missing_file.md"
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=nonexistent,
+        )
+        assert not valid
+        assert any("Documentation file not found" in e for e in errors)
+
+    def test_id_column_supported_when_present(self, tmp_path):
+        """Tables with explicit ID columns use ID for uniqueness."""
+        synthetic_doc = tmp_path / "ID_COL_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| ID | Guarantee | Where documented | Test(s) |
+|---|---|---|---|
+| G1 | First | README | `test_version.py::test_version_matches_pyproject` |
+| G2 | Second | README | `test_version.py::test_version_matches_pyproject` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert valid, f"Expected clean pass with ID column: {errors}"
+
+    def test_detects_nonexistent_class_qualifier(self, tmp_path):
+        """A test reference with a bogus class prefix must be rejected even if function exists."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Bogus Class Claim | README | `test_version.py::BogusClass::test_version_matches_pyproject` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any(
+            "references non-existent test symbol 'BogusClass::test_version_matches_pyproject'" in e
+            for e in errors
+        )
+
+    def test_detects_mismatched_class_method(self, tmp_path):
+        """A method in ClassB cited under ClassA must fail validation."""
+        synthetic_test_dir = tmp_path / "tests"
+        synthetic_test_dir.mkdir()
+        test_file = synthetic_test_dir / "test_sample.py"
+        test_file.write_text(
+            """
+class ClassA:
+    def method_a(self): pass
+
+class ClassB:
+    def method_b(self): pass
+""",
+            encoding="utf-8",
+        )
+
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Mismatched Method | README | `test_sample.py::ClassA::method_b` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=tmp_path,
+            doc_path=synthetic_doc,
+            test_dir=synthetic_test_dir,
+        )
+        assert not valid
+        assert any("references non-existent test symbol 'ClassA::method_b'" in e for e in errors)
+
+    def test_detects_inner_helper_closure_rejected(self, tmp_path):
+        """Functions defined inside other functions are closures, not runnable pytest tests."""
+        synthetic_test_dir = tmp_path / "tests"
+        synthetic_test_dir.mkdir()
+        test_file = synthetic_test_dir / "test_sample.py"
+        test_file.write_text(
+            """
+def test_real():
+    def inner_helper():
+        pass
+""",
+            encoding="utf-8",
+        )
+
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Inner Closure | README | `test_sample.py::inner_helper` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=tmp_path,
+            doc_path=synthetic_doc,
+            test_dir=synthetic_test_dir,
+        )
+        assert not valid
+        assert any("references non-existent test symbol 'inner_helper'" in e for e in errors)
+
+    def test_table_row_with_escaped_pipes_and_code_spans(self, tmp_path):
+        """Escaped pipes \\| and code spans with pipes must not break cell splitting."""
+        synthetic_doc = tmp_path / "ESCAPED_PIPES.md"
+        claim_tests = "`test_version.py::test_version_matches_pyproject` (with `flag | opt`)"
+        synthetic_doc.write_text(
+            f"""# Model
+## E. Guarantee → test map
+
+| Guarantee \\| Feature A | README § [Gates \\| Backends](link) | {claim_tests} |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert valid, f"Escaped pipes and code spans should parse cleanly: {errors}"
+
+    def test_markdown_link_url_test_reference(self, tmp_path):
+        """Test references formatted as markdown link targets must be parsed and verified."""
+        synthetic_doc = tmp_path / "LINK_TARGET.md"
+        link_ref = (
+            "[Click here to inspect test](test_version.py::test_version_matches_pyproject#L10)"
+        )
+        synthetic_doc.write_text(
+            f"""# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Link Target Claim | README | {link_ref} |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert valid, f"Expected markdown link target to resolve: {errors}"
+
+    def test_detects_case_and_whitespace_duplicate_guarantees(self, tmp_path):
+        """Duplicate identifiers differing only by casing or internal whitespace must be caught."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Atomic Guarantee | § 1 | `test_version.py::test_version_matches_pyproject` |
+| atomic   guarantee | § 2 | `test_version.py::test_version_matches_pyproject` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        expected_msg = (
+            "Duplicate guarantee identifier 'atomic guarantee' at line 7 "
+            "(first defined as 'Atomic Guarantee' at line 6)"
+        )
+        assert any(expected_msg in e for e in errors)
+
+    def test_case_sensitive_test_filename_enforced(self, tmp_path):
+        """Referencing a test file with incorrect casing must fail validation for safety."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Bad Case | README | `TEST_VERSION.py::test_version_matches_pyproject` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any("references non-existent test file: 'TEST_VERSION.py'" in e for e in errors)
+
+    def test_non_utf8_test_file_handled_gracefully(self, tmp_path):
+        """Non-UTF-8 test files must produce a diagnostic error rather than crashing."""
+        synthetic_test_dir = tmp_path / "tests"
+        synthetic_test_dir.mkdir()
+        bad_file = synthetic_test_dir / "test_invalid_encoding.py"
+        # Write invalid UTF-8 bytes
+        bad_file.write_bytes(b"\xff\xfe\x00\x00 invalid bytes")
+
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Encoding Claim | README | `test_invalid_encoding.py::test_dummy` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=tmp_path,
+            doc_path=synthetic_doc,
+            test_dir=synthetic_test_dir,
+        )
+        assert not valid
+        assert any("Error reading test file" in e for e in errors)
+
+    def test_detects_nonexistent_directory_for_existing_filename(self, tmp_path):
+        """Citing a non-existent subdirectory for an existing filename must fail validation."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Bad Dir | README | `bogus_folder/subfolder/test_version.py` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any(
+            "references non-existent test file: 'bogus_folder/subfolder/test_version.py'" in e
+            for e in errors
+        )
+
+    def test_case_sensitive_directory_components_enforced(self, tmp_path):
+        """Referencing a test path with incorrect directory casing must fail validation."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Bad Dir Case | README | `SDK/tests/test_version.py::test_version_matches_pyproject` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any(
+            "references non-existent test file: 'SDK/tests/test_version.py'" in e for e in errors
+        )
+
+    def test_external_url_not_treated_as_test_reference(self, tmp_path):
+        """External URLs must not be parsed as test files or trigger network calls."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        url = "https://github.com/mycelium-labs/mycelium/blob/main/sdk/tests/test_version.py"
+        synthetic_doc.write_text(
+            f"""# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| External Link | README | `test_version.py` (view [online]({url})) |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert valid, f"External URL link should not interfere with test resolution: {errors}"
+
+    def test_ast_discovers_symbols_in_compound_statements(self, tmp_path):
+        """AST extractor must discover tests defined inside if/try compound blocks."""
+        synthetic_test_dir = tmp_path / "tests"
+        synthetic_test_dir.mkdir()
+        test_file = synthetic_test_dir / "test_compound.py"
+        test_file.write_text(
+            """
+if True:
+    def test_conditional():
+        pass
+
+try:
+    def test_in_try():
+        pass
+except Exception:
+    pass
+
+class TestCompoundSuite:
+    if True:
+        def test_method_in_if(self):
+            pass
+""",
+            encoding="utf-8",
+        )
+
+        tree = ast.parse(test_file.read_text(encoding="utf-8"))
+        symbols = validator_mod.extract_symbols_from_ast(tree)
+
+        assert "test_conditional" in symbols
+        assert "test_in_try" in symbols
+        assert "TestCompoundSuite::test_method_in_if" in symbols
+
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Cond 1 | README | `test_compound.py::test_conditional` |
+| Cond 2 | README | `test_compound.py::test_in_try` |
+| Cond 3 | README | `test_compound.py::TestCompoundSuite::test_method_in_if` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=tmp_path,
+            doc_path=synthetic_doc,
+            test_dir=synthetic_test_dir,
+        )
+        assert valid, f"Symbols in compound statements should be discovered: {errors}"
+
+    def test_path_traversal_test_file_rejected(self, tmp_path):
+        """Directory traversal escaping the repository root must fail validation."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Traversal Claim | README | `../../outside_test.py::test_escape` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any(
+            "references non-existent test file: '../../outside_test.py'" in e for e in errors
+        )
+
+    def test_multi_line_html_comment_in_section_e(self, tmp_path):
+        """Multi-line HTML comments in Section E must not terminate table parsing."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee \u2192 test map
+
+<!--
+Multi-line comment explaining the table
+with multiple lines of text
+-->
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Comment Claim | README | `test_version.py::test_version_matches_pyproject` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert valid, f"Multi-line HTML comment should not break table parsing: {errors}"
+
+    def test_table_in_subsequent_section_not_parsed_as_section_e(self, tmp_path):
+        """A table in Section F must never leak into Section E when Section E has no table."""
+        synthetic_doc = tmp_path / "LEAK_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee → test map
+
+Section E has discussion text but no markdown table.
+
+---
+
+## F. Residual risks
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Rogue Claim | README | `test_version.py::test_version_matches_pyproject` |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any("No markdown table found in Section E" in e for e in errors)
+        assert not any("Rogue Claim" in e for e in errors)
+
+    def test_empty_table_row_detected_as_error(self, tmp_path):
+        """A table row with all empty cells must not be silently skipped as a delimiter."""
+        synthetic_doc = tmp_path / "EMPTY_ROW_MODEL.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee → test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Valid Claim | README | `test_version.py::test_version_matches_pyproject` |
+| | | |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any("Empty guarantee identifier" in e for e in errors)
+
+    def test_detects_malformed_test_references(self, tmp_path):
+        """Malformed test references (bad colons, bad extensions, bad symbols) must fail."""
+        malformed_samples = [
+            ("Dangling Colon", "`test_version.py::`", "invalid test symbol identifier"),
+            ("Triple Colon", "`test_version.py:::test`", "invalid test symbol identifier"),
+            ("Compiled File", "`test_version.pyc`", "test file path must end with '.py'"),
+            ("Backup Extension", "`test_version.py.bak`", "test file path must end with '.py'"),
+            (
+                "Bad Symbol Ext",
+                "`test_version.py::test_func.bak`",
+                "invalid test symbol identifier",
+            ),
+            (
+                "Bad Symbol Identifier",
+                "`test_version.py::123bad`",
+                "invalid test symbol identifier",
+            ),
+            ("Empty Filename", "`tests/.py::test_func`", "empty test filename"),
+        ]
+
+        for claim_name, bad_ref, expected_reason in malformed_samples:
+            synthetic_doc = tmp_path / f"MALFORMED_{claim_name.replace(' ', '_')}.md"
+            synthetic_doc.write_text(
+                f"""# Model
+## E. Guarantee → test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| {claim_name} | README | {bad_ref} |
+""",
+                encoding="utf-8",
+            )
+
+            valid, errors = validator_mod.validate_guarantee_map(
+                root=ROOT,
+                doc_path=synthetic_doc,
+            )
+            assert not valid, f"Expected validation failure for {claim_name} ({bad_ref})"
+            assert any(
+                "has malformed test reference" in e and expected_reason in e for e in errors
+            ), f"Expected reason '{expected_reason}' in errors: {errors}"
+
+    def test_cli_detects_malformed_test_reference_exit_code_one(self, tmp_path):
+        """CLI execution on document with malformed test reference exits with code 1."""
+        synthetic_doc = tmp_path / "SYNTHETIC_MALFORMED.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee → test map
+
+| Guarantee | Where documented | Test(s) |
+|---|---|---|
+| Bad Ref | README | `test_version.py::` |
+""",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--root",
+                str(ROOT),
+                "--doc",
+                str(synthetic_doc),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "malformed test reference 'test_version.py::'" in result.stderr
+
+    def test_detects_indistinguishable_header_columns(self, tmp_path):
+        """Table header where id and test columns resolve to same index must fail."""
+        synthetic_doc = tmp_path / "BAD_HEADER.md"
+        synthetic_doc.write_text(
+            """# Model
+## E. Guarantee → test map
+
+| Guarantee Tests | Notes |
+|---|---|
+| `test_version.py` | note |
+""",
+            encoding="utf-8",
+        )
+
+        valid, errors = validator_mod.validate_guarantee_map(
+            root=ROOT,
+            doc_path=synthetic_doc,
+        )
+        assert not valid
+        assert any(
+            "Malformed table header" in e
+            and "could not distinguish guarantee identifier and test columns" in e
+            for e in errors
+        )
+
+    def test_path_with_backslashes_normalized(self):
+        """Paths specified with Windows-style backslashes normalize and resolve cleanly."""
+        resolved = validator_mod.resolve_test_file(
+            ROOT, "sdk\\tests\\test_version.py", ROOT / "sdk" / "tests"
+        )
+        assert resolved is not None
+        assert resolved.name == "test_version.py"


### PR DESCRIPTION
## Summary
Resolves #150.

Builds on the source provenance and drift detection introduced in #151 / PR #173 by making the guarantee-to-test map in \sdk/docs/FAILURE_AND_THREAT_MODEL.md\ machine-verifiable.

## What Was Done
1. **Machine-Readable Validator Script** (\.github/scripts/check-guarantee-map.py\):
   - Parses Section E of \sdk/docs/FAILURE_AND_THREAT_MODEL.md\ into structured guarantee definitions.
   - Enforces unique, non-empty guarantee identifiers.
   - Validates that referenced test files exist in the repository with cross-platform case-sensitivity checks.
   - Parses AST of referenced test files to verify that referenced test functions, test classes, or methods exist.
   - Emits structured error diagnostics with file/line contexts and GitHub Actions annotations.
2. **CI Integration** (\.github/workflows/ci.yml\):
   - Added \Verify guarantee-to-test map\ step to the \ersion-hygiene\ job in CI, preventing documentation drift from merging on push or pull request.
3. **Comprehensive Regression Test Suite** (\sdk/tests/test_guarantee_map_validator.py\):
   - Added 37 unit tests covering live verification, synthetic missing test files, missing functions, duplicate IDs, malformed rows, and section boundary edge cases.
   - All tests pass with 0 mocking libraries, testing real AST resolution.

## Verification
- \python .github/scripts/check-guarantee-map.py\ passes with exit code 0 across all 27 guarantees and 108 test targets.
- \pytest sdk/tests/test_guarantee_map_validator.py\ passes with 37/37 passing in 2.76s.
- \uff check\ and \uff format --check\ pass cleanly with 0 violations.