### PR TITLE
feat(ci): add automated dependency vulnerability audit with pip-audit (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,23 @@ jobs:
         working-directory: sdk
         run: bandit -c pyproject.toml -r mycelium
 
+      - name: Dependency vulnerability audit
+        working-directory: sdk
+        # Dependency vulnerability gate (#146). pip-audit exits non-zero on
+        # findings or service errors. Exceptions must be recorded in
+        # sdk/.pip-audit-ignore with a reason and review date.
+        run: |
+          IGNORE_ARGS=()
+          if [ -f .pip-audit-ignore ]; then
+            while IFS= read -r line || [ -n "$line" ]; do
+              line="${line#"${line%%[![:space:]]*}"}"
+              [[ -z "$line" || "$line" =~ ^# ]] && continue
+              vuln_id=$(echo "$line" | awk '{print $1}')
+              [ -n "$vuln_id" ] && IGNORE_ARGS+=("--ignore-vuln" "$vuln_id")
+            done < .pip-audit-ignore
+          fi
+          pip-audit --desc on "${IGNORE_ARGS[@]}"
+
       - name: Documentation and provenance tests
         working-directory: sdk
         run: pytest tests/test_architecture_provenance.py tests/test_doc_commands.py -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ uv run pytest tests/ -v
 uv run pytest --cov=mycelium --cov-report=term-missing
 uv run ruff check mycelium tests
 uv run bandit -c pyproject.toml -r mycelium
+uv run pip-audit --desc on
 ```
 
 ### Alternative: pip
@@ -72,6 +73,7 @@ pytest tests/ -v
 pytest --cov=mycelium --cov-report=term-missing
 ruff check mycelium tests
 bandit -c pyproject.toml -r mycelium
+pip-audit --desc on
 ```
 
 On Windows PowerShell, activate the environment with
@@ -88,6 +90,7 @@ uv run pytest tests/ -v
 uv run pytest --cov=mycelium --cov-report=term-missing
 uv run ruff check mycelium tests
 uv run bandit -c pyproject.toml -r mycelium
+uv run pip-audit --desc on
 ```
 
 Use the equivalent commands inside an activated pip environment if you are not
@@ -202,6 +205,7 @@ Copy the applicable items into the pull request description:
 - [ ] Coverage gate passes (`pytest --cov=mycelium --cov-report=term-missing`)
 - [ ] `ruff check mycelium tests` passes
 - [ ] `bandit -c pyproject.toml -r mycelium` passes
+- [ ] `pip-audit --desc on` passes (from `sdk/`)
 - [ ] Redis/Postgres tests ran, or the PR explains why they do not apply
 - [ ] No relevant tests were silently skipped
 - [ ] Compatibility and durable-state impact were reviewed
@@ -340,3 +344,21 @@ To update the provenance manifest when architectural changes are intentionally a
 ```bash
 python .github/scripts/update-architecture-provenance.py
 ```
+
+### Dependency vulnerability audit
+
+CI audits the SDK runtime and release extras for known vulnerabilities (#146).
+Run the same local check from `sdk/` before opening a pull request that
+touches dependencies:
+
+```bash
+pip install -e ".[dev,redis,postgres,observability]"
+pip-audit --desc on
+```
+
+`pip-audit` exits non-zero on findings and on advisory-service errors, so an
+unavailable service fails closed. Temporary exceptions must stay specific,
+justified, and time-bounded adhering to `sdk/.pip-audit-ignore` policy:
+`# Format: <VULN_ID> # reason: <rationale> (review: YYYY-MM-DD)`.
+Do not add broad skips, and do not auto-upgrade dependencies in the audit step.
+

--- a/sdk/.pip-audit-ignore
+++ b/sdk/.pip-audit-ignore
@@ -1,0 +1,12 @@
+# Format: <VULN_ID> # reason: <rationale> (review: YYYY-MM-DD)
+#
+# Pip-Audit Vulnerability Ignore Policy (Issue #146)
+# =================================================
+# Any ignored advisory must include a specific justification (reason)
+# and a time-bounded review date (review: YYYY-MM-DD).
+#
+# Broad skips or silencing of vulnerabilities without justification are strictly forbidden.
+# Lines starting with '#' and empty lines are ignored by the parser.
+#
+# Example:
+# GHSA-xxxx-xxxx-xxxx # reason: Upstream patch pending; vulnerability not reachable via public API (review: 2026-10-01)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -2972,4 +2972,16 @@ pytest tests/ -v
 pytest --cov=mycelium --cov-report=term-missing
 ruff check mycelium tests
 bandit -c pyproject.toml -r mycelium
+pip-audit --desc on
 ```
+
+Before opening a pull request touching dependencies, audit the resolved
+environment for known vulnerabilities from `sdk/` (install with all release extras):
+
+```bash
+pip install -e ".[dev,redis,postgres,observability]"
+pip-audit --desc on
+```
+
+Exceptions must be specific, justified, and time-bounded adhering to the policy in
+[`.pip-audit-ignore`](.pip-audit-ignore) and [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "hypothesis",
     "langgraph>=1.2.9",
     "cyclonedx-bom>=7.3.1",
+    "pip-audit>=2.7.3",
 ]
 langgraph = [
     "langgraph>=1.2.9",
@@ -130,6 +131,7 @@ exclude = [
   "scripts/",
   "api-snapshot.json",
   "uv.lock",
+  ".pip-audit-ignore",
   "**/__pycache__/",
   "**/*.pyc",
 ]


### PR DESCRIPTION
## Summary
Resolves #146.

Adds automated dependency vulnerability scanning to CI using `pip-audit`, ensuring that the resolved environment across SDK runtime dependencies and release extras is audited against known advisory databases (PyPI / OSV).

## Changes
1. **CI Pipeline Integration** (`.github/workflows/ci.yml`):
   - Added `Dependency vulnerability audit` step to the `static` CI job in `sdk/`.
   - Runs `pip-audit --desc on` after installing runtime dependencies and release extras (`.[dev,redis,postgres,observability]`).
   - Automatically reads and passes ignored vulnerability IDs from `.pip-audit-ignore`.
   - Exits non-zero on discovered vulnerabilities or advisory-service errors (fails closed).
2. **Ignore Policy Definition** (`sdk/.pip-audit-ignore`):
   - Created policy file defining strict format requirements for temporary exceptions: `# Format: <VULN_ID> # reason: <rationale> (review: YYYY-MM-DD)`.
   - Prohibits broad skips or unreviewed ignores.
3. **Packaging & Dependency Specification** (`sdk/pyproject.toml`):
   - Added `pip-audit>=2.7.3` to the `dev` dependency group.
   - Added `.pip-audit-ignore` to sdist exclude list.
4. **Contributor Documentation** (`CONTRIBUTING.md`, `sdk/README.md`):
   - Added local `pip-audit --desc on` command instructions under `CONTRIBUTING.md` and `sdk/README.md`.
   - Added checklist item to pull request review guidelines.
   - Documented policy for temporary vulnerability exceptions.

## Verification
- Verified doc command compatibility via `pytest tests/test_doc_commands.py` (5/5 passing).
- Validated architecture provenance via `pytest tests/test_architecture_provenance.py` (11/11 passing).
- Ran `ruff check mycelium tests` with 0 violations.
- Verified `.pip-audit-ignore` parser logic against sample comments and ignore lines.
